### PR TITLE
no-issue: add guardrails and fix a smallbug on lc4j loop pattern

### DIFF
--- a/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/workflow/FlowLoopAgentService.java
+++ b/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/workflow/FlowLoopAgentService.java
@@ -61,7 +61,7 @@ public class FlowLoopAgentService<T> extends LoopAgentServiceImpl<T> implements 
      * Continue while exitCondition == false.
      */
     protected LoopPredicateIndex<AgenticScope, Object> continuePredicate() {
-        return (scope, item, idx) -> !flowExitCond.test(scope, idx);
+        return (scope, item, idx) -> !flowExitCond.test(scope, idx + 1);
     }
 
     @Override
@@ -92,7 +92,8 @@ public class FlowLoopAgentService<T> extends LoopAgentServiceImpl<T> implements 
             flowExitCond = (scope, loopCounter) -> false;
         }
         if (flowMaxIterations == 0) {
-            flowMaxIterations = Integer.MAX_VALUE;
+            // Integer.MAX_VALUE may explode on OoM in runtime
+            flowMaxIterations = 100;
         }
         final FlowPlannerBuilder builder = new FlowPlannerBuilder(this);
         return build(builder::build);


### PR DESCRIPTION
Small fix to avoid blowing up our workflow definition when max iterations is not set; add the index + 1 on the default continue predicate to pair with the predicate defined in the loop end.