### PR TITLE
Add scheduler to the main Maven reactor build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <module>langchain4j</module>
         <module>persistence</module>
         <module>durable-kubernetes</module>
+        <module>scheduler</module>
     </modules>
 
     <scm>


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-flow/issues/297

This adds the scheduler modules to the main Maven reactor build. It was not there by accident. 