### PR TITLE
Avoid hardcoding application URI in DevUIJsonRPCTest tests

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/FlowCachedDescriptorDevUIJsonRPCTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/FlowCachedDescriptorDevUIJsonRPCTest.java
@@ -3,6 +3,7 @@ package io.quarkiverse.flow.deployment.test.devui;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -17,10 +18,11 @@ public class FlowCachedDescriptorDevUIJsonRPCTest extends DevUIJsonRPCTest {
     @RegisterExtension
     static final QuarkusDevModeTest devMode = new QuarkusDevModeTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset("quarkus.http.port=0"), "application.properties")
                     .addClasses(DevUIWorkflow.class, CachedDevUIDescriptorObserver.class));
 
     public FlowCachedDescriptorDevUIJsonRPCTest() {
-        super("quarkus-flow", "http://localhost:8080");
+        super("quarkus-flow");
     }
 
     @Test

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/FlowInvokerWorkflowDevUIJsonRPCTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/FlowInvokerWorkflowDevUIJsonRPCTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -22,6 +23,7 @@ public class FlowInvokerWorkflowDevUIJsonRPCTest extends DevUIJsonRPCTest {
     @RegisterExtension
     static final QuarkusDevModeTest devMode = new QuarkusDevModeTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset("quarkus.http.port=0"), "application.properties")
                     .addClasses(
                             AgenticDevUIWorkflow.class,
                             DevUIAgenticServiceBean.class));

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/FlowWorkflowDefinitionDevUIJsonRPCTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/FlowWorkflowDefinitionDevUIJsonRPCTest.java
@@ -3,6 +3,7 @@ package io.quarkiverse.flow.deployment.test.devui;
 import java.util.Map;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ public class FlowWorkflowDefinitionDevUIJsonRPCTest extends DevUIJsonRPCTest {
     @RegisterExtension
     static final QuarkusDevModeTest devMode = new QuarkusDevModeTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset("quarkus.http.port=0"), "application.properties")
                     .addClasses(GreetingResource.class, DevUIWorkflow.class));
 
     private static final WorkflowDefinitionId workflowId = WorkflowDefinitionId.of(new DevUIWorkflow().descriptor());

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/LifecycleManagementDevUIJsonRPCTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/LifecycleManagementDevUIJsonRPCTest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -21,6 +22,7 @@ public class LifecycleManagementDevUIJsonRPCTest extends DevUIJsonRPCTest {
     @RegisterExtension
     static final QuarkusDevModeTest devMode = new QuarkusDevModeTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset("quarkus.http.port=0"), "application.properties")
                     .addClasses(GreetingResource.class, DevUIWorkflow.class));
 
     public LifecycleManagementDevUIJsonRPCTest() {

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/MVStoreWorkflowInstanceStoreDevModeTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/MVStoreWorkflowInstanceStoreDevModeTest.java
@@ -33,6 +33,7 @@ public class MVStoreWorkflowInstanceStoreDevModeTest extends DevUIJsonRPCTest {
                             """
                                     quarkus.flow.devui.storage-type=MVSTORE
                                     quarkus.flow.devui.mvstore.db-path=%s
+                                    quarkus.http.port=0
                                     """.formatted(DB_PATH)),
                             "application.properties"));
 


### PR DESCRIPTION
This pull request updates several test classes to ensure that the HTTP server port is set to zero during test execution, allowing the server to choose a random available port. This change helps prevent port conflicts during parallel test runs and improves test reliability. The main updates involve adding `quarkus.http.port=0` to the test `application.properties` in various DevUI-related workflow tests.

**Test configuration improvements:**

* Added `.addAsResource(new StringAsset("quarkus.http.port=0"), "application.properties")` to the test archive setup in the following test classes to ensure the HTTP server uses a random port:
  - `FlowCachedDescriptorDevUIJsonRPCTest` [[1]](diffhunk://#diff-ab7b05f623da66cd2ca10bc269213262a9650af7312d5f94e3d8f394454b650bR6) [[2]](diffhunk://#diff-ab7b05f623da66cd2ca10bc269213262a9650af7312d5f94e3d8f394454b650bR21-R25)
  - `FlowInvokerWorkflowDevUIJsonRPCTest` [[1]](diffhunk://#diff-4cb9ef623134a353d84e07a382a9fd71d3824edf3196254bd96e30f2ff8d8c5eR10) [[2]](diffhunk://#diff-4cb9ef623134a353d84e07a382a9fd71d3824edf3196254bd96e30f2ff8d8c5eR26)
  - `FlowWorkflowDefinitionDevUIJsonRPCTest` [[1]](diffhunk://#diff-105d4583516614c2f3c983ef71e9eb3b3523cd4c1ad5f13372de4c41a2567cafR6) [[2]](diffhunk://#diff-105d4583516614c2f3c983ef71e9eb3b3523cd4c1ad5f13372de4c41a2567cafR23)
  - `LifecycleManagementDevUIJsonRPCTest` [[1]](diffhunk://#diff-f94378566ccff2f728330d213f9bd5965e3e229350555ef2b1f8f4dbd3d3076fR8) [[2]](diffhunk://#diff-f94378566ccff2f728330d213f9bd5965e3e229350555ef2b1f8f4dbd3d3076fR25)
  - `MVStoreWorkflowInstanceStoreDevModeTest`

* In `FlowCachedDescriptorDevUIJsonRPCTest`, removed the explicit base URL from the superclass constructor, as the port is now dynamically assigned.

Closes #376 