### PR TITLE
ci: limit PR preview building only when the documentation sources are…

### DIFF
--- a/.github/workflows/build-website.yaml
+++ b/.github/workflows/build-website.yaml
@@ -3,20 +3,13 @@ name: Build website
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      - '.gitignore'
-      - 'LICENSE'
-      - '*.md'
-      - '*.adoc'
-      - '*.txt'
+    paths:
+      - 'docs/**'
 
   workflow_dispatch:
   pull_request:
-    paths-ignore:
-      - '.gitignore'
-      - 'LICENSE'
-      - '*.md'
-      - '*.txt'
+    paths:
+      - 'docs/**'
     types: [ opened, synchronize, reopened ]
 
 defaults:

--- a/.github/workflows/preview-docs.yaml
+++ b/.github/workflows/preview-docs.yaml
@@ -13,7 +13,10 @@ defaults:
 jobs:
   preview:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.name == 'Build website'
     permissions:
       pull-requests: write # Required to update PR status comment
     steps:


### PR DESCRIPTION
This Pull Request closes: #208 

[X] Save resources - no need to run preview if we do not update docs.
[X] Better contribution experience - no big comment with preview in the PR