### PR TITLE
fix: Duplicate assertj-core test dependency in langchain4j/deployment

### DIFF
--- a/langchain4j/deployment/pom.xml
+++ b/langchain4j/deployment/pom.xml
@@ -56,11 +56,6 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Fix #256 