### PR TITLE
fix: Add Build Website pipeline to run surge preview

### DIFF
--- a/.github/workflows/build-website.yaml
+++ b/.github/workflows/build-website.yaml
@@ -1,0 +1,67 @@
+name: Build website
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - '*.md'
+      - '*.adoc'
+      - '*.txt'
+
+  workflow_dispatch:
+  pull_request:
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - '*.md'
+      - '*.txt'
+    types: [ opened, synchronize, reopened ]
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Website
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: 'maven'
+
+
+      - name: Build with Maven
+        run: mvn -B clean verify --file pom.xml -DskipTests -DskipITs
+
+      - name: Store PR id
+        run: |
+          mkdir pr
+          echo ${{ github.event.number }} > ./pr/pr-id.txt
+
+      - name: Upload PR id as artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: pr-id
+          path: pr
+          retention-days: 1
+
+      - name: Publishing directory for PR preview
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v5
+        with:
+          name: site
+          path: ./docs/target/generated-docs
+          retention-days: 3

--- a/.github/workflows/preview-docs.yaml
+++ b/.github/workflows/preview-docs.yaml
@@ -2,7 +2,7 @@ name: Surge.sh Preview
 
 on:
   workflow_run:
-    workflows: [ "Publish website" ]
+    workflows: [ "Build website" ]
     types:
       - completed
 


### PR DESCRIPTION
Our surge preview is not working because we are missing a central part of it, which is building the docs website :)