### PR TITLE
Add artifact to metadata for all quarkus-extension.yaml files

### DIFF
--- a/durable-kubernetes/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/durable-kubernetes/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,6 @@
 name: Flow Durable Kubernetes
 description: Durable Workflows support on Kubernetes
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   keywords:
     - workflow

--- a/langchain4j/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/langchain4j/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,7 @@
 name: Flow LangChain4j
 description: |
   LangChain4j Agentic Workflow implementation for Quarkus Flow.
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   keywords:
     - workflow

--- a/persistence/jpa/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/persistence/jpa/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,7 @@
 name: Flow JPA
 description: |
   JPA Persistence Plugin
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   keywords:
     - workflow

--- a/persistence/mvstore/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/persistence/mvstore/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,7 @@
 name: Flow MVStore
 description: |
   MVStore Persistence Plugin
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   keywords:
     - workflow

--- a/persistence/redis/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/persistence/redis/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,7 @@
 name: Flow Redis
 description: |
   Redis Persistence Plugin
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   keywords:
     - workflow

--- a/scheduler/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/scheduler/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,7 @@
 name: Flow Scheduler
 description: |
   Flow scheduler implemetation relying on quarkus scheduler
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   keywords:
     - workflow


### PR DESCRIPTION


**Enhancements to extension metadata:**

* Added the `artifact` coordinate (groupId:artifactId:version) to the `quarkus-extension.yaml` files for the following modules: `Flow Durable Kubernetes`, `Flow LangChain4j`, `Flow JPA`, `Flow MVStore`, `Flow Redis`, and `Flow Scheduler`. This ensures accurate artifact metadata is available for each extension. [[1]](diffhunk://#diff-91b2d8738af7175ed164974d5de14fb56fb3fd49d24339c9d19565a8f319ececR3) [[2]](diffhunk://#diff-2b7dfd816697bdb1991312b43ea43f7bc5307936aa6343d0743a659b649f6c94R4) [[3]](diffhunk://#diff-518eafd761e8f700fa9589ef7913c30ad5a3acb12a9cc4f6efdc90739dc693ffR4) [[4]](diffhunk://#diff-cf203a73226f047f19e116f1151304691d5fc8f05f4acfea4055d511ca830c22R4) [[5]](diffhunk://#diff-7340dee98902f3b4cce11706df5ff3c364d2184eefed24722e755207326d7fdcR4) [[6]](diffhunk://#diff-71659c7227daaf78d7f8734496aa17fbb2611beca7cc869492904fa05d80dcecR4)