### PR TITLE
 Make HTTP client config aware of quarkus-proxy-registry

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -79,11 +79,14 @@
             <version>${mockwebserver.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-proxy-registry</artifactId>
         </dependency>
     </dependencies>
 

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -85,6 +85,11 @@
             <artifactId>micrometer-core</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-proxy-registry</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/runtime/src/main/java/io/quarkiverse/flow/config/HttpClientConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/config/HttpClientConfig.java
@@ -386,139 +386,31 @@ public interface HttpClientConfig {
     // -------------------------------------------------------------------------
 
     /**
-     * HTTP proxy host.
-     * <p>
-     * When set together with {@link #proxyPort()}, requests are sent through the
-     * given HTTP proxy.
+     * The name of the proxy configuration to use for configuring <b>HTTP</b> proxy.
      * <p>
      * Default client:
      *
      * <pre>
-     * quarkus.flow.http.client.proxy-host=proxy.mycorp.local
+     * quarkus flow.http.client.proxy-configuration-name=proxy-cfg
      * </pre>
      * <p>
      * Named client:
      *
      * <pre>
-     * quarkus.flow.http.client.named.&lt;name&gt;.proxy-host=proxy.mycorp.local
+     * quarkus.flow.http.client.named.&lt;name&gt;.proxy-configuration-name=proxy-cfg
      * </pre>
-     * <p>
-     * Internally mapped to {@code ClientBuilderImpl.proxy(host, port)}.
      *
-     * @return the proxy host, if configured
+     * There are some rules for using proxy configuration:
+     * <ul>
+     * <li>If not set and the default proxy configuration is configured ({@code quarkus.proxy.*}) then that will be used.</li>
+     * <li>If the proxy configuration name is set, the configuration from {@code quarkus.proxy.<name>.*} will be used.</li>
+     * <li>If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be
+     * thrown at runtime.</li>
+     * </ul>
+     * <p>
+     * Use the value {@code none} to disable using the default configuration defined via {@code quarkus.proxy.*}.
      */
-    Optional<String> proxyHost();
-
-    /**
-     * HTTP proxy port.
-     * <p>
-     * Only used when {@link #proxyHost()} is also set.
-     * <p>
-     * Default client:
-     *
-     * <pre>
-     * quarkus.flow.http.client.proxy-port=8080
-     * </pre>
-     * <p>
-     * Named client:
-     *
-     * <pre>
-     * quarkus.flow.http.client.named.&lt;name&gt;.proxy-port=8080
-     * </pre>
-     * <p>
-     * Internally mapped to {@code ClientBuilderImpl.proxy(host, port)}.
-     *
-     * @return the proxy port, if configured
-     */
-    Optional<Integer> proxyPort();
-
-    /**
-     * Username for authenticating with the HTTP proxy.
-     * <p>
-     * Default client:
-     *
-     * <pre>
-     * quarkus.flow.http.client.proxy-user=svc-flow
-     * </pre>
-     * <p>
-     * Named client:
-     *
-     * <pre>
-     * quarkus.flow.http.client.named.&lt;name&gt;.proxy-user=svc-flow
-     * </pre>
-     * <p>
-     * Internally mapped to {@code ClientBuilderImpl.proxyUser(user)}.
-     *
-     * @return the proxy username, if configured
-     */
-    Optional<String> proxyUser();
-
-    /**
-     * Password for authenticating with the HTTP proxy.
-     * <p>
-     * Default client:
-     *
-     * <pre>
-     * quarkus.flow.http.client.proxy-password=secret
-     * </pre>
-     * <p>
-     * Named client:
-     *
-     * <pre>
-     * quarkus.flow.http.client.named.&lt;name&gt;.proxy-password=secret
-     * </pre>
-     * <p>
-     * Internally mapped to {@code ClientBuilderImpl.proxyPassword(password)}.
-     *
-     * @return the proxy password, if configured
-     */
-    Optional<String> proxyPassword();
-
-    /**
-     * Hosts that should bypass the HTTP proxy.
-     * <p>
-     * The value is a {@code |}-separated pattern list, similar to the standard
-     * {@code http.nonProxyHosts} format:
-     *
-     * <pre>
-     * quarkus.flow.http.client.non-proxy-hosts=localhost|127.*|[::1]
-     * </pre>
-     * <p>
-     * Named client:
-     *
-     * <pre>
-     * quarkus.flow.http.client.named.&lt;name&gt;.non-proxy-hosts=localhost|127.*
-     * </pre>
-     * <p>
-     * Internally mapped to {@code ClientBuilderImpl.nonProxyHosts(hostsPattern)}.
-     *
-     * @return the non-proxy hosts pattern, if configured
-     */
-    Optional<String> nonProxyHosts();
-
-    /**
-     * Proxy connect timeout in milliseconds.
-     * <p>
-     * Controls how long the client will wait when establishing a connection
-     * to the configured HTTP proxy.
-     * <p>
-     * Default client:
-     *
-     * <pre>
-     * quarkus.flow.http.client.proxy-connect-timeout=3000
-     * </pre>
-     * <p>
-     * Named client:
-     *
-     * <pre>
-     * quarkus.flow.http.client.named.&lt;name&gt;.proxy-connect-timeout=3000
-     * </pre>
-     * <p>
-     * Internally mapped to {@code ClientBuilderImpl.proxyConnectTimeout(Duration)}.
-     *
-     * @return the proxy connect timeout in milliseconds, if configured
-     */
-    Optional<Long> proxyConnectTimeout();
+    Optional<String> proxyConfigurationName();
 
     // -------------------------------------------------------------------------
     // Behaviour / HTTP-level options

--- a/docs/modules/ROOT/pages/http-client.adoc
+++ b/docs/modules/ROOT/pages/http-client.adoc
@@ -246,36 +246,60 @@ by the server.
 
 == 8. Proxy support
 
-Proxy support is exposed as a thin layer over the RESTEasy Reactive `ClientBuilderImpl` API.
-All properties follow the usual `quarkus.flow.http.client` naming:
+Quarkus Flow provides proxy support through integration with the
+https://quarkus.io/guides/proxy-registry[Quarkus Proxy Registry].
+The Proxy Registry supplies a centralized and secure way to configure HTTP proxies across the Quarkus Platform,
+including support for https://quarkus.io/guides/credentials-provider[Credentials Providers].
+
+With this integration, Quarkus Flow HTTP clients can reference a proxy configuration by name,
+without directly embedding proxy details or credentials in application code.
+
+=== 8.1 Configuring a default proxy
+
+To use a proxy with the default Flow HTTP client, configure the Proxy Registry
+and reference it using the `proxy-configuration-name` property.
 
 [source,properties]
 ----
-# Default client proxy (host/port)
-quarkus.flow.http.client.proxy-host=proxy.mycorp.internal
-quarkus.flow.http.client.proxy-port=3128
+# Proxy Registry configuration
+quarkus.proxy.registry.host=proxy.mycorp.internal
+quarkus.proxy.registry.port=3128
 
-# Optional credentials
-quarkus.flow.http.client.proxy-user=api-user
-quarkus.flow.http.client.proxy-password=change-me
+# Optional proxy settings
+quarkus.proxy.registry.username=api-user
+quarkus.proxy.registry.password=change-me
+quarkus.proxy.registry.non-proxy-hosts=localhost,*.svc.cluster.local
+quarkus.proxy.registry.proxy-connect-timeout=5000
 
-# Pipe-separated non-proxy hosts pattern (mirrors Java proxy syntax)
-quarkus.flow.http.client.non-proxy-hosts=localhost|127.*|[::1]|*.svc.cluster.local
-
-# Connect timeout (milliseconds) for proxy handshake
-quarkus.flow.http.client.proxy-connect-timeout=5000
+# Flow HTTP client proxy configuration
+quarkus.flow.http.client.proxy-configuration-name=none # <1>
 ----
 
-Named clients use the same pattern:
+<1> Uses the default proxy configuration from the Proxy Registry.
+
+=== 8.2 Configuring a proxy for a named HTTP client
+
+Named Flow HTTP clients can reference a specific proxy configuration by name.
+This allows different clients to use different proxies if required.
 
 [source,properties]
 ----
-quarkus.flow.http.client.named.secureA.proxy-host=proxy.mycorp.internal
-quarkus.flow.http.client.named.secureA.proxy-port=3128
+# Named proxy configuration
+quarkus.proxy.my-proxy.registry.host=proxy.mycorp.internal
+quarkus.proxy.my-proxy.registry.port=3128
+
+# Named Flow HTTP client using the named proxy
+quarkus.flow.http.client.named.secureA.proxy-configuration-name=my-proxy # <1>
 ----
 
-If `proxy-host` is not set, the client falls back to standard JVM system properties
-(`http(s).proxyHost`, etc.), consistent with the underlying Vert.x behavior.
+<1> Uses the `my-proxy` configuration from the Proxy Registry.
+
+[NOTE]
+====
+For advanced Proxy Registry configuration, including the use of
+https://quarkus.io/guides/credentials-provider[Credentials Providers],
+refer to the https://quarkus.io/guides/proxy-registry[Quarkus Proxy Registry documentation].
+====
 
 == 9. Redirects, compression and chunk size
 

--- a/docs/modules/ROOT/pages/includes/quarkus-flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow.adoc
@@ -804,22 +804,20 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-flow_quarkus-flow-http-client-proxy-host]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-proxy-host[`quarkus.flow.http.client.proxy-host`]##
+a| [[quarkus-flow_quarkus-flow-http-client-proxy-configuration-name]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-proxy-configuration-name[`quarkus.flow.http.client.proxy-configuration-name`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.proxy-host+++[]
+config_property_copy_button:+++quarkus.flow.http.client.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-HTTP proxy host.
-
-When set together with `proxy-port()`, requests are sent through the given HTTP proxy.
+The name of the proxy configuration to use for configuring *HTTP* proxy.
 
 Default client:
 
 ```
-quarkus.flow.http.client.proxy-host=proxy.mycorp.local
+quarkus flow.http.client.proxy-configuration-name=proxy-cfg
 ```
 
 
@@ -827,221 +825,28 @@ quarkus.flow.http.client.proxy-host=proxy.mycorp.local
 Named client:
 
 ```
-quarkus.flow.http.client.named.<name>.proxy-host=proxy.mycorp.local
+quarkus.flow.http.client.named.<name>.proxy-configuration-name=proxy-cfg
 ```
 
+There are some rules for using proxy configuration:
+
+ - If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
+ - If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
+ - If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
 
 
-Internally mapped to `ClientBuilderImpl.proxy(host, port)`.
+
+Use the value `none` to disable using the default configuration defined via `quarkus.proxy.++*++`.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_HOST+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_HOST+++`
+Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-proxy-port]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-proxy-port[`quarkus.flow.http.client.proxy-port`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.proxy-port+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-HTTP proxy port.
-
-Only used when `proxy-host()` is also set.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-port=8080
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-port=8080
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxy(host, port)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_PORT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_PORT+++`
-endif::add-copy-button-to-env-var[]
---
-|int
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-proxy-user]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-proxy-user[`quarkus.flow.http.client.proxy-user`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Username for authenticating with the HTTP proxy.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-user=svc-flow
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-user=svc-flow
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxyUser(user)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-proxy-password]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-proxy-password[`quarkus.flow.http.client.proxy-password`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Password for authenticating with the HTTP proxy.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-password=secret
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-password=secret
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxyPassword(password)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-non-proxy-hosts]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-non-proxy-hosts[`quarkus.flow.http.client.non-proxy-hosts`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts that should bypass the HTTP proxy.
-
-The value is a `++\|++`-separated pattern list, similar to the standard `http.nonProxyHosts` format:
-
-```
-quarkus.flow.http.client.non-proxy-hosts=localhost\|127.*\|[::1]
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.non-proxy-hosts=localhost\|127.*
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.nonProxyHosts(hostsPattern)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NON_PROXY_HOSTS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-proxy-connect-timeout]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-proxy-connect-timeout[`quarkus.flow.http.client.proxy-connect-timeout`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.proxy-connect-timeout+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy connect timeout in milliseconds.
-
-Controls how long the client will wait when establishing a connection to the configured HTTP proxy.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-connect-timeout=3000
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-connect-timeout=3000
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxyConnectTimeout(Duration)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_CONNECT_TIMEOUT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_CONNECT_TIMEOUT+++`
-endif::add-copy-button-to-env-var[]
---
-|long
 |
 
 a| [[quarkus-flow_quarkus-flow-http-client-follow-redirects]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-follow-redirects[`quarkus.flow.http.client.follow-redirects`]##
@@ -2014,22 +1819,20 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-flow_quarkus-flow-http-client-named-named-proxy-host]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-proxy-host[`quarkus.flow.http.client.named."named".proxy-host`]##
+a| [[quarkus-flow_quarkus-flow-http-client-named-named-proxy-configuration-name]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-proxy-configuration-name[`quarkus.flow.http.client.named."named".proxy-configuration-name`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.named."named".proxy-host+++[]
+config_property_copy_button:+++quarkus.flow.http.client.named."named".proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-HTTP proxy host.
-
-When set together with `proxy-port()`, requests are sent through the given HTTP proxy.
+The name of the proxy configuration to use for configuring *HTTP* proxy.
 
 Default client:
 
 ```
-quarkus.flow.http.client.proxy-host=proxy.mycorp.local
+quarkus flow.http.client.proxy-configuration-name=proxy-cfg
 ```
 
 
@@ -2037,221 +1840,28 @@ quarkus.flow.http.client.proxy-host=proxy.mycorp.local
 Named client:
 
 ```
-quarkus.flow.http.client.named.<name>.proxy-host=proxy.mycorp.local
+quarkus.flow.http.client.named.<name>.proxy-configuration-name=proxy-cfg
 ```
 
+There are some rules for using proxy configuration:
+
+ - If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
+ - If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
+ - If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
 
 
-Internally mapped to `ClientBuilderImpl.proxy(host, port)`.
+
+Use the value `none` to disable using the default configuration defined via `quarkus.proxy.++*++`.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_HOST+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_HOST+++`
+Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-named-named-proxy-port]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-proxy-port[`quarkus.flow.http.client.named."named".proxy-port`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.named."named".proxy-port+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-HTTP proxy port.
-
-Only used when `proxy-host()` is also set.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-port=8080
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-port=8080
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxy(host, port)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_PORT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_PORT+++`
-endif::add-copy-button-to-env-var[]
---
-|int
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-named-named-proxy-user]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-proxy-user[`quarkus.flow.http.client.named."named".proxy-user`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.named."named".proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Username for authenticating with the HTTP proxy.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-user=svc-flow
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-user=svc-flow
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxyUser(user)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-named-named-proxy-password]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-proxy-password[`quarkus.flow.http.client.named."named".proxy-password`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.named."named".proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Password for authenticating with the HTTP proxy.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-password=secret
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-password=secret
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxyPassword(password)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-named-named-non-proxy-hosts]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-non-proxy-hosts[`quarkus.flow.http.client.named."named".non-proxy-hosts`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.named."named".non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts that should bypass the HTTP proxy.
-
-The value is a `++\|++`-separated pattern list, similar to the standard `http.nonProxyHosts` format:
-
-```
-quarkus.flow.http.client.non-proxy-hosts=localhost\|127.*\|[::1]
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.non-proxy-hosts=localhost\|127.*
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.nonProxyHosts(hostsPattern)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__NON_PROXY_HOSTS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-named-named-proxy-connect-timeout]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-proxy-connect-timeout[`quarkus.flow.http.client.named."named".proxy-connect-timeout`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.named."named".proxy-connect-timeout+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy connect timeout in milliseconds.
-
-Controls how long the client will wait when establishing a connection to the configured HTTP proxy.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-connect-timeout=3000
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-connect-timeout=3000
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxyConnectTimeout(Duration)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_CONNECT_TIMEOUT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_CONNECT_TIMEOUT+++`
-endif::add-copy-button-to-env-var[]
---
-|long
 |
 
 a| [[quarkus-flow_quarkus-flow-http-client-named-named-follow-redirects]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-follow-redirects[`quarkus.flow.http.client.named."named".follow-redirects`]##

--- a/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.flow.adoc
@@ -804,22 +804,20 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-flow_quarkus-flow-http-client-proxy-host]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-proxy-host[`quarkus.flow.http.client.proxy-host`]##
+a| [[quarkus-flow_quarkus-flow-http-client-proxy-configuration-name]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-proxy-configuration-name[`quarkus.flow.http.client.proxy-configuration-name`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.proxy-host+++[]
+config_property_copy_button:+++quarkus.flow.http.client.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-HTTP proxy host.
-
-When set together with `proxy-port()`, requests are sent through the given HTTP proxy.
+The name of the proxy configuration to use for configuring *HTTP* proxy.
 
 Default client:
 
 ```
-quarkus.flow.http.client.proxy-host=proxy.mycorp.local
+quarkus flow.http.client.proxy-configuration-name=proxy-cfg
 ```
 
 
@@ -827,221 +825,28 @@ quarkus.flow.http.client.proxy-host=proxy.mycorp.local
 Named client:
 
 ```
-quarkus.flow.http.client.named.<name>.proxy-host=proxy.mycorp.local
+quarkus.flow.http.client.named.<name>.proxy-configuration-name=proxy-cfg
 ```
 
+There are some rules for using proxy configuration:
+
+ - If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
+ - If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
+ - If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
 
 
-Internally mapped to `ClientBuilderImpl.proxy(host, port)`.
+
+Use the value `none` to disable using the default configuration defined via `quarkus.proxy.++*++`.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_HOST+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_HOST+++`
+Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-proxy-port]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-proxy-port[`quarkus.flow.http.client.proxy-port`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.proxy-port+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-HTTP proxy port.
-
-Only used when `proxy-host()` is also set.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-port=8080
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-port=8080
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxy(host, port)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_PORT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_PORT+++`
-endif::add-copy-button-to-env-var[]
---
-|int
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-proxy-user]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-proxy-user[`quarkus.flow.http.client.proxy-user`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Username for authenticating with the HTTP proxy.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-user=svc-flow
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-user=svc-flow
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxyUser(user)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-proxy-password]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-proxy-password[`quarkus.flow.http.client.proxy-password`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Password for authenticating with the HTTP proxy.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-password=secret
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-password=secret
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxyPassword(password)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-non-proxy-hosts]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-non-proxy-hosts[`quarkus.flow.http.client.non-proxy-hosts`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts that should bypass the HTTP proxy.
-
-The value is a `++\|++`-separated pattern list, similar to the standard `http.nonProxyHosts` format:
-
-```
-quarkus.flow.http.client.non-proxy-hosts=localhost\|127.*\|[::1]
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.non-proxy-hosts=localhost\|127.*
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.nonProxyHosts(hostsPattern)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NON_PROXY_HOSTS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-proxy-connect-timeout]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-proxy-connect-timeout[`quarkus.flow.http.client.proxy-connect-timeout`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.proxy-connect-timeout+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy connect timeout in milliseconds.
-
-Controls how long the client will wait when establishing a connection to the configured HTTP proxy.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-connect-timeout=3000
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-connect-timeout=3000
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxyConnectTimeout(Duration)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_CONNECT_TIMEOUT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_PROXY_CONNECT_TIMEOUT+++`
-endif::add-copy-button-to-env-var[]
---
-|long
 |
 
 a| [[quarkus-flow_quarkus-flow-http-client-follow-redirects]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-follow-redirects[`quarkus.flow.http.client.follow-redirects`]##
@@ -2014,22 +1819,20 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-flow_quarkus-flow-http-client-named-named-proxy-host]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-proxy-host[`quarkus.flow.http.client.named."named".proxy-host`]##
+a| [[quarkus-flow_quarkus-flow-http-client-named-named-proxy-configuration-name]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-proxy-configuration-name[`quarkus.flow.http.client.named."named".proxy-configuration-name`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.named."named".proxy-host+++[]
+config_property_copy_button:+++quarkus.flow.http.client.named."named".proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-HTTP proxy host.
-
-When set together with `proxy-port()`, requests are sent through the given HTTP proxy.
+The name of the proxy configuration to use for configuring *HTTP* proxy.
 
 Default client:
 
 ```
-quarkus.flow.http.client.proxy-host=proxy.mycorp.local
+quarkus flow.http.client.proxy-configuration-name=proxy-cfg
 ```
 
 
@@ -2037,221 +1840,28 @@ quarkus.flow.http.client.proxy-host=proxy.mycorp.local
 Named client:
 
 ```
-quarkus.flow.http.client.named.<name>.proxy-host=proxy.mycorp.local
+quarkus.flow.http.client.named.<name>.proxy-configuration-name=proxy-cfg
 ```
 
+There are some rules for using proxy configuration:
+
+ - If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
+ - If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
+ - If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
 
 
-Internally mapped to `ClientBuilderImpl.proxy(host, port)`.
+
+Use the value `none` to disable using the default configuration defined via `quarkus.proxy.++*++`.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_HOST+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_HOST+++`
+Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-named-named-proxy-port]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-proxy-port[`quarkus.flow.http.client.named."named".proxy-port`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.named."named".proxy-port+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-HTTP proxy port.
-
-Only used when `proxy-host()` is also set.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-port=8080
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-port=8080
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxy(host, port)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_PORT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_PORT+++`
-endif::add-copy-button-to-env-var[]
---
-|int
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-named-named-proxy-user]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-proxy-user[`quarkus.flow.http.client.named."named".proxy-user`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.named."named".proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Username for authenticating with the HTTP proxy.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-user=svc-flow
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-user=svc-flow
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxyUser(user)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-named-named-proxy-password]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-proxy-password[`quarkus.flow.http.client.named."named".proxy-password`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.named."named".proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Password for authenticating with the HTTP proxy.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-password=secret
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-password=secret
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxyPassword(password)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-named-named-non-proxy-hosts]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-non-proxy-hosts[`quarkus.flow.http.client.named."named".non-proxy-hosts`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.named."named".non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts that should bypass the HTTP proxy.
-
-The value is a `++\|++`-separated pattern list, similar to the standard `http.nonProxyHosts` format:
-
-```
-quarkus.flow.http.client.non-proxy-hosts=localhost\|127.*\|[::1]
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.non-proxy-hosts=localhost\|127.*
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.nonProxyHosts(hostsPattern)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__NON_PROXY_HOSTS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-flow_quarkus-flow-http-client-named-named-proxy-connect-timeout]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-proxy-connect-timeout[`quarkus.flow.http.client.named."named".proxy-connect-timeout`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.http.client.named."named".proxy-connect-timeout+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy connect timeout in milliseconds.
-
-Controls how long the client will wait when establishing a connection to the configured HTTP proxy.
-
-Default client:
-
-```
-quarkus.flow.http.client.proxy-connect-timeout=3000
-```
-
-
-
-Named client:
-
-```
-quarkus.flow.http.client.named.<name>.proxy-connect-timeout=3000
-```
-
-
-
-Internally mapped to `ClientBuilderImpl.proxyConnectTimeout(Duration)`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_CONNECT_TIMEOUT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_HTTP_CLIENT_NAMED__NAMED__PROXY_CONNECT_TIMEOUT+++`
-endif::add-copy-button-to-env-var[]
---
-|long
 |
 
 a| [[quarkus-flow_quarkus-flow-http-client-named-named-follow-redirects]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-named-named-follow-redirects[`quarkus.flow.http.client.named."named".follow-redirects`]##


### PR DESCRIPTION
# Changes

This pull request aligns proxy configuration with the new global configuration approach introduced in the Quarkus Platform, integrating proxy setup with the Credentials Provider for secure and centralized credential management.

Closes #156