### PR TITLE
Standardize correlation metadata header names to lowercase 

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-flow-messaging.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-messaging.adoc
@@ -63,8 +63,8 @@ When enabled, correlation metadata attributes are automatically added to emitted
 
 The default correlation metadata includes:
 
- - `XFlowInstanceId` the instance ID, see `WorkflowInstance++#++id()`
- - `XFlowTaskId` the task's position that where the request was made, see `io.serverlessworkflow.impl.TaskContext++#++position()`
+ - `flowinstanceid` the instance ID, see `WorkflowInstance++#++id()`
+ - `flowtaskid` the task's position that where the request was made, see `io.serverlessworkflow.impl.TaskContext++#++position()`
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-flow-messaging_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-messaging_quarkus.flow.adoc
@@ -63,8 +63,8 @@ When enabled, correlation metadata attributes are automatically added to emitted
 
 The default correlation metadata includes:
 
- - `XFlowInstanceId` the instance ID, see `WorkflowInstance++#++id()`
- - `XFlowTaskId` the task's position that where the request was made, see `io.serverlessworkflow.impl.TaskContext++#++position()`
+ - `flowinstanceid` the instance ID, see `WorkflowInstance++#++id()`
+ - `flowtaskid` the task's position that where the request was made, see `io.serverlessworkflow.impl.TaskContext++#++position()`
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/messaging.adoc
+++ b/docs/modules/ROOT/pages/messaging.adoc
@@ -153,12 +153,31 @@ For idempotency and traceability purposes, Quarkus Flow by default attaches corr
 
 The metadata are added into the link:https://github.com/cloudevents/spec/blob/v1.0/spec.md#extension-context-attributes[CloudEvent Extension Context Attribute].
 
-* `XFlowInstanceId` - contains the `WorkflowInstance` id
-* `XFlowTaskId` - contains the current position (link:https://datatracker.ietf.org/doc/html/rfc6901[JSON Pointer]) of the Workflow's task responsible for sending the HTTP request. For more information about this field see link:https://github.com/serverlessworkflow/specification/blob/main/dsl.md#task-descriptor[the Task Descriptor section on the specification docs].
+* `flowinstanceid` - contains the `WorkflowInstance` id
+* `flowtaskid` - contains the current position (link:https://datatracker.ietf.org/doc/html/rfc6901[JSON Pointer]) of the Workflow's task responsible for sending the HTTP request. For more information about this field see link:https://github.com/serverlessworkflow/specification/blob/main/dsl.md#task-descriptor[the Task Descriptor section on the specification docs].
 
 You can change the key through `quarkus.flow.messaging.metadata.instance-id.key` and `quarkus.flow.messaging.metadata.task-id.key` properties.
 
 These metadata enable end-to-end traceability and idempotency handling throughout the workflow execution. You can disable the automatic correlation header injection by setting the `quarkus.flow.messaging.enable-metadata-propagation` configuration property to `false`.
+
+=== Getting correlation metadata
+
+Correlation metadata is propagated as CloudEvent extension attributes.
+You can retrieve these attributes directly from the `CloudEvent` instance:
+
+[source,java]
+----
+import io.cloudevents.CloudEvent;
+import io.quarkus.logging.Log;
+
+public void printCorrelation(CloudEvent event) {
+    String instanceId = (String) event.getExtension("flowinstanceid");
+    String taskId = (String) event.getExtension("flowtaskid");
+
+    Log.infof("Flow Instance ID: %s", instanceId);
+    Log.infof("Flow Task ID: %s", taskId);
+}
+----
 
 == See also
 

--- a/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/FlowMessagingConfig.java
+++ b/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/FlowMessagingConfig.java
@@ -20,8 +20,8 @@ public interface FlowMessagingConfig {
      * <p>
      * The default correlation metadata includes:
      * <ul>
-     * <li><code>XFlowInstanceId</code> the instance ID, see {@link WorkflowInstance#id()}</li>
-     * <li><code>XFlowTaskId</code> the task's position that where the request was made, see
+     * <li><code>flowinstanceid</code> the instance ID, see {@link WorkflowInstance#id()}</li>
+     * <li><code>flowtaskid</code> the task's position that where the request was made, see
      * {@link io.serverlessworkflow.impl.TaskContext#position()}</li>
      * </ul>
      */

--- a/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/MetadataPropagationEmittedEventDecorator.java
+++ b/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/MetadataPropagationEmittedEventDecorator.java
@@ -11,8 +11,8 @@ import io.serverlessworkflow.impl.events.EmittedEventDecorator;
 
 public class MetadataPropagationEmittedEventDecorator implements EmittedEventDecorator {
 
-    public static final String FLOW_INSTANCE_ID = "XFlowInstanceId";
-    public static final String FLOW_TASK_ID = "XFlowTaskId";
+    public static final String FLOW_INSTANCE_ID = "flowinstanceid";
+    public static final String FLOW_TASK_ID = "flowtaskid";
 
     private final boolean enableMetadataPropagation;
     private final String instanceIDKey;


### PR DESCRIPTION
# Changes

Changed correlation metadata attribute names from PascalCase with 'X' prefix to lowercase format for better CloudEvents compatibility:

- XFlowInstanceId → flowinstanceid
- XFlowTaskId → flowtaskid

Fixes #252