### PR TITLE
Add integration test to check Agentic workflows in DevUI

### DIFF
--- a/core/deployment/src/main/resources/dev-ui/qwc-flow-workflow-execution.js
+++ b/core/deployment/src/main/resources/dev-ui/qwc-flow-workflow-execution.js
@@ -175,7 +175,7 @@ export class QwcFlowExecution extends observeState(QwcHotReloadElement) {
             <div class="button-container">
                 ${this._loading
                         ? html`<vaadin-progress-bar class="progress" indeterminate></vaadin-progress-bar>`
-                        : html`<vaadin-button theme="primary success" @click=${() => this._executeWorkflow()}>
+                        : html`<vaadin-button id="execute-workflow" theme="primary success" @click=${() => this._executeWorkflow()}>
                             <vaadin-icon icon="font-awesome-solid:play"></vaadin-icon>
                             Start workflow
                         </vaadin-button>`

--- a/core/deployment/src/main/resources/dev-ui/qwc-flow-workflows.js
+++ b/core/deployment/src/main/resources/dev-ui/qwc-flow-workflows.js
@@ -10,6 +10,8 @@ import { dialogRenderer, dialogFooterRenderer } from '@vaadin/dialog/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { devuiState } from 'devui-state';
 
+import { notifier } from 'notifier';
+
 import './qwc-flow-workflow-execution.js';
 
 import { themeState } from 'theme-state';
@@ -105,7 +107,7 @@ export class QwcFlow extends observeState(QwcHotReloadElement) {
                                                    id="see-${this._generateMermaidId(workflow.id)}">
                                         <vaadin-icon icon="font-awesome-solid:eye"></vaadin-icon>
                                     </vaadin-button>
-                                    <vaadin-button @click=${() => this._executeWorkflow(workflow)}>
+                                    <vaadin-button id="play-${this._generateMermaidId(workflow.id)}"  @click=${() => this._executeWorkflow(workflow)}>
                                         <vaadin-icon icon="font-awesome-solid:play"></vaadin-icon>
                                     </vaadin-button>
                                 `, [])}>
@@ -197,7 +199,7 @@ export class QwcFlow extends observeState(QwcHotReloadElement) {
             ${!this._currentMermaid ? `
             <span style="display:flex;align-items:center;gap:8px;color:var(--lumo-secondary-text-color);">
                 <vaadin-icon icon="font-awesome-solid:circle-info"></vaadin-icon>
-                <span style="margin:0;font-size:var(--lumo-font-size-xs);">
+                <span id="unavailable-mermaid-warning" style="margin:0;font-size:var(--lumo-font-size-xs);">
                 Diagram not available. Run the workflow once to generate it.
                 </span>
             </span>` : ''}
@@ -207,7 +209,7 @@ export class QwcFlow extends observeState(QwcHotReloadElement) {
     }
 
     _downloadDiagramAsPng() {
-        let svgData = document.querySelector('pre.mermaid > svg');
+        let svgData = document.querySelector("#page > qwc-flow-workflows").shadowRoot.querySelector("svg");
         if (!svgData) {
             return;
         }
@@ -223,7 +225,8 @@ export class QwcFlow extends observeState(QwcHotReloadElement) {
                 lnk.href = URL.createObjectURL(blob);
                 lnk.download = "flow-" + devuiState.applicationInfo.applicationName + "-" + new Date().toISOString().replace(/\D/g, '') + ".png";
                 lnk.click();
-                notifier.showSuccessMessage(lnk.download + " downloaded.", 'bottom-end');
+                const message = lnk.download + " downloaded.";
+                notifier.showSuccessMessage(message, 'bottom-end');
             });
         }
     }
