### PR TITLE
Resolve workflow identifier for CDI proxied beans

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/SimpleResource.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/SimpleResource.java
@@ -1,0 +1,21 @@
+package io.quarkiverse.flow.deployment.test.metrics;
+
+import java.util.Map;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+@Path("/simple-resource")
+public class SimpleResource {
+
+    @Inject
+    SimpleFlow flow;
+
+    @POST
+    public void start() {
+        flow.instance(Map.of("message", "hello"))
+                .start()
+                .join();
+    }
+}

--- a/core/integration-tests/pom.xml
+++ b/core/integration-tests/pom.xml
@@ -20,6 +20,14 @@
             <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.flow</groupId>
             <artifactId>quarkus-flow</artifactId>
             <version>${project.version}</version>

--- a/core/integration-tests/src/main/java/io/quarkiverse/flow/it/ProposalResource.java
+++ b/core/integration-tests/src/main/java/io/quarkiverse/flow/it/ProposalResource.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.flow.it;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+import io.serverlessworkflow.impl.WorkflowModel;
+
+@Path("/proposals")
+public class ProposalResource {
+
+    @Inject
+    SaveProposalWorkflow workflow;
+
+    @POST
+    @Produces("text/plain")
+    public String proposal() {
+        WorkflowModel model = workflow.instance().start().join();
+        return "Proposal created with ID: " + model.asNumber().orElseThrow().longValue();
+    }
+}

