### PR TITLE
no-issue: Remove paralell tests; Mock NewsletterDrafter test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,11 @@ jobs:
 
       - name: Build with Maven (Linux, full tests)
         if: matrix.os == 'ubuntu-latest'
-        run: mvn -B clean install -T 1C -Dno-format -DskipITs=true -Dquarkus.log.level=OFF -ntp
+        run: mvn -B clean install -Dno-format -DskipITs=true -Dquarkus.log.level=OFF -ntp
 
       - name: Build with Maven (Windows, skip ITs)
         if: matrix.os == 'windows-latest'
-        run: mvn -B clean install -T 1C -Dno-format -DskipITs=true -Dquarkus.log.level=OFF -Dquarkus.langchain4j.ollama.devservices.enabled=false -ntp
+        run: mvn -B clean install -Dno-format -DskipITs=true -Dquarkus.log.level=OFF -Dquarkus.langchain4j.ollama.devservices.enabled=false -ntp
 
       - name: Publish Failed Test Report
         uses: mikepenz/action-junit-report@v6

--- a/examples/newsletter-drafter/src/test/java/org/acme/newsletter/NewsletterWorkflowIT.java
+++ b/examples/newsletter-drafter/src/test/java/org/acme/newsletter/NewsletterWorkflowIT.java
@@ -4,12 +4,15 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.acme.newsletter.agents.AutoDraftCriticAgent;
+import org.acme.newsletter.agents.HumanEditorAgent;
 import org.acme.newsletter.domain.HumanReview;
 import org.acme.newsletter.domain.NewsletterDraft;
 import org.acme.newsletter.domain.NewsletterRequest;
 import org.acme.newsletter.services.MailService;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -32,9 +35,11 @@ import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @DisabledOnOs(OS.WINDOWS)
 @QuarkusTest
@@ -49,6 +54,31 @@ public class NewsletterWorkflowIT {
 
     @InjectMock
     MailService mailService;
+
+    @InjectMock
+    AutoDraftCriticAgent draftAgent;
+
+    @InjectMock
+    HumanEditorAgent humanEditorAgent;
+
+    @BeforeEach
+    void setupAiMocks() {
+        NewsletterDraft initialDraft = new NewsletterDraft(
+                "Bullish Market Update",
+                "Fed cuts taxes...",
+                "Full body text...");
+
+        NewsletterDraft revisedDraft = new NewsletterDraft(
+                "Cautious Market Update",
+                "Fed considers tax cuts...",
+                "Toned down body text...");
+
+        when(draftAgent.write(anyString(), any()))
+                .thenReturn(initialDraft);
+
+        when(humanEditorAgent.edit(any()))
+                .thenReturn(revisedDraft);
+    }
 
     @Test
     void agent_chain_human_review_two_rounds_via_rest() {

--- a/examples/newsletter-drafter/src/test/resources/application.properties
+++ b/examples/newsletter-drafter/src/test/resources/application.properties
@@ -1,1 +1,3 @@
 quarkus.http.test-port=0
+
+quarkus.langchain4j.ollama.devservices.enabled=false


### PR DESCRIPTION
Since GHA can't handle all the resources we require to run our tests in parallel, I'm disabling them to avoid flacky tests. Additionally, the Newsletter Drafter example will run with mocked agents since having 4 agents in memory is too much for our infrastructure to handle.