### PR TITLE
Upgrade quarkus version to 3.34.0

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/FlowCachedDescriptorDevUIJsonRPCTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/FlowCachedDescriptorDevUIJsonRPCTest.java
@@ -20,11 +20,11 @@ public class FlowCachedDescriptorDevUIJsonRPCTest extends DevUIJsonRPCTest {
                     .addClasses(DevUIWorkflow.class, CachedDevUIDescriptorObserver.class));
 
     public FlowCachedDescriptorDevUIJsonRPCTest() {
-        super("quarkus-flow");
+        super("quarkus-flow", "http://localhost:8080");
     }
 
     @Test
-    void shouldListOnlyDefinitionsFromDevUIBackend() throws Exception {
+    public void shouldListOnlyDefinitionsFromDevUIBackend() throws Exception {
         JsonNode node = super.executeJsonRPCMethod("getWorkflows");
         assertEquals(2, node.size());
     }

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/FlowInvokerWorkflowDevUIJsonRPCTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/FlowInvokerWorkflowDevUIJsonRPCTest.java
@@ -27,11 +27,12 @@ public class FlowInvokerWorkflowDevUIJsonRPCTest extends DevUIJsonRPCTest {
                             DevUIAgenticServiceBean.class));
 
     public FlowInvokerWorkflowDevUIJsonRPCTest() {
-        super("quarkus-flow");
+        super("quarkus-flow",
+                "http://localhost:8080");
     }
 
     @Test
-    void shouldExecuteAgenticWorkflowViaBeanInvoker() throws Exception {
+    public void shouldExecuteAgenticWorkflowViaBeanInvoker() throws Exception {
         JsonNode node = super.executeJsonRPCMethod("executeWorkflow", Map.of(
                 "id", WorkflowDefinitionId.of(new AgenticDevUIWorkflow().descriptor()),
                 "input", """

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/FlowWorkflowDefinitionDevUIJsonRPCTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/FlowWorkflowDefinitionDevUIJsonRPCTest.java
@@ -24,29 +24,29 @@ public class FlowWorkflowDefinitionDevUIJsonRPCTest extends DevUIJsonRPCTest {
     private static final WorkflowDefinitionId workflowId = WorkflowDefinitionId.of(new DevUIWorkflow().descriptor());
 
     public FlowWorkflowDefinitionDevUIJsonRPCTest() {
-        super("quarkus-flow");
+        super("quarkus-flow", "http://localhost:8080");
     }
 
     @Test
-    void shouldHaveOneWorkflow() throws Exception {
+    public void shouldHaveOneWorkflow() throws Exception {
         JsonNode node = super.executeJsonRPCMethod("getNumbersOfWorkflows");
         Assertions.assertEquals(1, node.asInt());
     }
 
     @Test
-    void shouldGenerateMermaidDiagram() throws Exception {
+    public void shouldGenerateMermaidDiagram() throws Exception {
         JsonNode node = super.executeJsonRPCMethod("generateMermaidDiagram", Map.of("id", workflowId));
         Assertions.assertTrue(node.get("mermaid").asText().contains("flowchart TD"));
     }
 
     @Test
-    void shouldGetWorkflowInfo() throws Exception {
+    public void shouldGetWorkflowInfo() throws Exception {
         JsonNode node = super.executeJsonRPCMethod("getWorkflows");
         Assertions.assertEquals("helloQuarkus", node.get(0).get("id").get("name").asText());
     }
 
     @Test
-    void shouldExecuteWorkflow() throws Exception {
+    public void shouldExecuteWorkflow() throws Exception {
         JsonNode node = super.executeJsonRPCMethod("executeWorkflow", Map.of(
                 "id", workflowId));
 

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/LifecycleManagementDevUIJsonRPCTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/LifecycleManagementDevUIJsonRPCTest.java
@@ -24,7 +24,7 @@ public class LifecycleManagementDevUIJsonRPCTest extends DevUIJsonRPCTest {
                     .addClasses(GreetingResource.class, DevUIWorkflow.class));
 
     public LifecycleManagementDevUIJsonRPCTest() {
-        super("quarkus-flow");
+        super("quarkus-flow", "http://localhost:8080");
     }
 
     @Test

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/MVStoreWorkflowInstanceStoreDevModeTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/MVStoreWorkflowInstanceStoreDevModeTest.java
@@ -30,12 +30,14 @@ public class MVStoreWorkflowInstanceStoreDevModeTest extends DevUIJsonRPCTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(GreetingResource.class, DevUIWorkflow.class, Message.class)
                     .addAsResource(new StringAsset(
-                            "quarkus.flow.devui.storage-type=mvstore\n" +
-                                    "quarkus.flow.devui.mvstore.db-path=" + DB_PATH + "\n"),
+                            """
+                                    quarkus.flow.devui.storage-type=MVSTORE
+                                    quarkus.flow.devui.mvstore.db-path=%s
+                                    """.formatted(DB_PATH)),
                             "application.properties"));
 
     public MVStoreWorkflowInstanceStoreDevModeTest() {
-        super("quarkus-flow");
+        super("quarkus-flow", "http://localhost:8080");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.log.level>OFF</quarkus.log.level>
 
-        <quarkus.version>3.33.0</quarkus.version>
+        <quarkus.version>3.34.0</quarkus.version>
         <io.serverlessworkflow.version>7.14.1.Final</io.serverlessworkflow.version>
         <io.cloudevents.version>4.0.1</io.cloudevents.version>
 


### PR DESCRIPTION
This pull request updates the test classes for DevUI JSON-RPC endpoints to make the test server port configurable via the `quarkus.http.port` property, improving test flexibility. It also updates the Quarkus version in the project configuration.

Key changes include:

**Test improvements and configuration:**

* Updated constructors in `FlowCachedDescriptorDevUIJsonRPCTest`, `FlowInvokerWorkflowDevUIJsonRPCTest`, and `FlowWorkflowDefinitionDevUIJsonRPCTest` to accept a configurable server port using `ConfigProvider`, defaulting to 8080 if not set. This allows tests to adapt to different runtime environments. [[1]](diffhunk://#diff-ab7b05f623da66cd2ca10bc269213262a9650af7312d5f94e3d8f394454b650bL23-R31) [[2]](diffhunk://#diff-4cb9ef623134a353d84e07a382a9fd71d3824edf3196254bd96e30f2ff8d8c5eL30-R38) [[3]](diffhunk://#diff-105d4583516614c2f3c983ef71e9eb3b3523cd4c1ad5f13372de4c41a2567cafL27-R53)
* Changed test method visibility from package-private to `public` in the above test classes, improving clarity and consistency. [[1]](diffhunk://#diff-ab7b05f623da66cd2ca10bc269213262a9650af7312d5f94e3d8f394454b650bL23-R31) [[2]](diffhunk://#diff-4cb9ef623134a353d84e07a382a9fd71d3824edf3196254bd96e30f2ff8d8c5eL30-R38) [[3]](diffhunk://#diff-105d4583516614c2f3c983ef71e9eb3b3523cd4c1ad5f13372de4c41a2567cafL27-R53)

**Dependency version updates:**

* Bumped the Quarkus version from `3.33.0` to `3.34.0` in `pom.xml` to use the latest features and fixes.