### PR TITLE
[no-issue] Upgrade quarkus version to 3.33.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.log.level>OFF</quarkus.log.level>
 
-        <quarkus.version>3.32.3</quarkus.version>
+        <quarkus.version>3.33.0</quarkus.version>
         <io.serverlessworkflow.version>7.13.8.Final</io.serverlessworkflow.version>
         <io.cloudevents.version>4.0.1</io.cloudevents.version>
 


### PR DESCRIPTION
This pull request updates the Quarkus framework version used in the project. 

Dependency update:

* Upgraded the Quarkus version from `3.32.3` to `3.33.0` in `pom.xml`.