### PR TITLE
[Fix #305] Change one to many mapping approach

### DIFF
--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/CompletedTaskEntity.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/CompletedTaskEntity.java
@@ -26,10 +26,10 @@ public class CompletedTaskEntity extends TaskInfoEntity {
     public CompletedTaskEntity() {
     }
 
-    public CompletedTaskEntity(String jsonPointer, Instant instant, WorkflowModel model, WorkflowModel context,
+    public CompletedTaskEntity(TaskInfoKey key, Instant instant, WorkflowModel model, WorkflowModel context,
             boolean isEndNode,
             String nextPosition) {
-        super(jsonPointer);
+        super(key);
         this.instant = instant;
         this.model = model;
         this.context = context;

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/JpaInstanceOperations.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/JpaInstanceOperations.java
@@ -8,6 +8,7 @@ import java.util.stream.Stream;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 
 import io.serverlessworkflow.impl.TaskContext;
@@ -31,6 +32,9 @@ public class JpaInstanceOperations implements PersistenceInstanceOperations {
     @Inject
     ProcessInstanceRepository repository;
 
+    @Inject
+    EntityManager em;
+
     @Override
     public void writeInstanceData(WorkflowContextData workflowContext) {
         WorkflowInstanceData instance = workflowContext.instanceData();
@@ -40,18 +44,19 @@ public class JpaInstanceOperations implements PersistenceInstanceOperations {
 
     @Override
     public void writeRetryTask(WorkflowContextData workflowContext, TaskContextData taskContext) {
-        find(workflowContext).getTasks()
-                .add(new RetriedTaskEntity(taskContext.position().jsonPointer(), ((TaskContext) taskContext).retryAttempt()));
+        em.persist(new RetriedTaskEntity(TaskInfoKey.from(workflowContext, taskContext),
+                ((TaskContext) taskContext).retryAttempt()));
     }
 
     @Override
     public void writeCompletedTask(WorkflowContextData workflowContext, TaskContextData taskContext) {
         TransitionInfo transition = ((TaskContext) taskContext).transition();
         AbstractTaskExecutor<?> next = (AbstractTaskExecutor<?>) transition.next();
-        find(workflowContext).getTasks().add(new CompletedTaskEntity(
-                taskContext.position().jsonPointer(), taskContext.completedAt(), taskContext.output(),
-                workflowContext.context(),
-                transition.isEndNode(), next == null ? null : next.position().jsonPointer()));
+        em.persist(
+                new CompletedTaskEntity(
+                        TaskInfoKey.from(workflowContext, taskContext), taskContext.completedAt(), taskContext.output(),
+                        workflowContext.context(),
+                        transition.isEndNode(), next == null ? null : next.position().jsonPointer()));
 
     }
 

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/ProcessInstanceEntity.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/ProcessInstanceEntity.java
@@ -5,12 +5,11 @@ import java.util.Collection;
 
 import jakarta.persistence.Basic;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinColumns;
 import jakarta.persistence.OneToMany;
 
 import org.hibernate.annotations.DynamicUpdate;
@@ -29,17 +28,16 @@ public class ProcessInstanceEntity {
     @Id
     private String applicationId;
 
-    @Basic(fetch = FetchType.LAZY, optional = true)
+    @Column(nullable = true)
     private WorkflowStatus status;
 
-    @Basic(fetch = FetchType.LAZY)
+    @Column(nullable = false)
     private Instant startedAt;
 
     @Basic(fetch = FetchType.LAZY)
     private WorkflowModel input;
 
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumns({ @JoinColumn(name = "processInstanceId"), @JoinColumn(name = "applicationId") })
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "processInstance")
     private Collection<TaskInfoEntity> tasks;
 
     public ProcessInstanceEntity() {

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/RetriedTaskEntity.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/RetriedTaskEntity.java
@@ -14,8 +14,8 @@ public class RetriedTaskEntity extends TaskInfoEntity {
     @Column
     private short retryAttempt;
 
-    public RetriedTaskEntity(String jsonPointer, short retryAttempt) {
-        super(jsonPointer);
+    public RetriedTaskEntity(TaskInfoKey key, short retryAttempt) {
+        super(key);
         this.retryAttempt = retryAttempt;
     }
 

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/TaskInfoEntity.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/TaskInfoEntity.java
@@ -2,30 +2,36 @@ package io.quarkiverse.flow.persistence.jpa;
 
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.ManyToOne;
 
 @Entity
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "task_type", discriminatorType = DiscriminatorType.INTEGER)
 public abstract class TaskInfoEntity {
-    @Id
-    @GeneratedValue
-    private long id;
+    @EmbeddedId
+    private TaskInfoKey taskInfoKey;
 
-    private String jsonPointer;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumns({
+            @JoinColumn(name = "applicationId", referencedColumnName = "applicationId", insertable = false, updatable = false),
+            @JoinColumn(name = "processInstanceId", referencedColumnName = "instanceId", insertable = false, updatable = false) })
+    private ProcessInstanceEntity processInstance;
 
     public TaskInfoEntity() {
     }
 
-    public TaskInfoEntity(String jsonPointer) {
-        this.jsonPointer = jsonPointer;
+    public TaskInfoEntity(TaskInfoKey taskInfoKey) {
+        this.taskInfoKey = taskInfoKey;
     }
 
     public String jsonPointer() {
-        return jsonPointer;
+        return taskInfoKey.getJsonPointer();
     }
 }

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/TaskInfoKey.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/TaskInfoKey.java
@@ -1,0 +1,75 @@
+package io.quarkiverse.flow.persistence.jpa;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import io.serverlessworkflow.impl.TaskContextData;
+import io.serverlessworkflow.impl.WorkflowContextData;
+
+@Embeddable
+public class TaskInfoKey implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static TaskInfoKey from(WorkflowContextData workflow, TaskContextData task) {
+        TaskInfoKey key = new TaskInfoKey();
+        key.jsonPointer = task.position().jsonPointer();
+        key.applicationId = workflow.definition().application().id();
+        key.processInstanceId = workflow.instanceData().id();
+        return key;
+    }
+
+    @Column
+    private String jsonPointer;
+
+    @Column
+    private String applicationId;
+
+    @Column
+    private String processInstanceId;
+
+    public String getJsonPointer() {
+        return jsonPointer;
+    }
+
+    public void setJsonPointer(String jsonPointer) {
+        this.jsonPointer = jsonPointer;
+    }
+
+    public String getApplicationId() {
+        return applicationId;
+    }
+
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    public String getProcessInstanceId() {
+        return processInstanceId;
+    }
+
+    public void setProcessInstanceId(String processInstanceId) {
+        this.processInstanceId = processInstanceId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(applicationId, jsonPointer, processInstanceId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TaskInfoKey other = (TaskInfoKey) obj;
+        return Objects.equals(applicationId, other.applicationId) && Objects.equals(jsonPointer, other.jsonPointer)
+                && Objects.equals(processInstanceId, other.processInstanceId);
+    }
+}


### PR DESCRIPTION
Fix https://github.com/quarkiverse/quarkus-flow/issues/305
Properly defined the id composite key for task entities. 
The owner of the mapping is now the task, which allows persisting them without loading the process instance. 
