### PR TITLE
Add how-to guide to help users when using data flow and transformations

### DIFF
--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/Call4PapersFlow.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/Call4PapersFlow.java
@@ -1,0 +1,120 @@
+package io.quarkiverse.flow.it;
+
+import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.function;
+import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.http;
+import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.output;
+
+import java.net.URI;
+import java.util.function.Function;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkiverse.flow.Flow;
+import io.serverlessworkflow.api.types.Workflow;
+import io.serverlessworkflow.fluent.func.FuncWorkflowBuilder;
+import io.serverlessworkflow.fluent.func.dsl.FuncDSL;
+
+// tag::validate-proposal[]
+@ApplicationScoped // <1>
+public class Call4PapersFlow extends Flow { // <2>
+
+    @ConfigProperty(name = "notification.service.base-url")
+    String baseUrl;
+
+    @Override
+    public Workflow descriptor() {
+        return FuncWorkflowBuilder.workflow("call4papers")
+                .tasks(
+                        // tag::validate-and-score[]
+                        // Step 1: Validate proposal with inputFrom transformation
+                        function("validateProposal", (Proposal input) -> {
+                            String proposalTitle = input.title();
+                            if (proposalTitle == null || proposalTitle.isBlank()) {
+                                throw new IllegalArgumentException("Title is required");
+                            }
+                            return input;
+                        }, Proposal.class)
+                                .inputFrom((ProposalSubmission submission) -> new Proposal(
+                                        submission.title(),
+                                        submission.proposal(), // Maps to abstractText
+                                        submission.author()), ProposalSubmission.class),
+                        // end::validate-proposal[]
+                        // Step 2: Score proposal with exportAs transformation
+                        function("scoreProposal", (Proposal input) -> { // <1>
+                            Integer score = calculateScore(input.abstractText());
+                            System.out.println("Score calculated having the result as: " + score);
+                            return score;
+                        }, Proposal.class)
+                                .outputAs((Integer score) -> new ProposalScore(score, score >= 7)), // <2>
+                        // end::validate-and-score[]
+                        // tag::last-tasks[]
+                        // Step 3: Prepare notification with exportAs using workflow context
+                        function("prepareNotification", Function.identity(), ProposalScore.class) // <1>
+                                .exportAs((object, workflowContext, taskContextData) -> { // <2>
+
+                                    ProposalScore taskOutput = output(taskContextData, ProposalScore.class); // <3>
+
+                                    ProposalSubmission submission = FuncDSL.input(workflowContext, // <4>
+                                            ProposalSubmission.class);
+
+                                    return new NotificationPayload( // <5>
+                                            submission.title(),
+                                            submission.author(),
+                                            taskOutput.score(),
+                                            taskOutput.accepted());
+                                }),
+
+                        // Step 4: Send notification via HTTP
+                        http("sendNotification")
+                                .POST()
+                                .body("${ $context }") // <6>
+                                .header("Content-Type", "application/json")
+                                .uri(URI.create(baseUrl + "/notifications")))
+                // end::last-tasks[]
+                .build();
+    }
+
+    /**
+     * Calculate a score for the proposal based on its abstract.
+     * In a real implementation, this might use NLP, keyword analysis, etc.
+     */
+    private Integer calculateScore(String abstractText) {
+        // Simple scoring: longer abstracts get higher scores
+        int length = abstractText.length();
+        if (length > 500)
+            return 9;
+        if (length > 300)
+            return 7;
+        if (length > 150)
+            return 5;
+        return 3;
+    }
+
+    // tag::data-types[]
+    /**
+     * External DTO received from the API
+     */
+    public record ProposalSubmission(String title, String proposal, String author) {
+    }
+
+    /**
+     * Internal domain model used for processing
+     */
+    public record Proposal(String title, String abstractText, String author) {
+    }
+
+    /**
+     * Scoring result persisted in workflow data
+     */
+    public record ProposalScore(long score, boolean accepted) {
+    }
+
+    /**
+     * Final notification payload enriched with data from multiple sources
+     */
+    public record NotificationPayload(String title, String author, long score, boolean accepted) {
+    }
+    // end::data-types[]
+}

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/Call4PapersTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/Call4PapersTest.java
@@ -1,0 +1,78 @@
+package io.quarkiverse.flow.it;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static java.util.Map.entry;
+
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.junit.QuarkusTest;
+import io.serverlessworkflow.impl.WorkflowModel;
+
+@QuarkusTest
+@QuarkusTestResource(Call4PapersTest.WireMockTestResource.class)
+public class Call4PapersTest {
+
+    @Inject
+    Call4PapersFlow flow;
+
+    @BeforeAll
+    static void setUp() {
+    }
+
+    @Test
+    void should_execute_correctly() {
+        var submission = new Call4PapersFlow.ProposalSubmission(
+                "Reactive Workflows with Quarkus",
+                "This paper explores reactive workflow patterns...",
+                "Jane Developer");
+
+        WorkflowModel workflowModel = flow.startInstance(submission).await().indefinitely();
+
+        Map<String, Object> map = workflowModel.asMap().orElseThrow();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(map).contains(entry("status", "Notification sent"));
+        });
+    }
+
+    public static class WireMockTestResource implements QuarkusTestResourceLifecycleManager {
+
+        static WireMockServer mock = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+
+        @Override
+        public Map<String, String> start() {
+            mock.start();
+            mock.addStubMapping(post("/notifications")
+                    .withRequestBody(matchingJsonPath("$.title", equalTo("Reactive Workflows with Quarkus")))
+                    .withRequestBody(matchingJsonPath("$.author", equalTo("Jane Developer")))
+                    .withRequestBody(matchingJsonPath("$.score", equalTo("3")))
+                    .withRequestBody(matchingJsonPath("$.accepted", equalTo("false")))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("{ \"status\": \"Notification sent\" }"))
+                    .build());
+            return Map.of(
+                    "notification.service.base-url", mock.baseUrl());
+        }
+
+        @Override
+        public void stop() {
+            mock.stop();
+        }
+    }
+}

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/JwtWithinWorkflowTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/JwtWithinWorkflowTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
@@ -56,7 +57,7 @@ public class JwtWithinWorkflowTest {
 
         @Override
         public Map<String, String> start() {
-            wireMockServer = new WireMockServer(port);
+            wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
             wireMockServer.start();
 
             wireMockServer.stubFor(

--- a/docs/modules/ROOT/examples/org/acme/dataflow/Call4PapersFlow.java
+++ b/docs/modules/ROOT/examples/org/acme/dataflow/Call4PapersFlow.java
@@ -1,0 +1,120 @@
+package org.acme.dataflow;
+
+import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.function;
+import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.http;
+import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.output;
+
+import java.net.URI;
+import java.util.function.Function;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkiverse.flow.Flow;
+import io.serverlessworkflow.api.types.Workflow;
+import io.serverlessworkflow.fluent.func.FuncWorkflowBuilder;
+import io.serverlessworkflow.fluent.func.dsl.FuncDSL;
+
+// tag::validate-proposal[]
+@ApplicationScoped // <1>
+public class Call4PapersFlow extends Flow { // <2>
+
+    @ConfigProperty(name = "notification.service.base-url")
+    String baseUrl;
+
+    @Override
+    public Workflow descriptor() {
+        return FuncWorkflowBuilder.workflow("call4papers")
+                .tasks(
+                        // tag::validate-and-score[]
+                        // Step 1: Validate proposal with inputFrom transformation
+                        function("validateProposal", (Proposal input) -> {
+                            String proposalTitle = input.title();
+                            if (proposalTitle == null || proposalTitle.isBlank()) {
+                                throw new IllegalArgumentException("Title is required");
+                            }
+                            return input;
+                        }, Proposal.class)
+                                .inputFrom((ProposalSubmission submission) -> new Proposal(
+                                        submission.title(),
+                                        submission.proposal(), // Maps to abstractText
+                                        submission.author()), ProposalSubmission.class),
+                        // end::validate-proposal[]
+                        // Step 2: Score proposal with exportAs transformation
+                        function("scoreProposal", (Proposal input) -> { // <1>
+                            Integer score = calculateScore(input.abstractText());
+                            System.out.println("Score calculated having the result as: " + score);
+                            return score;
+                        }, Proposal.class)
+                                .outputAs((Integer score) -> new ProposalScore(score, score >= 7)), // <2>
+                        // end::validate-and-score[]
+                        // tag::last-tasks[]
+                        // Step 3: Prepare notification with exportAs using workflow context
+                        function("prepareNotification", Function.identity(), ProposalScore.class) // <1>
+                                .exportAs((object, workflowContext, taskContextData) -> { // <2>
+
+                                    ProposalScore taskOutput = output(taskContextData, ProposalScore.class); // <3>
+
+                                    ProposalSubmission submission = FuncDSL.input(workflowContext, // <4>
+                                            ProposalSubmission.class);
+
+                                    return new NotificationPayload( // <5>
+                                            submission.title(),
+                                            submission.author(),
+                                            taskOutput.score(),
+                                            taskOutput.accepted());
+                                }),
+
+                        // Step 4: Send notification via HTTP
+                        http("sendNotification")
+                                .POST()
+                                .body("${ $context }") // <6>
+                                .header("Content-Type", "application/json")
+                                .uri(URI.create(baseUrl + "/notifications")))
+                // end::last-tasks[]
+                .build();
+    }
+
+    /**
+     * Calculate a score for the proposal based on its abstract.
+     * In a real implementation, this might use NLP, keyword analysis, etc.
+     */
+    private Integer calculateScore(String abstractText) {
+        // Simple scoring: longer abstracts get higher scores
+        int length = abstractText.length();
+        if (length > 500)
+            return 9;
+        if (length > 300)
+            return 7;
+        if (length > 150)
+            return 5;
+        return 3;
+    }
+
+    // tag::data-types[]
+    /**
+     * External DTO received from the API
+     */
+    public record ProposalSubmission(String title, String proposal, String author) {
+    }
+
+    /**
+     * Internal domain model used for processing
+     */
+    public record Proposal(String title, String abstractText, String author) {
+    }
+
+    /**
+     * Scoring result persisted in workflow data
+     */
+    public record ProposalScore(long score, boolean accepted) {
+    }
+
+    /**
+     * Final notification payload enriched with data from multiple sources
+     */
+    public record NotificationPayload(String title, String author, long score, boolean accepted) {
+    }
+    // end::data-types[]
+}

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -14,6 +14,7 @@
 *** xref:workflow-definitions.adoc[Define workflows from YAML]
 *** xref:scheduler.adoc[Schedule workflow executions]
 *** xref:secrets.adoc[Resolve secrets securely]
+*** xref:how-to-deal-with-state.adoc[Use data flow and context management]
 ** Agentic AI & LangChain4j
 *** xref:langchain4j.adoc[Orchestrate agents with the Java DSL]
 ** External Integrations

--- a/docs/modules/ROOT/pages/how-to-deal-with-state.adoc
+++ b/docs/modules/ROOT/pages/how-to-deal-with-state.adoc
@@ -1,0 +1,143 @@
+= How to transform data between workflow tasks
+include::includes/attributes.adoc[]
+:page-role: howto
+:sectnums:
+
+This guide shows you how to control data flow between tasks in a workflow using `inputFrom`, `exportAs`, and `outputAs` transformations.
+
+== What you'll build
+
+You'll create a conference paper submission workflow that:
+
+1. Receives a paper proposal submission
+2. Validates and scores the proposal
+3. Enriches the data with submission metadata
+4. Sends a notification with the review result
+
+This demonstrates the three key data transformation methods:
+
+* `inputFrom` – to shape what each task receives as input
+* `exportAs` – to control what gets persisted in the workflow data
+* `outputAs` – to pass enriched data between tasks without modifying workflow state
+
+[TIP]
+====
+For conceptual background on data flow, see xref:data-flow.adoc[Data Flow and Transformations].
+For a quick syntax reference, see xref:data-flow.adoc#quick-reference[Quick Reference].
+====
+
+== Prerequisites
+
+* A Quarkus Flow project (see xref:getting-started.adoc[Getting Started])
+* Basic understanding of Java records and functional programming
+
+== Step 1: Define your data types
+
+Create the records that represent data at different stages of the workflow:
+
+[source,java]
+----
+include::{examples-dir}org/acme/dataflow/Call4PapersFlow.java[tag=data-types]
+----
+
+== Step 2: Create the workflow with inputFrom
+
+Start by creating a workflow that transforms the input submission into your domain model:
+
+[source,java]
+----
+include::{examples-dir}org/acme/dataflow/Call4PapersFlow.java[tag=validate-proposal]
+----
+
+<1> Add CDI annotation to make the flow injectable
+<2> Extend `Flow` to define a workflow descriptor
+
+In the `validateProposal` task, we expect a `Proposal` as input, but the workflow receives a `ProposalSubmission`. Use `inputFrom` to transform the submission into the proposal domain model.
+
+[TIP]
+====
+`inputFrom` isolates tasks from changes in the workflow data structure. The task only sees what it needs.
+====
+
+== Step 3: Add scoring with outputAs
+
+Add a task that scores the proposal and uses `outputAs` to pass transformed data to the next step:
+
+[source,java]
+----
+include::{examples-dir}org/acme/dataflow/Call4PapersFlow.java[tag=validate-and-score]
+----
+<1> Task receives the output from the previous task (a `Proposal`)
+<2> Use `outputAs` to transform the task result (`Integer score`) into a `ProposalScore` and pass it to the next step
+
+
+[IMPORTANT]
+====
+`outputAs` transforms what gets passed to the subsequent steps.
+====
+
+== Step 4: Enrich data and commit with exportAs
+
+Add a task that prepares the notification by enriching the score with data from the original workflow input, then commits to workflow **context** using `exportAs`:
+
+[source,java]
+----
+include::{examples-dir}org/acme/dataflow/Call4PapersFlow.java[tag=last-tasks]
+----
+<1> Just pass the `ProposalScore` through without transformation (identity function)
+<2> Use `exportAs` with `JavaFilterFunction` to commit enriched data to workflow data
+<3> Use `FuncDSL.output()` to get type-safe access to the current task's output
+<4> Use `FuncDSL.input()` to get type-safe access to original workflow input
+<5> Create enriched payload combining data from multiple sources
+<6> HTTP task receives the committed NotificationPayload from workflow data.
+The body will be the `NotificationPayload` as JSON
+
+== Step 5: Complete example
+
+Here's the complete workflow with all transformations:
+
+[source,java]
+----
+include::{examples-dir}org/acme/dataflow/Call4PapersFlow.java[]
+----
+
+== Testing the workflow
+
+Start a workflow instance with a submission:
+
+[source,java]
+----
+@Inject
+Call4PapersFlow flow;
+
+public void submitProposal() {
+    var submission = new ProposalSubmission(
+        "Reactive Workflows with Quarkus",
+        "This paper explores reactive workflow patterns...",
+        "Jane Developer"
+    );
+    
+    flow.startInstance(submission).await().indefinitely();
+}
+----
+
+== Key takeaways
+
+* Use **`inputFrom`** to give tasks a focused, typed view of the data they need
+* Use **`exportAs`** to control what gets persisted in the workflow data document
+* Use **`outputAs`** to pass data to the next step without committing to workflow data
+* Use **`FuncDSL.input(workflowContext, Type.class)`** for type-safe access to the original workflow input
+* Use **`FuncDSL.output(taskContext, Type.class)`** for type-safe access to the current task's output
+* Access workflow and task context in transformations to combine data from multiple sources
+
+== Next steps
+
+* Learn about context-aware transformations with `JavaFilterFunction` in xref:data-flow.adoc[Data Flow and Transformations]
+* Explore JQ expressions as an alternative to Java functions
+* See xref:data-flow.adoc#quick-reference[Quick Reference] for all transformation method signatures
+
+== Related guides
+
+* xref:data-flow.adoc[Data Flow and Transformations] – Conceptual overview
+* xref:dsl-cheatsheet.adoc[Java DSL Cheatsheet] – Quick syntax reference
+* xref:test-debug.adoc[Testing and Debugging] – How to test workflows


### PR DESCRIPTION
This pull request introduces a comprehensive example and documentation for managing data flow and context within Quarkus Flow workflows. It adds a new guide demonstrating how to use `inputFrom`, `outputAs`, and `exportAs` to transform data between workflow tasks, provides a complete Java example (`Call4PapersFlow`), and includes integration tests to validate the workflow and its HTTP interactions. Additionally, it improves test infrastructure and navigation for easier discoverability.

**Documentation and Examples:**
- Added a new guide, "How to transform data between workflow tasks," explaining the use of `inputFrom`, `outputAs`, and `exportAs` for data flow and context management in workflows, with code snippets and a complete example (`how-to-deal-with-state.adoc`).
- Added a full example workflow implementation in `Call4PapersFlow.java` demonstrating data transformation and notification sending, referenced in the guide and included as a documentation example.
- Updated navigation to link to the new "Use data flow and context management" guide for better discoverability.

**Integration Tests:**
- Added `Call4PapersFlow` and `Call4PapersTest` to integration tests, ensuring the workflow logic and HTTP notification are correctly executed and validated using WireMock. [[1]](diffhunk://#diff-ee690ef3ddaf0785e9ad842d082d1c37b3454f32ccd4a4f4384b9494dee82f44R1-R120) [[2]](diffhunk://#diff-df1244df7584b63f2df5f8e0f6b1cfd9ab1103c14b25e650b44283af4321376dR1-R78)
- Improved test infrastructure by configuring WireMock servers to use dynamic ports, ensuring isolation and reliability in tests. [[1]](diffhunk://#diff-3150a6767b025795ef952da0eecf0c3c834130bbeafe536c80a9877a4f0c68ccR13) [[2]](diffhunk://#diff-3150a6767b025795ef952da0eecf0c3c834130bbeafe536c80a9877a4f0c68ccL59-R60)