### PR TITLE
no-issue: skip running k8s and coverage pipelines when docs are changed

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,7 @@ name: "Test Coverage Report"
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore: [ ".gitignore", "CODEOWNERS", "LICENSE", "**.md", "**.adoc", "**.txt", ".all-contributorsrc" ]
 
 env:
   QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_ID: llama3.2

--- a/.github/workflows/durable-k8s-kind.yml
+++ b/.github/workflows/durable-k8s-kind.yml
@@ -3,9 +3,9 @@ name: Durable Workflows (Kubernetes Lease) - Kind Verification
 on:
   push:
     branches: [ "main" ]
-    paths-ignore: [ ".gitignore", "CODEOWNERS", "LICENSE", "*.md", "*.adoc", "*.txt", ".all-contributorsrc", ".github/project.yml" ]
+    paths-ignore: [ ".gitignore", "CODEOWNERS", "LICENSE", "**.md", "**.adoc", "**.txt", ".all-contributorsrc", ".github/project.yml" ]
   pull_request:
-    paths-ignore: [ ".gitignore", "CODEOWNERS", "LICENSE", "*.md", "*.adoc", "*.txt", ".all-contributorsrc" ]
+    paths-ignore: [ ".gitignore", "CODEOWNERS", "LICENSE", "**.md", "**.adoc", "**.txt", ".all-contributorsrc" ]
 
 concurrency:
   group: durable-k8s-kind-${{ github.ref }}


### PR DESCRIPTION
See title.