### PR TITLE
Add a message when generating diagram from Langhain4J Agentic Workflow

### DIFF
--- a/core/deployment/src/main/resources/dev-ui/qwc-flow-workflows.js
+++ b/core/deployment/src/main/resources/dev-ui/qwc-flow-workflows.js
@@ -2,7 +2,6 @@ import { QwcHotReloadElement, html, css } from 'qwc-hot-reload-element';
 import { observeState } from 'lit-element-state';
 import { JsonRpc } from 'jsonrpc';
 import { unsafeHTML } from "lit/directives/unsafe-html.js"
-import { devuiState } from 'devui-state';
 import '@vaadin/grid';
 import '@vaadin/button';
 import '@vaadin/icon';
@@ -10,7 +9,6 @@ import '@vaadin/dialog';
 import { dialogRenderer, dialogFooterRenderer } from '@vaadin/dialog/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 
-import { notifier } from 'notifier';
 import './qwc-flow-workflow-execution.js';
 
 import { themeState } from 'theme-state';
@@ -158,8 +156,15 @@ export class QwcFlow extends observeState(QwcHotReloadElement) {
 
     _mermaidContent() {
         return unsafeHTML(`
+            ${!this._currentMermaid ? `
+            <span style="display:flex;align-items:center;gap:8px;color:var(--lumo-secondary-text-color);">
+                <vaadin-icon icon="font-awesome-solid:circle-info"></vaadin-icon>
+                <span style="margin:0;font-size:var(--lumo-font-size-xs);">
+                Diagram not available. Run the workflow once to generate it.
+                </span>
+            </span>` : ''}
              <pre class="mermaid mermaid-container" style="display: flex; flex-direction: column; align-items: center;">
-               ${this._currentMermaid}
+            ${this._currentMermaid}
             </pre>`);
     }
 


### PR DESCRIPTION
# Description

Improves the experience for the user when generating a diagram for Langchain4J Agentic Workflow backed by Quarkus Flow.

Langchain4J only creates the beans in runtime, it implies that we do not have the bean available for generating the diagram. 

This pull request aims to add a feedback message requesting the user to execute the Workflow for generating the diagram.

<img width="878" height="732" alt="Screenshot 2025-12-11 at 11 00 34" src="https://github.com/user-attachments/assets/0ebea3ef-25b7-412f-9161-ced3d3d37841" />