@@ -236,7 +239,7 @@ export class QwcFlow extends observeState(QwcHotReloadElement) {
                     ${dialogRenderer(() => this._mermaidContent(), [])}
                     ${dialogFooterRenderer(() => html`
                         <div class="buttonBar">
-                            <vaadin-button class="button" @click=${() => this._downloadDiagramAsPng()}>
+                            <vaadin-button id="download-diagram" class="button" @click=${() => this._downloadDiagramAsPng()}>
                                 <vaadin-icon icon="font-awesome-solid:file-export"></vaadin-icon>
                                 Export
                             </vaadin-button>

--- a/langchain4j/deployment/pom.xml
+++ b/langchain4j/deployment/pom.xml
@@ -31,8 +31,6 @@
             <artifactId>quarkus-langchain4j-agentic-deployment</artifactId>
             <version>${io.quarkiverse.langchain4j.version}</version>
         </dependency>
-
-
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-ollama-deployment</artifactId>
@@ -54,6 +52,17 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.playwright</groupId>
+            <artifactId>quarkus-playwright</artifactId>
+            <version>${io.quarkiverse.playwright}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/AgenticWorkflowInDevUIT.java
+++ b/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/AgenticWorkflowInDevUIT.java
@@ -1,0 +1,170 @@
+package io.quarkiverse.flow.langchain4j.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.SoftAssertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Playwright;
+
+import io.quarkiverse.flow.langchain4j.Agents;
+import io.quarkiverse.flow.langchain4j.SimpleWorkflow;
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class AgenticWorkflowInDevUIT {
+
+    private static final String PLAY_AGENTIC_ID = "play-mermaid-io-quarkiverse-flow-langchain4j-story-creator-with-configurable-style-editor-0-0-1";
+    private static final String SEE_AGENTIC_ID = "see-mermaid-io-quarkiverse-flow-langchain4j-story-creator-with-configurable-style-editor-0-0-1";
+    private static final String SEE_SIMPLE_ID = "see-mermaid-quarkus-flow-simple-workflow-0-0-1";
+    private static final String UNAVAILABLE_MERMAID_WARNING_SELECTOR = "id=unavailable-mermaid-warning";
+
+    private static BrowserType.LaunchOptions launchOptions;
+
+    @RegisterExtension
+    static QuarkusDevModeTest devMode = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Agents.class, SimpleWorkflow.class));
+
+    @BeforeAll
+    static void setUp() {
+        launchOptions = new BrowserType.LaunchOptions()
+                .setHeadless(true)
+                .setChromiumSandbox(false)
+                .setChannel("")
+                .setArgs(List.of("--disable-gpu"));
+    }
+
+    @Test
+    void should_show_warning_message_when_looking_for_agentic_mermaid_before_execution() {
+        try (Playwright playwright = createPlaywright();
+                Browser browser = playwright.chromium().launch(launchOptions)) {
+
+            QuarkusDevUIPage devUI = new QuarkusDevUIPage(browser.newPage());
+
+            devUI.navigateToDevUIHome();
+            devUI.clickOnWorkflows();
+            devUI.clickOnEyeButton(SEE_AGENTIC_ID);
+
+            devUI.waitForElement(UNAVAILABLE_MERMAID_WARNING_SELECTOR);
+
+            assertThat(devUI.isElementVisible(UNAVAILABLE_MERMAID_WARNING_SELECTOR))
+                    .as("Warning message should be visible when mermaid diagram is not available")
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void should_call_agentic_workflow() {
+        SoftAssertions softly = new SoftAssertions();
+
+        try (Playwright playwright = createPlaywright();
+                Browser browser = playwright.chromium().launch(launchOptions)) {
+
+            QuarkusDevUIPage devUI = new QuarkusDevUIPage(browser.newPage());
+
+            devUI.navigateToDevUIHome();
+
+            softly.assertThat(devUI.workflowsBadgeNumber())
+                    .as("Workflows badge should show available workflows")
+                    .isGreaterThanOrEqualTo(1);
+
+            devUI.clickOnWorkflows();
+            devUI.clickOnPlayButton(PLAY_AGENTIC_ID);
+            devUI.executeWorkflow();
+            devUI.waitByAIMessage();
+
+            softly.assertThat(devUI.content())
+                    .as("Workflow output should be displayed")
+                    .doesNotContain("# Your workflow output will be displayed here");
+        }
+
+        softly.assertAll();
+    }
+
+    @Test
+    void should_generate_mermaid_diagram_after_first_execution() {
+        SoftAssertions softly = new SoftAssertions();
+
+        try (Playwright playwright = createPlaywright();
+                Browser browser = playwright.chromium().launch(launchOptions)) {
+
+            QuarkusDevUIPage devUI = new QuarkusDevUIPage(browser.newPage());
+
+            devUI.navigateToDevUIHome();
+
+            softly.assertThat(devUI.workflowsBadgeNumber())
+                    .as("Workflows badge should show available workflows")
+                    .isGreaterThanOrEqualTo(1);
+
+            devUI.clickOnWorkflows();
+            devUI.clickOnPlayButton(PLAY_AGENTIC_ID);
+            devUI.executeWorkflow();
+            devUI.waitByAIMessage();
+
+            softly.assertThat(devUI.content())
+                    .as("Workflow output should be displayed")
+                    .doesNotContain("# Your workflow output will be displayed here");
+
+            devUI.navigateToDevUIHome();
+            devUI.clickOnWorkflows();
+            devUI.clickOnEyeButton(SEE_AGENTIC_ID);
+
+            devUI.waitForMermaidContainer();
+
+            softly.assertThat(devUI.isMermaidContainerVisible())
+                    .as("Mermaid diagram should be visible after workflow execution")
+                    .isTrue();
+        }
+
+        softly.assertAll();
+    }
+
+    @Test
+    void should_download_the_generated_mermaid_diagram() {
+        SoftAssertions softly = new SoftAssertions();
+
+        try (Playwright playwright = createPlaywright();
+                Browser browser = playwright.chromium().launch(launchOptions)) {
+
+            QuarkusDevUIPage devUI = new QuarkusDevUIPage(browser.newPage());
+
+            devUI.navigateToDevUIHome();
+            devUI.clickOnWorkflows();
+            devUI.clickOnEyeButton(SEE_SIMPLE_ID);
+
+            devUI.waitForMermaidContainer();
+
+            softly.assertThat(devUI.isMermaidContainerVisible())
+                    .as("Mermaid diagram should be visible before download")
+                    .isTrue();
+
+            softly.assertThat(devUI.isDownloadButtonVisible())
+                    .as("Download button should be visible")
+                    .isTrue();
+
+            devUI.clickOnDownload();
+
+            softly.assertThat(devUI.isDownloadButtonVisible())
+                    .as("Download button should still be visible after download")
+                    .isTrue();
+        }
+
+        softly.assertAll();
+    }
+
+    private static Playwright createPlaywright() {
+        Map<String, String> env = new HashMap<>(System.getenv());
+        env.put("DEBUG", "pw:api");
+        return Playwright.create(new Playwright.CreateOptions().setEnv(env));
+    }
+}

--- a/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/QuarkusDevUIPage.java
+++ b/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/QuarkusDevUIPage.java
@@ -1,0 +1,77 @@
+package io.quarkiverse.flow.langchain4j.deployment;
+
+import com.microsoft.playwright.Page;
+
+public record QuarkusDevUIPage(Page page) {
+
+    private static final String DEV_UI_BASE_URL = "http://localhost:8080/q/dev-ui";
+    private static final String WORKFLOWS_LINK_SELECTOR = "[href=\"quarkus-flow\\/workflows\"]";
+    private static final String WORKFLOWS_BADGE_SELECTOR = "[namespace=quarkus-flow] > qui-badge";
+    private static final String EXECUTE_WORKFLOW_SELECTOR = "id=execute-workflow";
+    private static final String MARKDOWN_OUTPUT_SELECTOR = "[data-language=markdown]";
+    private static final String DOWNLOAD_DIAGRAM_SELECTOR = "id=download-diagram";
+    private static final String MERMAID_CONTAINER_SELECTOR = "pre.mermaid-container";
+
+    public void navigateToDevUIHome() {
+        page.navigate(DEV_UI_BASE_URL + "/extensions");
+    }
+
+    public Integer workflowsBadgeNumber() {
+        page.waitForSelector(WORKFLOWS_BADGE_SELECTOR);
+        return Integer.valueOf(page.locator(WORKFLOWS_BADGE_SELECTOR).textContent());
+    }
+
+    public void clickOnWorkflows() {
+        page.waitForSelector(WORKFLOWS_LINK_SELECTOR).click();
+    }
+
+    public void clickOnPlayButton(String buttonId) {
+        clickOnButton(buttonId);
+    }
+
+    public void clickOnEyeButton(String buttonId) {
+        clickOnButton(buttonId);
+    }
+
+    public void executeWorkflow() {
+        page.waitForSelector(EXECUTE_WORKFLOW_SELECTOR).click();
+    }
+
+    public String content() {
+        return page.content();
+    }
+
+    public void waitByAIMessage() {
+        page.waitForCondition(() -> page.waitForSelector(MARKDOWN_OUTPUT_SELECTOR)
+                .textContent()
+                .contains("Your workflow output will be displayed here"));
+    }
+
+    public void clickOnDownload() {
+        page.waitForSelector(DOWNLOAD_DIAGRAM_SELECTOR).click();
+    }
+
+    public void waitForMermaidContainer() {
+        page.waitForCondition(() -> page.isVisible(MERMAID_CONTAINER_SELECTOR));
+    }
+
+    public boolean isMermaidContainerVisible() {
+        return page.isVisible(MERMAID_CONTAINER_SELECTOR);
+    }
+
+    public boolean isDownloadButtonVisible() {
+        return page.isVisible(DOWNLOAD_DIAGRAM_SELECTOR);
+    }
+
+    public boolean isElementVisible(String selector) {
+        return page.isVisible(selector);
+    }
+
+    public void waitForElement(String selector) {
+        page.waitForSelector(selector);
+    }
+
+    private void clickOnButton(String buttonId) {
+        page.waitForSelector("id=" + buttonId).click();
+    }
+}

--- a/langchain4j/runtime/src/test/java/io/quarkiverse/flow/langchain4j/SimpleWorkflow.java
+++ b/langchain4j/runtime/src/test/java/io/quarkiverse/flow/langchain4j/SimpleWorkflow.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.flow.langchain4j;
+
+import static io.serverlessworkflow.fluent.func.FuncWorkflowBuilder.workflow;
+import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkiverse.flow.Flow;
+import io.serverlessworkflow.api.types.Workflow;
+
+@ApplicationScoped
+public class SimpleWorkflow extends Flow {
+
+    @Override
+    public Workflow descriptor() {
+        return workflow("simple-workflow", "quarkus.flow").tasks(set("{ message: \"Ana Sara\" }")).build();
+    }
+}


### PR DESCRIPTION
This pull request introduces new test dependencies and adds integration tests for agentic workflows in the Dev UI. The main focus is on enabling and validating UI behavior for agentic workflows using Playwright-based browser testing. Additionally, a simple agentic workflow example is provided for testing purposes.

**Test and Dev UI Integration Enhancements:**

* Added `quarkus-playwright` and `quarkus-rest-jackson` as test dependencies in `pom.xml` to enable browser-based UI testing and REST support in tests.
* Introduced a Playwright-based integration test, `AgenticWorkflowInDevUIT`, to verify that agentic workflows are correctly displayed in the Dev UI.

**Agentic Workflow Example:**

* Added `SimpleAgenticWorkflow` class as an application-scoped bean with a sample creative writer AI service for use in tests.

**Dependency Cleanup:**

* Minor cleanup in `pom.xml` by removing extra blank lines.


Closes #138 