### PR TITLE
Closes #292 - gha: auto-update 'Reporting Date' on project field changes

### DIFF
--- a/.github/workflows/track-reporting-date-project-setup.md
+++ b/.github/workflows/track-reporting-date-project-setup.md
@@ -1,0 +1,57 @@
+# GitHub Project Setup Guide
+
+## Project
+
+**URL:** `https://github.com/orgs/quarkiverse/projects/11`
+
+---
+
+## Required fields
+
+The workflow reads and writes specific fields on each project item. All field names are **case-sensitive** and must match exactly.
+
+### Tracked fields (read by the workflow)
+
+Changes to any of these fields trigger an update to `Reporting Date` and a new entry in `Reporting Log`.
+
+| Field name       | Type          | Notes                                      |
+|------------------|---------------|--------------------------------------------|
+| `Status`         | Single select | e.g. Backlog, In Progress, Done            |
+| `Priority`       | Single select | e.g. Low, Medium, High                     |
+| `Estimate`       | Number        | Estimated effort or story points           |
+| `Remaining Work` | Number        | Remaining effort                           |
+| `Time Spent`     | Number        | Time already spent                         |
+
+### Workflow-managed fields (written by the workflow)
+
+These fields are updated automatically and should not be edited manually.
+
+| Field name       | Type   | Purpose                                                       |
+|------------------|--------|---------------------------------------------------------------|
+| `Reporting Date` | Date   | Set to today whenever a tracked field changes                 |
+| `Reporting Log`  | Text   | Log of changes, newest entry first, max 5 entries             |
+
+#### Reporting Log entry format
+
+Entries are separated by ` | `, ordered **newest first**. Field values within each entry are separated by `, `:
+
+```
+DATE, Status, Priority, Estimate, Remaining Work, Time Spent
+```
+
+Multiple entries example (newest → oldest, max 5):
+```
+2026-03-03, In Progress, High, 8, 5, 3 | 2026-03-01, Backlog, High, 8, 8, 0
+```
+
+The oldest entry is automatically discarded when the log exceeds 5 entries.
+
+---
+
+## How to add a field to the project
+
+1. Go to **`https://github.com/orgs/quarkiverse/projects/11`**
+2. Click **"+"** at the right end of the column headers → **"New field"**
+3. Enter the field name and select the correct type
+4. Click **"Save"**
+

--- a/.github/workflows/track-reporting-date-testing.md
+++ b/.github/workflows/track-reporting-date-testing.md
@@ -1,0 +1,47 @@
+# track-reporting-date workflow — Testing Guide
+
+## Prerequisites
+
+Make sure the setup from the guide is complete:
+- `GH_TOKEN` secret is set in the repository (PAT with `project` and `read:org` scopes)
+- The project (`https://github.com/orgs/quarkiverse/projects/11`) has both a **`Reporting Date`** (Date) and a **`Reporting Log`** (Text) field
+
+---
+
+## Testing steps
+
+1. **Go to your project** → `https://github.com/orgs/quarkiverse/projects/11`
+
+2. **Pick any issue/item** in the project and change one of the tracked fields:
+   - Status, Priority, Estimate, Remaining Work, or Time Spent
+
+3. **Wait until 05:00 UTC** for the scheduled workflow to trigger, or use the manual trigger below to run it immediately
+
+4. **Check the workflow ran** → go to your repository → **Actions** tab → open the latest run of `Track Reporting Date on Field Changes` and inspect the logs. You should see the item listed with a change detected and an update confirmation.
+
+5. **Verify the result** → go back to the project item and confirm:
+   - `Reporting Date` is set to today
+   - `Reporting Log` has a new entry prepended in the format `YYYY-MM-DD, Status, Priority, Estimate, Remaining Work, Time Spent`, separated from older entries by ` | `, with a maximum of 5 entries total
+
+---
+
+## Manual trigger (skip the scheduled wait)
+
+1. Go to **Actions → Track Reporting Date on Field Changes → Run workflow**
+2. Click **"Run workflow"**
+3. The workflow runs immediately against the latest project state
+
+---
+
+## Negative test (optional)
+
+Change a field that is **not** in the tracked list (e.g. title or assignee). After the next workflow run, the logs should show the item was processed but skipped with `No change detected. Skipping.`
+
+---
+
+## Troubleshooting
+
+- **Workflow fails with auth error** → the `GH_TOKEN` secret is missing or the PAT doesn't have `project` and `read:org` scopes
+- **`Reporting Date` field not found** → the field name in the project doesn't exactly match `Reporting Date` (case-sensitive)
+- **`Reporting Log` field not found** → the field name in the project doesn't exactly match `Reporting Log` (case-sensitive), or the field hasn't been created yet
+- **Item not processed** → the item may not appear in the first 100 results; increase the `items(first: 100)` limit in the workflow if the project has more than 100 items

