### PR TITLE
Remove fixed ollama fixed port and increase timeout on nightly CI

### DIFF
--- a/.github/workflows/native-nigthly-ci.yaml
+++ b/.github/workflows/native-nigthly-ci.yaml
@@ -37,6 +37,7 @@ jobs:
           mvn -B install -Dnative -ntp
           -Dquarkus.native.container-build
           -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-25
+          -Dquarkus.langchain4j.timeout=60000
           -DskipITs=false
 
       - name: Publish Failed Test Report

--- a/core/integration-tests/src/test/resources/application.properties
+++ b/core/integration-tests/src/test/resources/application.properties
@@ -5,7 +5,6 @@ quarkus.log.category."io.vertx".level=INFO
 quarkus.log.category."dev.langchain4j".level=INFO
 
 quarkus.langchain4j.ollama.timeout=120s
-quarkus.langchain4j.ollama.base-url=http://127.0.0.1:11434/
 
 # Enable the extension's metrics logic
 quarkus.flow.metrics.enabled=true


### PR DESCRIPTION
This pull request introduces a configuration update to increase the timeout for LangChain4j operations in the native build workflow and removes an unused Ollama base URL property from the test application properties. These changes help ensure more robust builds and cleaner configuration.

Configuration improvements:

* Increased the LangChain4j operation timeout to 60 seconds in the native build GitHub Actions workflow by adding `-Dquarkus.langchain4j.timeout=60000` to the Maven build arguments (`.github/workflows/native-nigthly-ci.yaml`).

Cleanup of test properties:

* Removed the unused `quarkus.langchain4j.ollama.base-url` property from the test `application.properties` file (`core/integration-tests/src/test/resources/application.properties`).