### PR TITLE
chore: fix examples and docs module to not be released

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -10,6 +10,9 @@
 
     <artifactId>quarkus-flow-docs</artifactId>
     <name>Quarkus Flow :: Documentation</name>
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
 
     <dependencies>
         <!-- Make sure the doc is built after the other artifacts -->

--- a/examples/newsletter-drafter/pom.xml
+++ b/examples/newsletter-drafter/pom.xml
@@ -10,6 +10,7 @@
     <properties>
         <compiler-plugin.version>3.14.0</compiler-plugin.version>
         <maven.compiler.release>17</maven.compiler.release>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,6 +11,10 @@
     <name>Quarkus Flow :: Examples</name>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <modules>
         <module>newsletter-drafter</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
     <modules>
         <module>core</module>
         <module>messaging</module>
-        <module>examples</module>
     </modules>
 
     <scm>


### PR DESCRIPTION
`examples` module was being added to the main pom, causing it to be released by mistake on Maven. Luckily, our example didn't have the necessary configuration to be released.