### PR TITLE
Add support for Mutiny on Flow API

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/GreetingResource.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/GreetingResource.java
@@ -17,7 +17,6 @@
 package io.quarkiverse.flow.deployment.test.devui;
 
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -25,6 +24,8 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
 import org.jboss.resteasy.reactive.ResponseStatus;
+
+import io.smallrye.mutiny.Uni;
 
 @Path("/hello")
 @ApplicationScoped
@@ -35,7 +36,8 @@ public class GreetingResource {
 
     @GET
     @ResponseStatus(200)
-    public CompletionStage<Message> hello() {
-        return devUIWorkflow.instance(Map.of("name", "Quarkiverse")).start().thenApply(w -> w.as(Message.class).orElseThrow());
+    public Uni<Message> hello() {
+        return devUIWorkflow.startInstance(Map.of("name", "Quarkiverse")).onItem()
+                .transform(wf -> wf.as(Message.class).orElseThrow());
     }
 }

--- a/core/integration-tests/src/main/java/io/quarkiverse/flow/it/GenericAgenticResource.java
+++ b/core/integration-tests/src/main/java/io/quarkiverse/flow/it/GenericAgenticResource.java
@@ -1,13 +1,12 @@
 package io.quarkiverse.flow.it;
 
-import java.util.concurrent.CompletionStage;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 
 import io.smallrye.common.annotation.Blocking;
+import io.smallrye.mutiny.Uni;
 
 @Path("/generic")
 @ApplicationScoped
@@ -18,11 +17,11 @@ public class GenericAgenticResource {
 
     @POST
     @Blocking
-    public CompletionStage<String> hello(String message) {
+    public Uni<String> hello(String message) {
         return genericAgenticWorkflow
-                .instance(message)
-                .start()
-                .thenApply(w -> w.asText().orElseThrow());
+                .startInstance(message)
+                .onItem()
+                .transform(wf -> wf.as(String.class).orElseThrow());
     }
 
 }

--- a/core/integration-tests/src/main/java/io/quarkiverse/flow/it/HelloResource.java
+++ b/core/integration-tests/src/main/java/io/quarkiverse/flow/it/HelloResource.java
@@ -16,15 +16,14 @@
  */
 package io.quarkiverse.flow.it;
 
-import java.util.Map;
-import java.util.concurrent.CompletionStage;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
 import org.jboss.resteasy.reactive.ResponseStatus;
+
+import io.smallrye.mutiny.Uni;
 
 @Path("/hello")
 @ApplicationScoped
@@ -33,9 +32,22 @@ public class HelloResource {
     @Inject
     HelloWorkflow helloWorldWorkflow;
 
+    @Inject
+    ProblematicWorkflow problematicWorkflow;
+
     @ResponseStatus(200)
     @GET
-    public CompletionStage<Message> hello() {
-        return helloWorldWorkflow.startInstance(Map.of()).thenApply(w -> w.as(Message.class).orElseThrow());
+    public Uni<Message> hello() {
+        return helloWorldWorkflow.startInstance()
+                .onItem()
+                .transform(wf -> wf.as(Message.class).orElseThrow());
+    }
+
+    @Path("/problem-details")
+    @GET
+    public Uni<Message> problemDetails() {
+        return problematicWorkflow.startInstance()
+                .onItem()
+                .transform(wf -> wf.as(Message.class).orElseThrow());
     }
 }

--- a/core/integration-tests/src/main/java/io/quarkiverse/flow/it/ProblematicWorkflow.java
+++ b/core/integration-tests/src/main/java/io/quarkiverse/flow/it/ProblematicWorkflow.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.flow.it;
+
+import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.openapi;
+
+import java.net.URI;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkiverse.flow.Flow;
+import io.serverlessworkflow.api.types.Workflow;
+import io.serverlessworkflow.fluent.func.FuncWorkflowBuilder;
+
+@ApplicationScoped
+public class ProblematicWorkflow extends Flow {
+
+    @Override
+    public Workflow descriptor() {
+        final URI problematic = URI.create("openapi/problematic.json");
+
+        return FuncWorkflowBuilder.workflow("problematic-workflow")
+                // You find the operation in the spec file, field operationId.
+                .tasks(openapi("findNothing").document(problematic).operation("getProblematic")
+                        // We use a jq expression to select from the JSON array the first item after the task response.
+                        .outputAs("${{ message }}")) // the code will fail before for testing ExceptionMapper
+                .build();
+    }
+
+}

--- a/core/integration-tests/src/main/resources/openapi/problematic.json
+++ b/core/integration-tests/src/main/resources/openapi/problematic.json
@@ -1,0 +1,38 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Minimal API",
+        "version": "1.0.0",
+        "description": "A very minimal OpenAPI document"
+    },
+      "servers": [
+    {
+      "url": "https://petstore3.swagger.io/api/v3/"
+    }
+  ],
+    "paths": {
+        "/problematic": {
+            "get": {
+                "operationId": "getProblematic",
+                "summary": "There is no such endpoint in petstore application, it is intentional to test error handling",
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/HelloResourceTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/HelloResourceTest.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.flow.it;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
@@ -19,5 +20,15 @@ public class HelloResourceTest {
                 .statusCode(200)
                 .contentType(ContentType.JSON)
                 .body("message", is("hello world!"));
+    }
+
+    @Test
+    public void testProblemDetails() {
+        given()
+                .when().get("/hello/problem-details")
+                .then()
+                .statusCode(404)
+                .contentType(ContentType.JSON)
+                .body("type", containsString("https://serverlessworkflow.io/spec/1.0.0/errors/communication"));
     }
 }

--- a/core/integration-tests/src/test/resources/__snapshots__/FlowCodestartTest/testContent/src_main_java_ilove_quark_us_HelloResource.java
+++ b/core/integration-tests/src/test/resources/__snapshots__/FlowCodestartTest/testContent/src_main_java_ilove_quark_us_HelloResource.java
@@ -6,8 +6,9 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import org.jboss.resteasy.reactive.ResponseStatus;
 
+import io.smallrye.mutiny.Uni;
+
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
 
 @Path("/hello-flow")
 @ApplicationScoped
@@ -18,10 +19,11 @@ public class HelloResource {
 
     @GET
     @ResponseStatus(200)
-    public CompletionStage<Message> hello() {
+    public Uni<Message> hello() {
         return hello
-                .startInstance(Map.of())                // convenience on Flow
-                .thenApply(w -> w.as(Message.class).orElseThrow());
+                .startInstance()                // convenience on Flow
+                .onItem()
+                .transform(w -> w.as(Message.class).orElseThrow());
     }
 
 }

--- a/core/runtime/src/main/codestarts/quarkus/quarkus-flow-codestart/java/src/main/java/org/acme/HelloResource.java
+++ b/core/runtime/src/main/codestarts/quarkus/quarkus-flow-codestart/java/src/main/java/org/acme/HelloResource.java
@@ -6,8 +6,9 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import org.jboss.resteasy.reactive.ResponseStatus;
 
+import io.smallrye.mutiny.Uni;
+
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
 
 @Path("/hello-flow")
 @ApplicationScoped
@@ -18,10 +19,11 @@ public class HelloResource {
 
     @GET
     @ResponseStatus(200)
-    public CompletionStage<Message> hello() {
+    public Uni<Message> hello() {
         return hello
-                .startInstance(Map.of())                // convenience on Flow
-                .thenApply(w -> w.as(Message.class).orElseThrow());
+                .startInstance()                // convenience on Flow
+                .onItem()
+                .transform(w -> w.as(Message.class).orElseThrow());
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/flow/Flow.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/Flow.java
@@ -1,6 +1,6 @@
 package io.quarkiverse.flow;
 
-import java.util.concurrent.CompletionStage;
+import java.util.Map;
 
 import jakarta.annotation.PostConstruct;
 
@@ -10,6 +10,7 @@ import io.serverlessworkflow.impl.WorkflowDefinition;
 import io.serverlessworkflow.impl.WorkflowInstance;
 import io.serverlessworkflow.impl.WorkflowModel;
 import io.smallrye.common.annotation.Identifier;
+import io.smallrye.mutiny.Uni;
 
 public abstract class Flow implements Flowable {
 
@@ -39,7 +40,11 @@ public abstract class Flow implements Flowable {
         return definition().instance(in);
     }
 
-    public CompletionStage<WorkflowModel> startInstance(Object in) {
-        return instance(in).start();
+    public Uni<WorkflowModel> startInstance(Object in) {
+        return Uni.createFrom().completionStage(instance(in).start());
+    }
+
+    public Uni<WorkflowModel> startInstance() {
+        return startInstance(Map.of());
     }
 }

--- a/docs/modules/ROOT/examples/org/acme/EchoResource.java
+++ b/docs/modules/ROOT/examples/org/acme/EchoResource.java
@@ -2,7 +2,6 @@ package org.acme;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -11,6 +10,7 @@ import jakarta.ws.rs.QueryParam;
 
 import io.quarkiverse.flow.Flow;
 import io.smallrye.common.annotation.Identifier;
+import io.smallrye.mutiny.Uni;
 
 @Path("/echo")
 public class EchoResource {
@@ -20,10 +20,10 @@ public class EchoResource {
     Flow flow;
 
     @GET
-    public CompletionStage<String> echo(@QueryParam("name") String name) {
+    public Uni<String> echo(@QueryParam("name") String name) {
         final String finalName = Objects.requireNonNullElse(name, "(Duke)");
-        return flow.instance(Map.of("name", finalName))
-                .start()
-                .thenApply(result -> result.asText().orElseThrow());
+        return flow.startInstance(Map.of("name", finalName))
+                .onItem()
+                .transform(wf -> wf.asText().orElseThrow());
     }
 }

--- a/docs/modules/ROOT/examples/org/acme/HelloResource.java
+++ b/docs/modules/ROOT/examples/org/acme/HelloResource.java
@@ -1,7 +1,6 @@
 package org.acme;
 
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -9,6 +8,8 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
 import org.jboss.resteasy.reactive.ResponseStatus;
+
+import io.smallrye.mutiny.Uni;
 
 @Path("/hello")
 @ApplicationScoped
@@ -19,9 +20,10 @@ public class HelloResource {
 
     @GET
     @ResponseStatus(200)
-    public CompletionStage<Message> hello() {
+    public Uni<Message> hello() {
         return hello
                 .startInstance(Map.of()) // convenience on Flow
-                .thenApply(w -> w.as(Message.class).orElseThrow());
+                .onItem()
+                .transform(w -> w.as(Message.class).orElseThrow());
     }
 }

--- a/docs/modules/ROOT/examples/org/acme/agentic/InvestmentMemoResource.java
+++ b/docs/modules/ROOT/examples/org/acme/agentic/InvestmentMemoResource.java
@@ -1,7 +1,6 @@
 package org.acme.agentic;
 
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -9,6 +8,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+
+import io.smallrye.mutiny.Uni;
 
 /**
  * Simple JAX-RS entrypoint that drives the InvestmentMemoFlow.
@@ -25,9 +26,9 @@ public class InvestmentMemoResource {
     @GET
     @Path("/{ticker}")
     @Produces(MediaType.APPLICATION_JSON)
-    public CompletionStage<InvestmentMemo> analyse(@PathParam("ticker") String ticker) {
-        return flow.instance(Map.of("ticker", ticker, "objective", "Long-term growth", "horizon", "3–5 years")).start()
-                .thenApply(data -> data.as(InvestmentMemo.class).orElseThrow());
+    public Uni<InvestmentMemo> analyse(@PathParam("ticker") String ticker) {
+        return flow.startInstance(Map.of("ticker", ticker, "objective", "Long-term growth", "horizon", "3–5 years"))
+                .onItem().transform(data -> data.as(InvestmentMemo.class).orElseThrow());
     }
 }
 // end::resource[]

--- a/docs/modules/ROOT/examples/org/acme/example/CustomerProfileResource.java
+++ b/docs/modules/ROOT/examples/org/acme/example/CustomerProfileResource.java
@@ -1,13 +1,14 @@
 package org.acme.example;
 
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+
+import io.smallrye.mutiny.Uni;
 
 @Path("/api/profile")
 @Produces(MediaType.APPLICATION_JSON)
@@ -17,7 +18,7 @@ public class CustomerProfileResource {
     CustomerProfileFlow customerProfileFlow;
 
     @GET
-    public CompletionStage<Map<String, Object>> getProfileViaWorkflow() {
-        return customerProfileFlow.instance(Map.of()).start().thenApply(r -> r.asMap().orElseThrow());
+    public Uni<Map<String, Object>> getProfileViaWorkflow() {
+        return customerProfileFlow.startInstance().onItem().transform(r -> r.asMap().orElseThrow());
     }
 }

--- a/docs/modules/ROOT/examples/test/HelloWorkflowTest.java
+++ b/docs/modules/ROOT/examples/test/HelloWorkflowTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.junit.QuarkusTest;
 import io.serverlessworkflow.impl.WorkflowModel;
 
-@QuarkusTest
+@QuarkusTest // <1>
 class HelloWorkflowTest {
 
     @Inject
@@ -24,7 +24,7 @@ class HelloWorkflowTest {
     @Test
     void should_produce_hello_message() throws Exception {
         WorkflowModel result = workflow.instance(Map.of())
-                .start()
+                .start() // <2>
                 .toCompletableFuture()
                 .get(5, TimeUnit.SECONDS);
 

--- a/docs/modules/ROOT/pages/http-openapi-tasks.adoc
+++ b/docs/modules/ROOT/pages/http-openapi-tasks.adoc
@@ -272,22 +272,24 @@ Quarkus Flow provides an *exception mapper* that turns `WorkflowException` into 
 * status code is `error.status` (for example `401`), and
 * body is the `WorkflowError` serialized as JSON (Problem Details style).
 
-[[completionstage-vs-blocking-style]]
-=== 4.1 CompletionStage vs blocking style
+[[non-blocking-vs-blocking-style]]
+=== 4.1 Reactive vs blocking style
 
 How HTTP errors surface in your REST resources depends on how you call the workflow:
 
-* If you return a *`CompletionStage`* from your JAX-RS endpoint and call
-`instance(...).start()` without blocking, any `WorkflowException` will propagate
+* If you return a *`CompletionStage`/`io.smallrye.mutiny.Uni`* from your JAX-RS endpoint and call
+`instance(...).start()` or `startInstance(...)` without blocking, any `WorkflowException` will propagate
 directly and be handled by Quarkus Flow’s `ExceptionMapper<WorkflowException>`.
 The mapper turns it into an RFC 7807 / `WorkflowError` HTTP response.
-* If you choose the *blocking style* (`.start().get()`, `.join()`, …), Java wraps
-the underlying exception in `ExecutionException`. In that case you should either:
+* If you choose the *blocking style* (`.start().get()`, `.join()`, or `.await().indefinitely()`), Java wraps
+the underlying exception in `ExecutionException` or `CompletionException`. In that case you should either:
 **(a)** unwrap and rethrow the `WorkflowException`, or **(b)** prefer the
-`CompletionStage` style so the mapper can see the original exception.
+`Uni`/`CompletionStage` style so the mapper can see the original exception.
+* Additionally, If you are using `io.smallrye.mutiny.Uni`, you can handle errors with operators like `onFailure()` to handle the errors
+before they propagate to the JAX-RS layer.
 
 The mapper is not limited to HTTP/OpenAPI tasks: **any JAX-RS resource that throws
-`WorkflowException`** (directly, or via a non-blocked `CompletionStage`) will be
+`WorkflowException`** (directly, or via a non-blocked `Uni`/`CompletionStage`) will be
 handled by the same mapper and produce an RFC 7807 response.
 
 A recommended pattern for REST endpoints is:

--- a/docs/modules/ROOT/pages/test-debug.adoc
+++ b/docs/modules/ROOT/pages/test-debug.adoc
@@ -116,7 +116,7 @@ This verifies *both*:
 == 3. Verify HTTP error mapping (`WorkflowException` → RFC 7807)
 
 Quarkus Flow registers a standard `ExceptionMapper<WorkflowException>`.
-Any JAX-RS resource that throws `WorkflowException` (directly, or via a non-blocked `CompletionStage`)
+Any JAX-RS resource that throws `WorkflowException` (directly, or via a non-blocked `Uni`/`CompletionStage`)
 will automatically be translated into an RFC 7807 / `WorkflowError` response.
 
 For workflows that use HTTP / OpenAPI tasks (for example, calling a secured endpoint), you can test the error mapping like this:
@@ -149,8 +149,8 @@ class CustomerProfileResourceTest {
 
 Tips:
 
-* Use the **reactive style** in your resource (`CompletionStage`), as recommended in
-xref:http-openapi-tasks.adoc#completionstage-vs-blocking-style[CompletionStage vs blocking style],
+* Use the **reactive style** in your resource (`Uni`/`CompletionStage`), as recommended in
+xref:http-openapi-tasks.adoc#non-blocking-vs-blocking-style[Non-blocking vs blocking style],
 so that `WorkflowException` propagates directly.
 * If you *do* block (`.get()`, `.join()`), remember that Java wraps exceptions in `ExecutionException` —
 unwrap and rethrow `WorkflowException` if you want the mapper to handle it.

--- a/docs/modules/ROOT/pages/wk-lab-1-hello-flow-devui.adoc
+++ b/docs/modules/ROOT/pages/wk-lab-1-hello-flow-devui.adoc
@@ -81,8 +81,9 @@ include::{examples-dir}org/acme/Message.java[]
 Key points:
 
 * The resource injects the `HelloWorkflow` class directly.
-* `startInstance()` starts the workflow and returns a `CompletionStage`.
-* The method returns `CompletionStage<String>` so the endpoint stays non-blocking.
+* `startInstance()` creates a `Uni<WorkflowModel>`.
+* `.onItem().transform(...)` observes the item emitted by `Uni<WorkflowModel>` and transforms it to `Uni<Message>`.
+* The method returns `Uni<Message>`, so the endpoint stays non-blocking.
 
 == 4. Run in dev mode
 
@@ -126,7 +127,7 @@ Even without a dedicated card, you can:
 == 6. What you learned
 
 * Quarkus Flow discovers `Flow` subclasses at build time and makes them injectable.
-* You can expose workflows through normal Quarkus REST endpoints using `CompletionStage`.
+* You can expose workflows through normal Quarkus REST endpoints using `Uni`.
 * Dev UI gives you a convenient front-end for iterating on workflows while in dev mode.
 
 Next: xref:wk-lab-2-http-openapi.adoc[Lab 2 – Call HTTP & OpenAPI services].

--- a/docs/modules/ROOT/pages/wk-lab-2-http-openapi.adoc
+++ b/docs/modules/ROOT/pages/wk-lab-2-http-openapi.adoc
@@ -61,7 +61,7 @@ include::{examples-dir}org/acme/example/CustomerProfileResource.java[]
 
 Notice:
 
-* The method returns `CompletionStage<Response>` and calls `instance(...).start()`.
+* The method returns `Uni<Map<String, Object>>` and calls `onItem().transform(...)`.
 * If the HTTP call fails (for example, `401` or `404`), a `WorkflowException` is thrown.
 * Quarkus Flow’s `ExceptionMapper<WorkflowException>` returns a Problem Details JSON body
 based on the underlying `WorkflowError`.

--- a/docs/modules/ROOT/pages/wk-lab-4-agentic-langchain4j.adoc
+++ b/docs/modules/ROOT/pages/wk-lab-4-agentic-langchain4j.adoc
@@ -187,10 +187,10 @@ include::{examples-dir}org/acme/agentic/InvestmentMemoResource.java[tag=resource
 * It injects the `InvestmentMemoFlow` `Flow` subclass and starts an instance.
 * It returns the resulting `InvestmentMemo` to the caller as JSON.
 
-Because the method returns `CompletionStage<Response>` (or another reactive type),
+Because the method returns `Uni<Response>` (or another reactive type),
 any `WorkflowException` (e.g. HTTP 4xx/5xx from the market-data API) propagates
 directly and is mapped to a RFC 7807 / `WorkflowError` HTTP response. See
-xref:http-openapi-tasks.adoc#completionstage-vs-blocking-style[CompletionStage vs blocking style]
+xref:http-openapi-tasks.adoc#non-blocking-vs-blocking-style[Non-blocking vs blocking style]
 for details.
 
 === 5.2 Run from Flow Dev UI

--- a/docs/modules/ROOT/pages/workflow-definitions.adoc
+++ b/docs/modules/ROOT/pages/workflow-definitions.adoc
@@ -93,17 +93,16 @@ You can define a global namespace prefix for *Fully Qualified Class Name* identi
 
 A typical execution flow in this example looks like:
 
-1. `flow.instance(Map.of("name", finalName))` creates a new workflow instance with the initial data (`name`).
-2. `.start()` begins the workflow execution and returns a `CompletionStage<WorkflowModel>`.
-3. `.thenApply(result -> result.asText().orElseThrow())` transforms the `WorkflowModel` into a JSON `String` representation of the workflow data.
-4. The JAX-RS method returns a `CompletionStage<String>`, so the endpoint remains reactive/non-blocking.
+1. `flow.startInstance(Map.of("name", finalName))` creates a new `io.smallrye.mutiny.Uni<WorkflowModel>` instance with the initial data (`name`).
+2. `.onItem().transform(...)` observes and transform the item emitted by `Uni` and creates a new `Uni<String>` with the JSON representation of the workflow data.
+3. The JAX-RS method returns a `Uni<String>`, so the endpoint remains reactive/non-blocking.
 
 === 2.1 Blocking vs non-blocking REST endpoints
 
 The `EchoResource` above uses the *recommended non-blocking style* for Quarkus REST endpoints:
 
-* the method returns `CompletionStage<String>`
-* the workflow is started with `instance(...).start()` and the `CompletionStage` is propagated back to the caller
+* the method returns `Uni<String>`
+* the workflow is started with `startInstance(...)` and the `Uni` is propagated back to the caller
 
 This style integrates well with Quarkus’ reactive model and, when a workflow is invoked
 from a JAX-RS resource, lets any `WorkflowException` propagate directly to the HTTP layer.
@@ -113,14 +112,13 @@ automatically be translated into an RFC 7807 / `WorkflowError` HTTP response.
 
 If you prefer a *blocking* style in very simple scenarios (for example in a CLI or quick prototype), you can:
 
-* call `.start().join()` to wait for the result, and
-* return a `Response` or a plain DTO from your JAX-RS method.
+* call `.instance().start().join()` using a `CompletionStage` or `.await().indefinetely()` when using Mutiny to wait for the result, and return a `Response` or a plain DTO from your JAX-RS method.
 
-In that case, be aware that blocking on a `CompletionStage` may wrap underlying exceptions
-(for example in `ExecutionException`), and you might need to unwrap and rethrow `WorkflowException`
+In that case, be aware that blocking on a `CompletionStage`/`Uni` may wrap underlying exceptions
+(for example in `ExecutionException`, `CompletionException`), and you might need to unwrap and rethrow `WorkflowException`
 if you want the standard HTTP error mapping.
 For a deeper discussion and a full HTTP/OpenAPI example, see
-xref:http-openapi-tasks.adoc#completionstage-vs-blocking-style[CompletionStage vs blocking style].
+xref:http-openapi-tasks.adoc#non-blocking-vs-blocking-style[Non-blocking vs blocking style].
 
 == 3. Run the application
 

--- a/examples/agentic-http/src/main/java/org/acme/agentic/InvestmentMemoResource.java
+++ b/examples/agentic-http/src/main/java/org/acme/agentic/InvestmentMemoResource.java
@@ -7,7 +7,8 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+
+import io.smallrye.mutiny.Uni;
 
 /**
  * Simple JAX-RS entrypoint that drives the InvestmentMemoFlow.
@@ -24,9 +25,9 @@ public class InvestmentMemoResource {
     @GET
     @Path("/{ticker}")
     @Produces(MediaType.APPLICATION_JSON)
-    public CompletionStage<InvestmentMemo> analyse(@PathParam("ticker") String ticker) {
-        return flow.instance(Map.of("ticker", ticker, "objective", "Long-term growth", "horizon", "3–5 years")).start()
-                .thenApply(data -> data.as(InvestmentMemo.class).orElseThrow());
+    public Uni<InvestmentMemo> analyse(@PathParam("ticker") String ticker) {
+        return flow.startInstance(Map.of("ticker", ticker, "objective", "Long-term growth", "horizon", "3–5 years"))
+                .onItem().transform(data -> data.as(InvestmentMemo.class).orElseThrow());
     }
 }
 // end::resource[]

--- a/examples/http-basic-auth/README.md
+++ b/examples/http-basic-auth/README.md
@@ -202,9 +202,13 @@ The public REST resource starts the workflow and returns the final workflow cont
 package org.acme.http;
 
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import io.smallrye.mutiny.Uni;
 
-import io.quarkiverse.flow.FlowInstance;
+package org.acme.example;
+
+import java.util.Map;
+
+import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -219,12 +223,8 @@ public class CustomerProfileResource {
     CustomerProfileFlow customerProfileFlow;
 
     @GET
-    public CompletionStage<Map<String, Object>> getProfileViaWorkflow() {
-        FlowInstance instance = customerProfileFlow.instance(Map.of());
-
-        return instance
-                .start()
-                .thenApply(result -> result.asMap().orElseThrow());
+    public Uni<Map<String, Object>> getProfileViaWorkflow() {
+        return customerProfileFlow.startInstance().onItem().transform(r -> r.asMap().orElseThrow());
     }
 }
 ```

--- a/examples/http-basic-auth/src/main/java/org/acme/http/CustomerProfileResource.java
+++ b/examples/http-basic-auth/src/main/java/org/acme/http/CustomerProfileResource.java
@@ -6,7 +6,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+
+import io.smallrye.mutiny.Uni;
 
 @Path("/api/profile")
 @Produces(MediaType.APPLICATION_JSON)
@@ -16,7 +17,7 @@ public class CustomerProfileResource {
     CustomerProfileFlow customerProfileFlow;
 
     @GET
-    public CompletionStage<Map<String, Object>> getProfileViaWorkflow() throws Exception {
-        return customerProfileFlow.instance(Map.of()).start().thenApply(r -> r.asMap().orElseThrow());
+    public Uni<Map<String, Object>> getProfileViaWorkflow() throws Exception {
+        return customerProfileFlow.startInstance().onItem().transform(r -> r.asMap().orElseThrow());
     }
 }

--- a/examples/petstore-openapi/src/main/java/org/acme/http/PetstoreResource.java
+++ b/examples/petstore-openapi/src/main/java/org/acme/http/PetstoreResource.java
@@ -2,6 +2,7 @@ package org.acme.http;
 
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
+import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -9,7 +10,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
 
 @Path("/")
 @ApplicationScoped
@@ -30,7 +30,7 @@ public class PetstoreResource {
     @GET
     @Path("/pet")
     @Produces(MediaType.APPLICATION_JSON)
-    public CompletionStage<Map<String, Object>> getPet() throws Exception {
-        return petstoreFlow.instance(Map.of()).start().thenApply(result -> result.asMap().orElseThrow());
+    public Uni<Map<String, Object>> getPet() throws Exception {
+        return petstoreFlow.startInstance().onItem().transform(result -> result.asMap().orElseThrow());
     }
 }


### PR DESCRIPTION
# Changes

This pull request:

* Introduces a new method on `Flow`class

```java
    public Uni<WorkflowModel> startInstance(Object in) {
        return Uni.createFrom().completionStage(instance(in).start());
    }

    public Uni<WorkflowModel> startInstance() {
        return startInstance(Map.of());
    }
```
* Change the documentation accordingly with the API changes

Closes #18