### PR TITLE
chore: fix InvestAnalystAgent class annotation

### DIFF
--- a/docs/modules/ROOT/examples/org/acme/agentic/InvestmentAnalystAgent.java
+++ b/docs/modules/ROOT/examples/org/acme/agentic/InvestmentAnalystAgent.java
@@ -41,10 +41,8 @@ public interface InvestmentAnalystAgent {
     /**
      * Analyze the prompt and produce an investment memo.
      *
-     * @param memoryId
-     *        Conversation / workflow memory id (provided by Quarkus Flow).
-     * @param prompt
-     *        Ticker, objective, horizon and raw market-data JSON.
+     * @param memoryId Conversation / workflow memory id (provided by Quarkus Flow).
+     * @param prompt Ticker, objective, horizon and raw market-data JSON.
      */
     @UserMessage("""
             Ticker: {prompt.ticker}

--- a/examples/agentic-http/src/main/java/org/acme/agentic/InvestmentAnalystAgent.java
+++ b/examples/agentic-http/src/main/java/org/acme/agentic/InvestmentAnalystAgent.java
@@ -5,6 +5,7 @@ import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 import io.quarkiverse.langchain4j.RegisterAiService;
+import jakarta.enterprise.context.ApplicationScoped;
 
 // tag::agent[]
 
@@ -14,6 +15,7 @@ import io.quarkiverse.langchain4j.RegisterAiService;
  * It receives an {@link InvestmentPrompt} (ticker + JSON market snapshot) and returns an {@link InvestmentMemo} with a
  * short recommendation.
  */
+@ApplicationScoped
 @RegisterAiService
 @SystemMessage("""
         You are a careful, conservative investment analyst.
@@ -38,10 +40,8 @@ public interface InvestmentAnalystAgent {
     /**
      * Analyze the prompt and produce an investment memo.
      *
-     * @param memoryId
-     *        Conversation / workflow memory id (provided by Quarkus Flow).
-     * @param prompt
-     *        Ticker, objective, horizon and raw market-data JSON.
+     * @param memoryId Conversation / workflow memory id (provided by Quarkus Flow).
+     * @param prompt Ticker, objective, horizon and raw market-data JSON.
      */
     @UserMessage("""
             Ticker: {prompt.ticker}


### PR DESCRIPTION
Small PR to fix an annoying formatting bug. All the examples from docs are copied from our `examples` dir - there should be the source of truth. Do not try to change those directly.