### PR TITLE
Update grafana dashboard to use grafana variables instead hardcoded

### DIFF
--- a/core/runtime/src/main/resources/META-INF/grafana/grafana-dashboard-quarkus-flow.json
+++ b/core/runtime/src/main/resources/META-INF/grafana/grafana-dashboard-quarkus-flow.json
@@ -334,7 +334,7 @@
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (workflow) (\n  rate(quarkus_flow_workflow_duration_seconds_sum[5m])\n)\n/\nsum by (workflow) (\n  rate(quarkus_flow_workflow_duration_seconds_count[5m])\n)\n",
+          "expr": "sum by (workflow) (\n  rate(quarkus_flow_workflow_duration_seconds_sum[$__rate_interval])\n)\n/\nsum by (workflow) (\n  rate(quarkus_flow_workflow_duration_seconds_count[$__rate_interval])\n)\n",
           "format": "time_series",
           "legendFormat": "{{workflow}}",
           "range": true,
@@ -431,7 +431,7 @@
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max by (workflow) (\n  quarkus_flow_workflow_duration_seconds_max\n)\n",
+          "expr": "max by (workflow) (\n  quarkus_flow_workflow_duration_seconds_max\n) > 0\n",
           "format": "time_series",
           "legendFormat": "{{workflow}}",
           "range": true,
@@ -553,7 +553,7 @@
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(\n  0.95,\n  sum by (le, workflow) (\n    rate(quarkus_flow_workflow_duration_seconds_bucket[5m])\n  )\n)\n",
+          "expr": "histogram_quantile(\n  0.95,\n  sum by (le, workflow) (\n    rate(quarkus_flow_workflow_duration_seconds_bucket[$__rate_interval])\n  )\n)\n",
           "format": "time_series",
           "legendFormat": "{{workflow}}",
           "range": true,


### PR DESCRIPTION
This pull request updates several Prometheus expressions in the Grafana dashboard configuration to improve flexibility and accuracy in workflow duration metrics. The changes primarily focus on making the dashboard queries more dynamic and ensuring that only relevant data is displayed.

**Grafana dashboard query improvements:**

* Updated queries to use the dynamic interval variable (`$__rate_interval`) instead of a fixed `5m` window, allowing dashboard users to control the time range for rate calculations. (`grafana-dashboard-quarkus-flow.json`, [[1]](diffhunk://#diff-d7871a3490666bac175b4c55d8163ac787afea0e654f33d52b5974fc564201a8L337-R337) [[2]](diffhunk://#diff-d7871a3490666bac175b4c55d8163ac787afea0e654f33d52b5974fc564201a8L556-R556)
* Modified the maximum workflow duration query to only show values greater than zero, filtering out any non-relevant results. (`grafana-dashboard-quarkus-flow.json`, [core/runtime/src/main/resources/META-INF/grafana/grafana-dashboard-quarkus-flow.jsonL434-R434](diffhunk://#diff-d7871a3490666bac175b4c55d8163ac787afea0e654f33d52b5974fc564201a8L434-R434))

Closes #399 