### PR TITLE
Allow backend lifecycle management to work with Agentic workflows

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowDevUIProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowDevUIProcessor.java
@@ -2,9 +2,11 @@ package io.quarkiverse.flow.deployment;
 
 import io.quarkiverse.flow.config.FlowDevUIConfig;
 import io.quarkiverse.flow.devui.InMemoryWorkflowInstanceStore;
+import io.quarkiverse.flow.devui.LifecycleManagementBackendObjectMapperCustomizer;
 import io.quarkiverse.flow.devui.MVStoreWorkflowInstanceStore;
 import io.quarkiverse.flow.devui.ManagementLifecycleListener;
 import io.quarkiverse.flow.devui.ManagementLifecycleRPCService;
+import io.quarkiverse.flow.devui.RuntimeDevApplicationBuilderCustomizer;
 import io.quarkiverse.flow.devui.WorkflowRPCService;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.IsDevelopment;
@@ -35,25 +37,33 @@ public class FlowDevUIProcessor {
     }
 
     @BuildStep(onlyIf = IsLocalDevelopment.class)
-    void createJsonRPCProviders(BuildProducer<JsonRPCProvidersBuildItem> rpcProviders) {
+    void createJsonRPCProviders(BuildProducer<JsonRPCProvidersBuildItem> rpcProviders, FlowDevUIConfig flowDevUIConfig) {
         rpcProviders.produce(new JsonRPCProvidersBuildItem(WorkflowRPCService.class));
-        rpcProviders.produce(new JsonRPCProvidersBuildItem(ManagementLifecycleRPCService.class));
+        if (flowDevUIConfig.backend().storage().enabled()) {
+            rpcProviders.produce(new JsonRPCProvidersBuildItem(ManagementLifecycleRPCService.class));
+        }
     }
 
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     AdditionalBeanBuildItem additionalBeans(FlowDevUIConfig flowDevUIConfig) {
 
+        if (!flowDevUIConfig.backend().storage().enabled()) {
+            return null;
+        }
+
         AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder()
                 .addBeanClasses(
-                        ManagementLifecycleListener.class);
+                        RuntimeDevApplicationBuilderCustomizer.class,
+                        ManagementLifecycleListener.class,
+                        ManagementLifecycleRPCService.class,
+                        LifecycleManagementBackendObjectMapperCustomizer.class)
+                .setUnremovable();
 
         switch (flowDevUIConfig.storageType()) {
             case MVSTORE -> builder.addBeanClass(MVStoreWorkflowInstanceStore.class);
             case IN_MEMORY -> builder.addBeanClass(InMemoryWorkflowInstanceStore.class);
         }
 
-        return builder
-                .setUnremovable()
-                .build();
+        return builder.build();
     }
 }

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/LifecycleManagementDevUIJsonRPCTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/LifecycleManagementDevUIJsonRPCTest.java
@@ -1,10 +1,14 @@
 package io.quarkiverse.flow.deployment.test.devui;
 
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -21,6 +25,11 @@ public class LifecycleManagementDevUIJsonRPCTest extends DevUIJsonRPCTest {
     @RegisterExtension
     static final QuarkusDevModeTest devMode = new QuarkusDevModeTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.flow.devui.mvstore.db-path=target/flow-lifecycle-management.mv.db
+                            quarkus.flow.devui.backend.storage.enabled=true
+                            """),
+                            "application.properties")
                     .addClasses(GreetingResource.class, DevUIWorkflow.class));
 
     public LifecycleManagementDevUIJsonRPCTest() {
@@ -117,6 +126,40 @@ public class LifecycleManagementDevUIJsonRPCTest extends DevUIJsonRPCTest {
                 "the instance ID must be the same value");
 
         softly.assertAll();
+    }
+
+    @Test
+    void list_all_workflow_instances_should_expose_serialized_input_and_output() throws Exception {
+        String instanceId = RestAssured.given()
+                .get("/hello/async")
+                .then()
+                .statusCode(202)
+                .extract()
+                .path("id");
+
+        await().atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    JsonNode result = this.executeJsonRPCMethod("findByWorkflowInstanceId", Map.of("instanceId", instanceId));
+                    Assertions.assertThat(result.get("status").asText()).isEqualTo("COMPLETED");
+                });
+
+        JsonNode root = this.executeJsonRPCMethod("listAllWorkflowInstances", Map.of(
+                "page", 0,
+                "size", 20,
+                "sort", "LAST_UPDATE_DESC"));
+
+        JsonNode workflowInstance = root.valueStream()
+                .filter(node -> instanceId.equals(node.path("instanceId").asText()))
+                .findFirst()
+                .orElseThrow();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(workflowInstance.path("input").path("name").asText()).isEqualTo("Quarkiverse");
+            softly.assertThat(workflowInstance.path("input").has("null")).isFalse();
+            softly.assertThat(workflowInstance.path("output").path("message").asText()).isEqualTo("Message from Alice to me!");
+            softly.assertThat(workflowInstance.path("output").has("null")).isFalse();
+        });
     }
 
     private static void executeDevUIWorkflow(int times) {

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/MVStoreWorkflowInstanceStoreDevModeTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/MVStoreWorkflowInstanceStoreDevModeTest.java
@@ -9,7 +9,6 @@ import java.util.Map;
 
 import org.assertj.core.api.SoftAssertions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -29,12 +28,7 @@ public class MVStoreWorkflowInstanceStoreDevModeTest extends DevUIJsonRPCTest {
     static final QuarkusDevModeTest devMode = new QuarkusDevModeTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(GreetingResource.class, DevUIWorkflow.class, Message.class)
-                    .addAsResource(new StringAsset(
-                            """
-                                    quarkus.flow.devui.storage-type=MVSTORE
-                                    quarkus.flow.devui.mvstore.db-path=%s
-                                    """.formatted(DB_PATH)),
-                            "application.properties"));
+                    .addAsResource("application-backend-devui.properties", "application.properties"));
 
     public MVStoreWorkflowInstanceStoreDevModeTest() {
         super("quarkus-flow", "http://localhost:8080");
@@ -141,6 +135,8 @@ public class MVStoreWorkflowInstanceStoreDevModeTest extends DevUIJsonRPCTest {
                     JsonNode result = super.executeJsonRPCMethod("findByWorkflowInstanceId", Map.of(
                             "instanceId", instanceId));
                     assertThat(result).isNotNull();
+                    assertThat(result.isNull()).as("Result should not be a null node").isFalse();
+                    assertThat(result.has("status")).as("Result should have status field").isTrue();
                     assertThat(result.get("status").asText()).isEqualTo("COMPLETED");
                 });
 

--- a/core/deployment/src/test/resources/application-backend-devui.properties
+++ b/core/deployment/src/test/resources/application-backend-devui.properties
@@ -1,0 +1,3 @@
+quarkus.flow.devui.storage-type=MVSTORE
+quarkus.flow.devui.mvstore.db-path=target/test-mvstore-devmode.mv.db
+quarkus.flow.devui.backend.storage.enabled=true

--- a/core/runtime-dev/src/main/java/io/quarkiverse/flow/devui/FlowInstanceDeserializer.java
+++ b/core/runtime-dev/src/main/java/io/quarkiverse/flow/devui/FlowInstanceDeserializer.java
@@ -41,7 +41,7 @@ public class FlowInstanceDeserializer extends StdDeserializer<FlowInstance> {
         String workflowVersion = node.get("workflowVersion").asText();
         WorkflowStatus status = WorkflowStatus.valueOf(node.get("status").asText());
         Instant startTime = Instant.ofEpochMilli(node.get("startTime").asLong());
-        WorkflowModel input = parseWorkflowModel(node.get("input"));
+        WorkflowModel input = readWorkflowModel(node.get("input"));
 
         FlowInstance instance = new FlowInstance(
                 instanceId,
@@ -56,7 +56,7 @@ public class FlowInstanceDeserializer extends StdDeserializer<FlowInstance> {
         JsonNode endTimeNode = node.get("endTime");
         if (endTimeNode != null && !endTimeNode.isNull()) {
             Instant endTime = Instant.ofEpochMilli(endTimeNode.asLong());
-            WorkflowModel output = parseWorkflowModel(node.get("output"));
+            WorkflowModel output = readWorkflowModel(node.get("output"));
             instance.recordCompletion(endTime, output);
         }
 
@@ -85,33 +85,6 @@ public class FlowInstanceDeserializer extends StdDeserializer<FlowInstance> {
         return instance;
     }
 
-    private WorkflowModel parseWorkflowModel(JsonNode node) {
-        if (node == null || node.isNull()) {
-            return null;
-        }
-        // Convert JsonNode to Object and then to WorkflowModel
-        Object obj = parseObject(node);
-        return obj != null ? modelFactory.fromOther(obj) : null;
-    }
-
-    private Object parseObject(JsonNode node) {
-        if (node == null || node.isNull()) {
-            return null;
-        }
-        if (node.isTextual()) {
-            return node.asText();
-        }
-        if (node.isNumber()) {
-            return node.numberValue();
-        }
-        if (node.isBoolean()) {
-            return node.asBoolean();
-        }
-        // For complex objects, return the JsonNode itself
-        // Jackson will handle the conversion when needed
-        return node;
-    }
-
     private void restoreHistoryEvent(FlowInstance instance, LifecycleEventSummary event) {
         String eventType = event.type();
         switch (eventType) {
@@ -126,4 +99,12 @@ public class FlowInstanceDeserializer extends StdDeserializer<FlowInstance> {
             default -> instance.recordTaskEvent(eventType, event.taskName(), event.timestamp());
         }
     }
+
+    private WorkflowModel readWorkflowModel(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        return modelFactory.fromAny(node);
+    }
+
 }

--- a/core/runtime-dev/src/main/java/io/quarkiverse/flow/devui/FlowInstanceSerializer.java
+++ b/core/runtime-dev/src/main/java/io/quarkiverse/flow/devui/FlowInstanceSerializer.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import io.quarkiverse.flow.devui.FlowInstance.LifecycleEventSummary;
+import io.serverlessworkflow.impl.jackson.JsonUtils;
 
 public class FlowInstanceSerializer extends StdSerializer<FlowInstance> {
 
@@ -48,15 +49,14 @@ public class FlowInstanceSerializer extends StdSerializer<FlowInstance> {
             gen.writeNullField("errorMessage");
         }
 
-        // Serialize WorkflowModel as its Java object representation
         if (value.getInput() != null) {
-            gen.writeObjectField("input", value.getInput().asJavaObject());
+            gen.writeObjectField("input", JsonUtils.modelToJson(value.getInput()));
         } else {
             gen.writeNullField("input");
         }
 
         if (value.getOutput() != null) {
-            gen.writeObjectField("output", value.getOutput().asJavaObject());
+            gen.writeObjectField("output", JsonUtils.modelToJson(value.getOutput()));
         } else {
             gen.writeNullField("output");
         }

--- a/core/runtime-dev/src/main/java/io/quarkiverse/flow/devui/LifecycleManagementBackendObjectMapperCustomizer.java
+++ b/core/runtime-dev/src/main/java/io/quarkiverse/flow/devui/LifecycleManagementBackendObjectMapperCustomizer.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.flow.devui;
+
+import jakarta.inject.Singleton;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+@Singleton
+public class LifecycleManagementBackendObjectMapperCustomizer implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        SimpleModule simpleModule = new SimpleModule();
+        simpleModule.addSerializer(FlowInstance.class, new FlowInstanceSerializer());
+        simpleModule.addDeserializer(FlowInstance.class, new FlowInstanceDeserializer());
+        objectMapper.registerModule(simpleModule);
+    }
+}

--- a/core/runtime-dev/src/main/java/io/quarkiverse/flow/devui/MVStoreWorkflowInstanceStore.java
+++ b/core/runtime-dev/src/main/java/io/quarkiverse/flow/devui/MVStoreWorkflowInstanceStore.java
@@ -6,8 +6,8 @@ import java.util.Objects;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 import org.slf4j.Logger;
@@ -15,9 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 
-import io.quarkiverse.flow.config.FlowDevUIConfig;
 import io.serverlessworkflow.impl.WorkflowStatus;
 
 @ApplicationScoped
@@ -26,45 +24,45 @@ public class MVStoreWorkflowInstanceStore implements WorkflowInstanceStore {
     private static final Logger log = LoggerFactory.getLogger(MVStoreWorkflowInstanceStore.class);
     private static final String MAP_NAME = "flowInstances";
 
-    @Inject
-    FlowDevUIConfig config;
-
-    private static final ObjectMapper objectMapper;
-
-    static {
-        SimpleModule module = new SimpleModule();
-        module.addSerializer(FlowInstance.class, new FlowInstanceSerializer());
-        module.addDeserializer(FlowInstance.class, new FlowInstanceDeserializer());
-
-        objectMapper = new ObjectMapper()
-                .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
-                .registerModule(module);
-    }
+    private final ObjectMapper objectMapper;
+    private final String dbPath;
 
     private MVStore store;
     private MVMap<String, String> flowInstancesMap;
 
+    public MVStoreWorkflowInstanceStore(
+            @ConfigProperty(name = "quarkus.flow.devui.mvstore.db-path", defaultValue = "flow-devui.mv.db") String dbPath,
+            ObjectMapper objectMapper) {
+        this.dbPath = dbPath;
+        this.objectMapper = objectMapper;
+    }
+
     @PostConstruct
     void init() {
-        String path = config.mvstore().dbPath();
+        if (flowInstancesMap != null) {
+            return;
+        }
         try {
-            store = MVStore.open(path);
+            store = MVStore.open(dbPath);
             flowInstancesMap = store.openMap(MAP_NAME);
-            log.debug("MVStore initialized at: {}", path);
+            log.debug("MVStore initialized at: {}", dbPath);
         } catch (Exception e) {
-            log.error("Failed to initialize MVStore at: {}", path, e);
+            log.error("Failed to initialize MVStore at: {}", dbPath, e);
             throw new RuntimeException("Failed to initialize MVStore", e);
         }
     }
 
     @PreDestroy
-    void close() {
+    public void close() {
         if (store != null) {
             try {
                 store.close();
                 log.info("MVStore closed");
             } catch (Exception e) {
                 log.warn("Error closing MVStore", e);
+            } finally {
+                store = null;
+                flowInstancesMap = null;
             }
         }
     }

--- a/core/runtime-dev/src/main/java/io/quarkiverse/flow/devui/ManagementLifecycleRPCService.java
+++ b/core/runtime-dev/src/main/java/io/quarkiverse/flow/devui/ManagementLifecycleRPCService.java
@@ -7,47 +7,59 @@ import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.serverlessworkflow.impl.WorkflowStatus;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 @ApplicationScoped
 public class ManagementLifecycleRPCService {
 
     private static final int MAX_PAGE_SIZE = 1000;
     private final WorkflowInstanceStore store;
+    private final ObjectMapper objectMapper;
 
-    public ManagementLifecycleRPCService(WorkflowInstanceStore store) {
+    public ManagementLifecycleRPCService(WorkflowInstanceStore store, ObjectMapper objectMapper) {
         this.store = store;
+        this.objectMapper = objectMapper;
     }
 
     @JsonRpcDescription("Get all workflow instances with pagination and sorting")
-    public List<FlowInstance> listAllWorkflowInstances(
+    public JsonArray listAllWorkflowInstances(
             @JsonRpcDescription("Page number (0-based)") Integer page,
             @JsonRpcDescription("Page size") Integer size,
-            @JsonRpcDescription("Sort order") String sort) {
+            @JsonRpcDescription("Sort order") String sort) throws JsonProcessingException {
         Integer finalPage = validatePage(page);
         Integer finalSize = validateSize(size);
         String finalSort = Optional.ofNullable(sort).orElse(WorkflowInstanceStore.Sort.START_TIME_ASC.name());
         WorkflowInstanceStore.Sort sortEnum = parseSortOrder(finalSort);
-        return store.listAll(finalPage, finalSize, sortEnum);
+        List<FlowInstance> flowInstances = store.listAll(finalPage, finalSize, sortEnum);
+        String json = objectMapper.writeValueAsString(flowInstances);
+        return new JsonArray(json);
     }
 
     @JsonRpcDescription("Find workflow instance by workflow ID")
-    public FlowInstance findByWorkflowInstanceId(
-            @JsonRpcDescription("Workflow instance ID") String instanceId) {
-        return store.findByInstanceId(Objects.requireNonNull(instanceId, "instanceId must not be null"));
+    public JsonObject findByWorkflowInstanceId(
+            @JsonRpcDescription("Workflow instance ID") String instanceId) throws JsonProcessingException {
+        FlowInstance flowInstance = store.findByInstanceId(Objects.requireNonNull(instanceId, "instanceId must not be null"));
+        String json = objectMapper.writeValueAsString(flowInstance);
+        return new JsonObject(json);
     }
 
     @JsonRpcDescription("Find workflow instances by status")
-    public List<FlowInstance> findByStatus(
+    public JsonArray findByStatus(
             @JsonRpcDescription("Status") String status,
             @JsonRpcDescription("Page number (0-based)") Integer page,
-            @JsonRpcDescription("Page size") Integer size) {
+            @JsonRpcDescription("Page size") Integer size) throws JsonProcessingException {
         Objects.requireNonNull(status, "status must not be null");
         Integer finalPage = validatePage(page);
         Integer finalSize = validateSize(size);
         WorkflowStatus workflowStatus = parseWorkflowStatus(status);
-        return store.findByStatus(workflowStatus, finalPage, finalSize);
+        String json = objectMapper.writeValueAsString(store.findByStatus(workflowStatus, finalPage, finalSize));
+        return new JsonArray(json);
     }
 
     private WorkflowStatus parseWorkflowStatus(String status) {

--- a/core/runtime-dev/src/test/java/io/quarkiverse/flow/devui/MVStoreWorkflowInstanceStoreTest.java
+++ b/core/runtime-dev/src/test/java/io/quarkiverse/flow/devui/MVStoreWorkflowInstanceStoreTest.java
@@ -2,7 +2,6 @@ package io.quarkiverse.flow.devui;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -14,10 +13,24 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import io.quarkiverse.flow.config.FlowDevUIConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 import io.serverlessworkflow.impl.WorkflowStatus;
 
 public class MVStoreWorkflowInstanceStoreTest {
+
+    private static final ObjectMapper objectMapper;
+    static {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(FlowInstance.class, new FlowInstanceSerializer());
+        module.addDeserializer(FlowInstance.class, new FlowInstanceDeserializer());
+
+        objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .registerModule(module);
+    }
 
     @TempDir
     Path tempDir;
@@ -39,25 +52,7 @@ public class MVStoreWorkflowInstanceStoreTest {
     }
 
     private MVStoreWorkflowInstanceStore createStore(String path) {
-        MVStoreWorkflowInstanceStore store = new MVStoreWorkflowInstanceStore();
-
-        // Create a mock config
-        store.config = new FlowDevUIConfig() {
-            @Override
-            public StorageType storageType() {
-                return StorageType.MVSTORE;
-            }
-
-            @Override
-            public FlowDevUIConfig.MVStore mvstore() {
-                return new FlowDevUIConfig.MVStore() {
-                    @Override
-                    public String dbPath() {
-                        return path;
-                    }
-                };
-            }
-        };
+        MVStoreWorkflowInstanceStore store = new MVStoreWorkflowInstanceStore(path, objectMapper);
 
         store.init();
         return store;
@@ -171,7 +166,7 @@ public class MVStoreWorkflowInstanceStoreTest {
     }
 
     @Test
-    void should_persist_data_across_store_restarts() throws IOException {
+    void should_persist_data_across_store_restarts() {
         // Save some data
         store.saveOrUpdate(createWorkflowInstance("id1", WorkflowStatus.RUNNING,
                 Instant.parse("2024-01-01T10:00:00Z"), Instant.parse("2024-01-01T10:05:00Z")));

--- a/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowDevUIBackendConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowDevUIBackendConfig.java
@@ -1,0 +1,23 @@
+package io.quarkiverse.flow.config;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface FlowDevUIBackendConfig {
+
+    StorageConfig storage();
+
+    @ConfigGroup
+    interface StorageConfig {
+
+        /**
+         * Enables or disables backend persistence for Dev UI workflow data.
+         * <p>
+         * When disabled, no storage is used and no workflow metadata is persisted (DevUI only).
+         * <p>
+         */
+        @WithDefault("false")
+        boolean enabled();
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowDevUIConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowDevUIConfig.java
@@ -1,6 +1,5 @@
 package io.quarkiverse.flow.config;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -10,21 +9,9 @@ import io.smallrye.config.WithDefault;
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public interface FlowDevUIConfig {
 
-    /**
-     * Storage type for workflow instances in dev mode.
-     */
-    enum StorageType {
-        /**
-         * In-memory storage. Data is lost when the application restarts.
-         */
-        IN_MEMORY,
+    FlowDevUIBackendConfig backend();
 
-        /**
-         * File-based storage using H2 MVStore. Data is persisted to disk
-         * and survives application restarts.
-         */
-        MVSTORE
-    }
+    MVStoreConfig mvstore();
 
     /**
      * The type of storage to use for workflow instances in dev mode.
@@ -33,24 +20,7 @@ public interface FlowDevUIConfig {
      * <li><b>mvstore</b>: Data is persisted to a file using H2 MVStore</li>
      * </ul>
      */
-    @WithDefault("mvstore")
-    StorageType storageType();
+    @WithDefault("in-memory")
+    MVStoreConfig.StorageType storageType();
 
-    /**
-     * MVStore-specific configuration options.
-     * Only applicable when {@code storage-type=mvstore}.
-     */
-    MVStore mvstore();
-
-    @ConfigGroup
-    interface MVStore {
-
-        /**
-         * Path to the MVStore database file.
-         * <p>
-         * Only used when {@code storage-type=mvstore}.
-         */
-        @WithDefault("target/flow-devui.mv.db")
-        String dbPath();
-    }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/flow/config/MVStoreConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/config/MVStoreConfig.java
@@ -1,0 +1,34 @@
+package io.quarkiverse.flow.config;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public interface MVStoreConfig {
+
+    /**
+     * Storage type for workflow instances in Dev mode.
+     */
+    enum StorageType {
+        /**
+         * In-memory storage. Data is lost when the application restarts.
+         */
+        IN_MEMORY("in-memory"),
+
+        /**
+         * File-based storage using H2 MVStore. Data is persisted to disk
+         * and survives application restarts.
+         */
+        MVSTORE("mvstore");
+
+        private final String configValue;
+
+        StorageType(String configValue) {
+            this.configValue = configValue;
+        }
+
+        @Override
+        public String toString() {
+            return configValue;
+        }
+    }
+}

--- a/docs/modules/ROOT/pages/includes/quarkus-flow-messaging_quarkus.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-messaging_quarkus.adoc
@@ -1,0 +1,127 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-flow-messaging_quarkus-defaults-enabled]] [.property-path]##link:#quarkus-flow-messaging_quarkus-defaults-enabled[`+++quarkus.defaults-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.defaults-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Register default consumer/publisher beans bound to 'flow-in'/'flow-out' channels
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_DEFAULTS_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_DEFAULTS_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-flow-messaging_quarkus-lifecycle-enabled]] [.property-path]##link:#quarkus-flow-messaging_quarkus-lifecycle-enabled[`+++quarkus.lifecycle-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.lifecycle-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Register the default events lifecycle publisher to the 'flow-lifecycle-out'. By default, the application won't publish any lifecycle event to this channel.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LIFECYCLE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LIFECYCLE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-flow-messaging_quarkus-enable-metadata-correlation]] [.property-path]##link:#quarkus-flow-messaging_quarkus-enable-metadata-correlation[`+++quarkus.enable-metadata-correlation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.enable-metadata-correlation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the emitters should propagate correlation metadata.
+
+When enabled, correlation metadata attributes are automatically added to emitted CloudEvents to enable traceability and correlation across workflow instances and tasks.
+
+The default correlation metadata includes:
+
+ - `flowinstanceid` the instance ID, see `WorkflowInstance++#++id()`
+ - `flowtaskid` the task's position that where the request was made, see `io.serverlessworkflow.impl.TaskContext++#++position()`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ENABLE_METADATA_CORRELATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ENABLE_METADATA_CORRELATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-flow-messaging_quarkus-metadata-task-id-key]] [.property-path]##link:#quarkus-flow-messaging_quarkus-metadata-task-id-key[`+++quarkus.metadata.task-id.key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.metadata.task-id.key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The metadata's key name to be used in correlation propagation.
+
+This defines the actual link:https://github.com/cloudevents/spec/blob/v1.0/spec.md#extension-context-attributes[extension context attribute's] key name that will be used in the emitted CloudEvents.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_METADATA_TASK_ID_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_METADATA_TASK_ID_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-flow-messaging_quarkus-metadata-instance-id-key]] [.property-path]##link:#quarkus-flow-messaging_quarkus-metadata-instance-id-key[`+++quarkus.metadata.instance-id.key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.metadata.instance-id.key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The metadata's key name to be used in correlation propagation.
+
+This defines the actual link:https://github.com/cloudevents/spec/blob/v1.0/spec.md#extension-context-attributes[extension context attribute's] key name that will be used in the emitted CloudEvents.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_METADATA_INSTANCE_ID_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_METADATA_INSTANCE_ID_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+|===
+

--- a/docs/modules/ROOT/pages/includes/quarkus-flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow.adoc
@@ -97,6 +97,29 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-devui-backend-storage-enabled]] [.property-path]##link:#quarkus-flow_quarkus-flow-devui-backend-storage-enabled[`+++quarkus.flow.devui.backend.storage.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.devui.backend.storage.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables or disables backend persistence for Dev UI workflow data.
+
+When disabled, no storage is used and no workflow metadata is persisted (DevUI only).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DEVUI_BACKEND_STORAGE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_DEVUI_BACKEND_STORAGE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-devui-storage-type]] [.property-path]##link:#quarkus-flow_quarkus-flow-devui-storage-type[`+++quarkus.flow.devui.storage-type+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.devui.storage-type+++[]
@@ -119,30 +142,7 @@ Environment variable: `+++QUARKUS_FLOW_DEVUI_STORAGE_TYPE+++`
 endif::add-copy-button-to-env-var[]
 --
 a|`in-memory`, `mvstore`
-|`+++mvstore+++`
-
-a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-devui-mvstore-db-path]] [.property-path]##link:#quarkus-flow_quarkus-flow-devui-mvstore-db-path[`+++quarkus.flow.devui.mvstore.db-path+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.devui.mvstore.db-path+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Path to the MVStore database file.
-
-Only used when `storage-type=mvstore`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DEVUI_MVSTORE_DB_PATH+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_DEVUI_MVSTORE_DB_PATH+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++target/flow-devui.mv.db+++`
+|`+++in-memory+++`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-metrics-enabled]] [.property-path]##link:#quarkus-flow_quarkus-flow-metrics-enabled[`+++quarkus.flow.metrics.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.adoc
@@ -1,0 +1,58 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-backend-storage-enabled]] [.property-path]##link:#quarkus-flow_quarkus-backend-storage-enabled[`+++quarkus.backend.storage.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.backend.storage.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables or disables backend persistence for Dev UI workflow data.
+
+When disabled, no storage is used and no workflow metadata is persisted (DevUI only).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_BACKEND_STORAGE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_BACKEND_STORAGE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-storage-type]] [.property-path]##link:#quarkus-flow_quarkus-storage-type[`+++quarkus.storage-type+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.storage-type+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The type of storage to use for workflow instances in dev mode.
+
+ - *in-memory*: Data is stored in memory and lost on restart
+ - *mvstore*: Data is persisted to a file using H2 MVStore
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_STORAGE_TYPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_STORAGE_TYPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`in-memory`, `mvstore`
+|`+++in-memory+++`
+
+|===
+

--- a/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.flow.adoc
@@ -97,6 +97,29 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-devui-backend-storage-enabled]] [.property-path]##link:#quarkus-flow_quarkus-flow-devui-backend-storage-enabled[`+++quarkus.flow.devui.backend.storage.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.devui.backend.storage.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables or disables backend persistence for Dev UI workflow data.
+
+When disabled, no storage is used and no workflow metadata is persisted (DevUI only).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DEVUI_BACKEND_STORAGE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_DEVUI_BACKEND_STORAGE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-devui-storage-type]] [.property-path]##link:#quarkus-flow_quarkus-flow-devui-storage-type[`+++quarkus.flow.devui.storage-type+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.devui.storage-type+++[]
@@ -119,30 +142,7 @@ Environment variable: `+++QUARKUS_FLOW_DEVUI_STORAGE_TYPE+++`
 endif::add-copy-button-to-env-var[]
 --
 a|`in-memory`, `mvstore`
-|`+++mvstore+++`
-
-a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-devui-mvstore-db-path]] [.property-path]##link:#quarkus-flow_quarkus-flow-devui-mvstore-db-path[`+++quarkus.flow.devui.mvstore.db-path+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.devui.mvstore.db-path+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Path to the MVStore database file.
-
-Only used when `storage-type=mvstore`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DEVUI_MVSTORE_DB_PATH+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_DEVUI_MVSTORE_DB_PATH+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++target/flow-devui.mv.db+++`
+|`+++in-memory+++`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-metrics-enabled]] [.property-path]##link:#quarkus-flow_quarkus-flow-metrics-enabled[`+++quarkus.flow.metrics.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/examples/newsletter-drafter/src/main/java/org/acme/newsletter/NewsletterWorkflow.java
+++ b/examples/newsletter-drafter/src/main/java/org/acme/newsletter/NewsletterWorkflow.java
@@ -9,14 +9,11 @@ import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.switchWhenOrElse;
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.toOne;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.quarkiverse.flow.Flow;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.fluent.func.FuncWorkflowBuilder;
-import io.serverlessworkflow.impl.jackson.JsonUtils;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.util.Collection;
 import java.util.Map;
 import org.acme.newsletter.agents.AutoDraftCriticAgent;
 import org.acme.newsletter.agents.HumanEditorAgent;

--- a/examples/newsletter-drafter/src/main/resources/application.properties
+++ b/examples/newsletter-drafter/src/main/resources/application.properties
@@ -53,3 +53,4 @@ mp.messaging.incoming.flow-out-incoming.auto.offset.reset=earliest
 # Enabled it to increase tracing
 quarkus.flow.tracing.enabled=true
 
+quarkus.flow.devui.backend.storage.enabled=true


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the workflow instance management and serialization logic, especially for the Dev UI backend. The main changes include enhanced serialization/deserialization of workflow input/output, improved test coverage, and better integration of object mapping and configuration. These updates ensure that workflow instance data is consistently serialized as JSON, input/output fields are properly exposed, and configuration is more flexible and testable.

**Serialization and Deserialization Improvements:**

* Refactored `FlowInstanceSerializer` and `FlowInstanceDeserializer` to use consistent JSON serialization for workflow input and output, leveraging `JsonUtils.modelToJson` and a new `readWorkflowModel` method for correctness and maintainability. [[1]](diffhunk://#diff-5e39b113cdc952d747f510bc4c768c5bcc003b70a132470853515f990d6b128aL51-R59) [[2]](diffhunk://#diff-3da8308e16fb8a224d8a9c0b73c35da089e257e79bd2db7703cc445c72592a2cL44-R44) [[3]](diffhunk://#diff-3da8308e16fb8a224d8a9c0b73c35da089e257e79bd2db7703cc445c72592a2cL59-R59) [[4]](diffhunk://#diff-3da8308e16fb8a224d8a9c0b73c35da089e257e79bd2db7703cc445c72592a2cL88-L114) [[5]](diffhunk://#diff-3da8308e16fb8a224d8a9c0b73c35da089e257e79bd2db7703cc445c72592a2cR102-R109)
* Added `LifecycleManagementBackendObjectMapperCustomizer` to centralize registration of custom serializers/deserializers for `FlowInstance`, ensuring all object mappers are properly configured.

**Backend and Configuration Refactoring:**

* Refactored `MVStoreWorkflowInstanceStore` to receive its database path and `ObjectMapper` via dependency injection, removing direct config and static initialization, and improving testability and flexibility. [[1]](diffhunk://#diff-badefe50f59bb53e75395e1fd4de5e91c074f84fa2ea8f30511c20176c808050L9-L20) [[2]](diffhunk://#diff-badefe50f59bb53e75395e1fd4de5e91c074f84fa2ea8f30511c20176c808050L29-R65)
* Updated `FlowDevUIProcessor` to register new beans and conditionally enable backend storage and related services based on configuration. [[1]](diffhunk://#diff-0e1d76c26ebca2f24e1b8e30d051e8dc60140a327c1ab403f393c95a213cddcfR5-R9) [[2]](diffhunk://#diff-0e1d76c26ebca2f24e1b8e30d051e8dc60140a327c1ab403f393c95a213cddcfL38-R67)

**API and Data Exposure Changes:**

* Modified `ManagementLifecycleRPCService` to return workflow instances as JSON arrays/objects (using Vert.x `JsonArray`/`JsonObject`) instead of raw Java objects, ensuring correct serialization of input/output fields in API responses.

**Test and Configuration Enhancements:**

* Improved and added tests to verify that workflow instance input/output fields are correctly serialized and exposed, and refactored test configuration to use dedicated properties files and enable backend storage as needed. [[1]](diffhunk://#diff-f94378566ccff2f728330d213f9bd5965e3e229350555ef2b1f8f4dbd3d3076fR3-R11) [[2]](diffhunk://#diff-f94378566ccff2f728330d213f9bd5965e3e229350555ef2b1f8f4dbd3d3076fR28-R32) [[3]](diffhunk://#diff-f94378566ccff2f728330d213f9bd5965e3e229350555ef2b1f8f4dbd3d3076fR131-R164) [[4]](diffhunk://#diff-f6ffcbe152fce8c4cbd3febed8a4421b090c8be0e6dae7526b5ed90b7325abb1L12) [[5]](diffhunk://#diff-f6ffcbe152fce8c4cbd3febed8a4421b090c8be0e6dae7526b5ed90b7325abb1L32-R31) [[6]](diffhunk://#diff-f6ffcbe152fce8c4cbd3febed8a4421b090c8be0e6dae7526b5ed90b7325abb1R138-R139) [[7]](diffhunk://#diff-26f9f60c85cf87976e1574ddc228734c08ca4d4ebb184311e6674f08ed2da133R1-R3)

These changes collectively make the workflow management backend more robust, maintainable, and testable, while ensuring that API consumers receive complete and accurate workflow instance data.

Closes #374 