--- a/.github/workflows/track-reporting-date.md
+++ b/.github/workflows/track-reporting-date.md
@@ -1,0 +1,65 @@
+# track-reporting-date workflow — Setup Guide
+
+## What it does
+
+Runs **daily at 05:00 UTC** and checks **all** project items. For each item it compares the current values of the five tracked fields (**Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**) against the last entry in the item's **`Reporting Log`** field. If a change is detected (or the log is empty), the workflow:
+
+1. Sets **`Reporting Date`** to today
+2. Prepends a new entry to **`Reporting Log`** in the format:
+   ```
+   YYYY-MM-DD, Status, Priority, Estimate, Remaining Work, Time Spent
+   ```
+
+No action is taken when non-tracked fields change (e.g. title, assignee).
+
+---
+
+## Setup
+
+### 1. Add the required fields to the project
+
+In **`https://github.com/orgs/quarkiverse/projects/11`**, make sure the following fields exist:
+
+| Field name       | Type   | Purpose                                                        |
+|------------------|--------|----------------------------------------------------------------|
+| `Reporting Date` | Date   | Set to today when a tracked field changes                      |
+| `Reporting Log`  | Text   | Log of tracked field values, newest entry first, max 5 entries |
+
+### 2. Create a Personal Access Token (PAT)
+
+1. Go to **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)**
+2. Click **"Generate new token (classic)"**
+3. Give it a name (e.g. `secret-santa-project-automation`)
+4. Under **Scopes**, check both:
+   - **`project`** — grants read/write access to GitHub Projects v2
+   - **`read:org`** — required to access organization-level project data
+5. Click **"Generate token"** and **copy it immediately** (you won't see it again)
+
+> Why not use the default `GITHUB_TOKEN`? That token is automatically created per workflow run and is scoped to the repository only. It cannot read or write fields on organization-level GitHub Projects v2.
+
+### 3. Store the token as a repository secret
+
+1. Go to your repository: **`quarkus-flow` → Settings → Secrets and variables → Actions**
+2. Click **"New repository secret"**
+3. Set:
+   - **Name**: `GH_TOKEN` (exactly as referenced in the workflow)
+   - **Secret**: paste the token you copied above
+4. Click **"Add secret"**
+
+---
+
+Once all steps are done, the workflow will run automatically every day at 05:00 UTC and update `Reporting Date` and `Reporting Log` whenever a tracked field has changed since the last run.
+
+---
+
+## Why cron instead of GitHub project events?
+
+GitHub Actions does **not** natively support triggering workflows from GitHub Projects (v2) field changes. The available event triggers (`issues`, `pull_request`, `project_card`, etc.) only fire on classic Projects (v1) or on issue/PR metadata changes — not on custom project fields like `Status`, `Priority`, `Estimate`, etc.
+
+The only way to react to custom project field changes in GitHub Actions is via the **GitHub GraphQL API**, which is only accessible by polling. Hence the scheduled cron approach:
+
+1. The workflow runs on schedule and queries all project items via GraphQL.
+2. For each item, it compares the current field values against the last entry in `Reporting Log`.
+3. If anything changed since the last run, it updates `Reporting Date` and prepends a new entry to `Reporting Log`.
+
+This is a known limitation of GitHub Projects v2 — there is no `project_field_changed` webhook or Actions trigger available.

--- a/.github/workflows/track-reporting-date.yml
+++ b/.github/workflows/track-reporting-date.yml
@@ -1,0 +1,204 @@
+name: Track Reporting Date on Field Changes
+
+# ---------------------------------------------------------------------------
+# Schedule configuration
+# NOTE: GitHub Actions does not support variables in cron expressions.
+#       To change the schedule update the cron expression below.
+#       All times are in UTC.
+# ---------------------------------------------------------------------------
+on:
+  schedule:
+    - cron: '0 5 * * *'   # daily at 05:00 UTC
+  workflow_dispatch:
+
+# Requires a PAT with 'project' and 'read:org' scopes stored as secret GH_TOKEN.
+# The default GITHUB_TOKEN does not have write access to organization-level projects.
+
+jobs:
+  track-reporting-date:
+    name: Check and update 'Reporting Date'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      PROJECT_OWNER: quarkiverse
+      PROJECT_NUMBER: 11
+    steps:
+      - name: Update 'Reporting Date' and 'Reporting Log' for changed items
+        run: |
+          set -e
+
+          TODAY=$(date -u +%Y-%m-%d)
+
+          # Extract a field value from a project item JSON blob by field name.
+          # Handles text, number, single-select and date field types.
+          get_field() {
+            local item_json="$1"
+            local field_name="$2"
+            echo "$item_json" | jq -r --arg n "$field_name" '
+              [ .fieldValues.nodes[] | select(.field.name == $n) ] |
+              if length == 0 then ""
+              else .[0] |
+                if .text != null then .text
+                elif .number != null then (.number | tostring)
+                elif .["name"] != null then .["name"]
+                elif .date != null then .date
+                else ""
+                end
+              end
+            '
+          }
+
+          # Fetch all project items along with their field metadata and values
+          RESPONSE=$(gh api graphql -f query='
+            query($owner: String!, $number: Int!) {
+              organization(login: $owner) {
+                projectV2(number: $number) {
+                  id
+                  fields(first: 30) {
+                    nodes {
+                      ... on ProjectV2Field {
+                        id
+                        name
+                      }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                      }
+                    }
+                  }
+                  items(first: 100) {
+                    nodes {
+                      id
+                      fieldValues(first: 20) {
+                        nodes {
+                          ... on ProjectV2ItemFieldTextValue {
+                            text
+                            field { ... on ProjectV2Field { name } }
+                          }
+                          ... on ProjectV2ItemFieldNumberValue {
+                            number
+                            field { ... on ProjectV2Field { name } }
+                          }
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            name
+                            field { ... on ProjectV2SingleSelectField { name } }
+                          }
+                          ... on ProjectV2ItemFieldDateValue {
+                            date
+                            field { ... on ProjectV2Field { name } }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ' -f owner="$PROJECT_OWNER" -F number=$PROJECT_NUMBER)
+
+          PROJECT_ID=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.id')
+          REPORTING_DATE_FIELD_ID=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Reporting Date") | .id')
+          REPORTING_LOG_FIELD_ID=$(echo "$RESPONSE"  | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Reporting Log")  | .id')
+
+          if [ -z "$REPORTING_DATE_FIELD_ID" ]; then
+            echo "Error: 'Reporting Date' field not found in project."
+            exit 1
+          fi
+          if [ -z "$REPORTING_LOG_FIELD_ID" ]; then
+            echo "Error: 'Reporting Log' field not found in project."
+            exit 1
+          fi
+
+          echo "Project ID             : $PROJECT_ID"
+          echo "Reporting Date field ID: $REPORTING_DATE_FIELD_ID"
+          echo "Reporting Log field ID : $REPORTING_LOG_FIELD_ID"
+
+          UPDATED_COUNT=0
+          SKIPPED_COUNT=0
+
+          while IFS= read -r item; do
+            ITEM_ID=$(echo "$item" | jq -r '.id')
+            echo ""
+            echo "Item $ITEM_ID"
+
+            STATUS=$(get_field        "$item" "Status")
+            PRIORITY=$(get_field      "$item" "Priority")
+            ESTIMATE=$(get_field      "$item" "Estimate")
+            REMAINING_WORK=$(get_field "$item" "Remaining Work")
+            TIME_SPENT=$(get_field    "$item" "Time Spent")
+            REPORTING_LOG=$(get_field "$item" "Reporting Log")
+
+            # Parse tracked field values from the latest (first) entry in the log.
+            # Log format: ENTRY1 | ENTRY2 | ... where each entry is DATE, STATUS, PRIORITY, ESTIMATE, REMAINING_WORK, TIME_SPENT
+            if [ -z "$REPORTING_LOG" ]; then
+              LAST_STATUS="" LAST_PRIORITY="" LAST_ESTIMATE=""
+              LAST_REMAINING_WORK="" LAST_TIME_SPENT=""
+            else
+              LAST_ENTRY=$(echo "$REPORTING_LOG" | sed 's/ | /\n/g' | head -1)
+              LAST_STATUS=$(echo         "$LAST_ENTRY" | cut -d',' -f2 | xargs)
+              LAST_PRIORITY=$(echo       "$LAST_ENTRY" | cut -d',' -f3 | xargs)
+              LAST_ESTIMATE=$(echo       "$LAST_ENTRY" | cut -d',' -f4 | xargs)
+              LAST_REMAINING_WORK=$(echo "$LAST_ENTRY" | cut -d',' -f5 | xargs)
+              LAST_TIME_SPENT=$(echo     "$LAST_ENTRY" | cut -d',' -f6 | xargs)
+            fi
+
+            echo "  Current : $STATUS, $PRIORITY, $ESTIMATE, $REMAINING_WORK, $TIME_SPENT"
+            echo "  Last log: $LAST_STATUS, $LAST_PRIORITY, $LAST_ESTIMATE, $LAST_REMAINING_WORK, $LAST_TIME_SPENT"
+
+            # Skip if nothing has changed
+            if [ "$STATUS"         = "$LAST_STATUS"         ] && \
+               [ "$PRIORITY"        = "$LAST_PRIORITY"        ] && \
+               [ "$ESTIMATE"        = "$LAST_ESTIMATE"        ] && \
+               [ "$REMAINING_WORK"  = "$LAST_REMAINING_WORK"  ] && \
+               [ "$TIME_SPENT"      = "$LAST_TIME_SPENT"      ]; then
+              echo "  → No change detected. Skipping."
+              SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+              continue
+            fi
+
+            echo "  → Change detected. Updating 'Reporting Date' and prepending to 'Reporting Log'."
+
+            # Build new entry: DATE, STATUS, PRIORITY, ESTIMATE, REMAINING_WORK, TIME_SPENT
+            NEW_ENTRY="${TODAY}, ${STATUS}, ${PRIORITY}, ${ESTIMATE}, ${REMAINING_WORK}, ${TIME_SPENT}"
+
+            # Prepend new entry and keep at most 5 entries total (discard oldest)
+            if [ -z "$REPORTING_LOG" ]; then
+              NEW_LOG="$NEW_ENTRY"
+            else
+              TRIMMED=$(echo "$REPORTING_LOG" | sed 's/ | /\n/g' | head -4 | paste -sd'~' | sed 's/~/ | /g')
+              NEW_LOG="${NEW_ENTRY} | ${TRIMMED}"
+            fi
+
+            # Update 'Reporting Date' to today
+            gh api graphql -f query='
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { date: $date }
+                }) { projectV2Item { id } }
+              }
+            ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+              -f fieldId="$REPORTING_DATE_FIELD_ID" -f date="$TODAY"
+
+            # Append new entry to 'Reporting Log'
+            gh api graphql -f query='
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $text: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { text: $text }
+                }) { projectV2Item { id } }
+              }
+            ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+              -f fieldId="$REPORTING_LOG_FIELD_ID" -f text="$NEW_LOG"
+
+            echo "  → Done."
+            UPDATED_COUNT=$((UPDATED_COUNT + 1))
+
+          done < <(echo "$RESPONSE" | jq -c '.data.organization.projectV2.items.nodes[]')
+
+          echo ""
+          echo "Summary: $UPDATED_COUNT item(s) updated, $SKIPPED_COUNT item(s) skipped."


### PR DESCRIPTION
## Summary

- Adds a scheduled GitHub Actions workflow (`track-reporting-date.yml`) that runs daily at 05:00 UTC
- For each item in [quarkiverse/projects/11](https://github.com/orgs/quarkiverse/projects/11), detects changes to **Status**, **Priority**, **Estimate**, **Remaining Work**, or **Time Spent**
- On change, sets `Reporting Date` to today and prepends a new entry to `Reporting Log` (max 5 entries kept)

## ⚠️ Mandatory setup before merging

A Personal Access Token (PAT) with `project` and `read:org` scopes must be created and stored as the `GH_TOKEN` repository secret. The default `GITHUB_TOKEN` does not have access to organization-level projects and the workflow will fail without it.

See [track-reporting-date.md](.github/workflows/track-reporting-date.md) for full setup instructions, and [track-reporting-date-project-setup.md](.github/workflows/track-reporting-date-project-setup.md) for required project fields.

## Test plan

- [ ] Create `GH_TOKEN` secret with `project` and `read:org` scopes
- [ ] Ensure `Reporting Date` (Date) and `Reporting Log` (Text) fields exist in the project
- [ ] Change a tracked field on any project item
- [ ] Trigger workflow manually via Actions → Run workflow
- [ ] Verify `Reporting Date` is set to today and `Reporting Log` has a new entry

See [track-reporting-date-testing.md](.github/workflows/track-reporting-date-testing.md) for detailed testing steps.

Closes #292