--- a/core/integration-tests/src/main/java/io/quarkiverse/flow/it/SaveProposalWorkflow.java
+++ b/core/integration-tests/src/main/java/io/quarkiverse/flow/it/SaveProposalWorkflow.java
@@ -1,0 +1,47 @@
+package io.quarkiverse.flow.it;
+
+import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.function;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.Entity;
+import jakarta.transaction.Transactional;
+
+import io.quarkiverse.flow.Flow;
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.serverlessworkflow.api.types.Workflow;
+import io.serverlessworkflow.fluent.func.FuncWorkflowBuilder;
+
+@ApplicationScoped
+public class SaveProposalWorkflow extends Flow {
+
+    @Override
+    public Workflow descriptor() {
+        return FuncWorkflowBuilder.workflow("saveProposalWorkflow")
+                .tasks(function("doSave", this::save, String.class).outputAs(o -> (Long) o))
+                .build();
+    }
+
+    @Transactional
+    public Long save(String proposal) {
+        Proposal p = new Proposal(proposal);
+        p.persist();
+        return p.id;
+    }
+
+    @Entity
+    static class Proposal extends PanacheEntity {
+
+        private String proposal;
+
+        protected Proposal() {
+        }
+
+        public Proposal(String proposal) {
+            this.proposal = proposal;
+        }
+
+        public String getProposal() {
+            return proposal;
+        }
+    }
+}

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/ProposalResourceTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/ProposalResourceTest.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.flow.it;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+class ProposalResourceTest {
+
+    @Test
+    void should_resolve_workflow_identifier_when_the_workflow_bean_is_a_proxy() {
+        RestAssured.given()
+                .accept("text/plain")
+                .post("/proposals")
+                .then()
+                .body(Matchers.containsString("Proposal created with ID: 1"))
+                .extract()
+                .body()
+                .asString();
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/flow/Flowable.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/Flowable.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.flow;
 
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.arc.InterceptionProxySubclass;
+import io.quarkus.arc.Subclass;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.impl.WorkflowDefinitionId;
 
@@ -18,7 +21,15 @@ public interface Flowable {
     }
 
     default String identifier() {
-        return this.getClass().getName();
+        if (this instanceof ClientProxy proxy) {
+            return proxy.getClass().getSuperclass().getName();
+        } else if (this instanceof InterceptionProxySubclass proxy) {
+            return proxy.getClass().getSuperclass().getName();
+        } else if (this instanceof Subclass subclass) {
+            return subclass.getClass().getSuperclass().getName();
+        } else {
+            return this.getClass().getName();
+        }
     }
 
 }

--- a/examples/agentic-http/src/main/java/org/acme/agentic/InvestmentAnalystAgent.java
+++ b/examples/agentic-http/src/main/java/org/acme/agentic/InvestmentAnalystAgent.java
@@ -40,8 +40,10 @@ public interface InvestmentAnalystAgent {
     /**
      * Analyze the prompt and produce an investment memo.
      *
-     * @param memoryId Conversation / workflow memory id (provided by Quarkus Flow).
-     * @param prompt Ticker, objective, horizon and raw market-data JSON.
+     * @param memoryId
+     *        Conversation / workflow memory id (provided by Quarkus Flow).
+     * @param prompt
+     *        Ticker, objective, horizon and raw market-data JSON.
      */
     @UserMessage("""
             Ticker: {prompt.ticker}

--- a/examples/micrometer-prometheus/src/main/java/org/acme/SimpleWorkflow.java
+++ b/examples/micrometer-prometheus/src/main/java/org/acme/SimpleWorkflow.java
@@ -1,12 +1,10 @@
 package org.acme;
 
 import static io.serverlessworkflow.fluent.func.FuncWorkflowBuilder.workflow;
-import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.function;
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.set;
 
 import io.quarkiverse.flow.Flow;
 import io.serverlessworkflow.api.types.Workflow;
-import io.serverlessworkflow.fluent.func.dsl.FuncDSL;
 import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
@@ -14,7 +12,6 @@ public class SimpleWorkflow extends Flow {
 
     @Override
     public Workflow descriptor() {
-        return workflow("simple-workflow", "quarkus.flow")
-                .tasks(set("{ message: \"Ana Sara\" }")).build();
+        return workflow("simple-workflow", "quarkus.flow").tasks(set("{ message: \"Ana Sara\" }")).build();
     }
 }

--- a/examples/micrometer-prometheus/src/main/java/org/acme/TryWorkflowsResource.java
+++ b/examples/micrometer-prometheus/src/main/java/org/acme/TryWorkflowsResource.java
@@ -56,8 +56,7 @@ public class TryWorkflowsResource {
 
         instance.resume();
 
-        return Uni.createFrom().completionStage(start.toCompletableFuture())
-                .onItem()
+        return Uni.createFrom().completionStage(start.toCompletableFuture()).onItem()
                 .transform(workflowModel -> workflowModel.as(Message.class).orElseThrow());
     }
 

--- a/examples/petstore-openapi/src/test/java/org/acme/http/PetstoreFlowIT.java
+++ b/examples/petstore-openapi/src/test/java/org/acme/http/PetstoreFlowIT.java
@@ -2,12 +2,11 @@ package org.acme.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import java.util.Map;
-
 import org.junit.jupiter.api.Test;
-import io.quarkus.test.common.QuarkusTestResource;
 
 @QuarkusTest
 @QuarkusTestResource(PetstoreMockResource.class)
@@ -28,12 +27,8 @@ class PetstoreFlowIT {
         // Very lightweight sanity checks – we mainly care that the flow ran end-to-end
         assertThat(pet).isNotNull();
         assertThat(pet).isNotEmpty();
-        assertThat(((Number) pet.get("id")).intValue())
-                .as("pet id from mocked response")
-                .isEqualTo(123);
-        assertThat((String) pet.get("name"))
-                .as("pet name from mocked response")
-                .isEqualTo("Mocked Pet");
+        assertThat(((Number) pet.get("id")).intValue()).as("pet id from mocked response").isEqualTo(123);
+        assertThat((String) pet.get("name")).as("pet name from mocked response").isEqualTo("Mocked Pet");
 
     }
 }

--- a/examples/petstore-openapi/src/test/java/org/acme/http/PetstoreMockResource.java
+++ b/examples/petstore-openapi/src/test/java/org/acme/http/PetstoreMockResource.java
@@ -1,16 +1,20 @@
 package org.acme.http;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
 import com.github.tomakehurst.wiremock.WireMockServer;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 
 public class PetstoreMockResource implements QuarkusTestResourceLifecycleManager {
 
@@ -28,17 +32,13 @@ public class PetstoreMockResource implements QuarkusTestResourceLifecycleManager
         configureFor("localhost", wireMock.port());
 
         // 1) findByStatus -> returns a list with a deterministic pet id
-        stubFor(get(urlPathEqualTo("/api/v3/pet/findByStatus"))
-                .withQueryParam("status", matching(".*"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "application/json")
+        stubFor(get(urlPathEqualTo("/api/v3/pet/findByStatus")).withQueryParam("status", matching(".*"))
+                .willReturn(aResponse().withHeader("Content-Type", "application/json")
                         .withBody("[{\"id\":123,\"name\":\"Mocked Pet\"}]")));
 
         // 2) getPetById -> returns deterministic pet details
-        stubFor(get(urlPathEqualTo("/api/v3/pet/123"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "application/json")
-                        .withBody("{\"id\":123,\"name\":\"Mocked Pet\"}")));
+        stubFor(get(urlPathEqualTo("/api/v3/pet/123")).willReturn(aResponse()
+                .withHeader("Content-Type", "application/json").withBody("{\"id\":123,\"name\":\"Mocked Pet\"}")));
 
         // Rewrite OpenAPI servers[0].url to the WireMock port
         rewriteOpenApi("http://localhost:" + wireMock.port() + "/api/v3/");


### PR DESCRIPTION
Fixes issue where workflow beans with CDI interceptors (e.g., `@Transactional`) were generating incorrect identifiers due to proxy class names ending with `_Subclass` or `_ClientProxy` suffixes.

Closes #192 