### PR TITLE
Add test-jar configuration to integration-tests modules, where missing.

### DIFF
--- a/durable-kubernetes/integration-tests/pom.xml
+++ b/durable-kubernetes/integration-tests/pom.xml
@@ -73,6 +73,16 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/persistence/jpa/integration-tests/pom.xml
+++ b/persistence/jpa/integration-tests/pom.xml
@@ -68,6 +68,16 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/persistence/mvstore/integration-tests/pom.xml
+++ b/persistence/mvstore/integration-tests/pom.xml
@@ -65,6 +65,16 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/persistence/redis/integration-tests/pom.xml
+++ b/persistence/redis/integration-tests/pom.xml
@@ -65,6 +65,16 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/scheduler/integration-tests/pom.xml
+++ b/scheduler/integration-tests/pom.xml
@@ -66,6 +66,16 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-flow/issues/308

- Adds missing configuration to produce tests jars during the build. 