### PR TITLE
Fix #421 - Update scheduler test to use supported interval

### DIFF
--- a/scheduler/integration-tests/src/main/flow/every-start.yaml
+++ b/scheduler/integration-tests/src/main/flow/every-start.yaml
@@ -5,7 +5,7 @@ document:
   version: '0.1.0'
 schedule:
   every:
-      milliseconds: 10
+      seconds: 1
 do: 
   - recovered:
       set:

--- a/scheduler/integration-tests/src/test/java/io/quarkiverse/flow/scheduler/test/FlowSchedulerTest.java
+++ b/scheduler/integration-tests/src/test/java/io/quarkiverse/flow/scheduler/test/FlowSchedulerTest.java
@@ -41,11 +41,13 @@ public class FlowSchedulerTest {
 
     @Test
     void testEvery() {
+        // Workflow is scheduled every 1 second, wait for first instance with buffer for CI delays
         await()
-                .atMost(Duration.ofSeconds(3).plus(Duration.ofMillis(200)))
+                .atMost(Duration.ofSeconds(5))
                 .until(() -> everyDefinition.scheduledInstances().size() == 1);
+        // Wait for second instance (1s interval + buffer)
         await()
-                .atMost(Duration.ofSeconds(3).plus(Duration.ofMillis(200)))
+                .atMost(Duration.ofSeconds(5))
                 .until(() -> everyDefinition.scheduledInstances().size() == 2);
     }
 


### PR DESCRIPTION
## Summary

Fixes #421 by updating FlowSchedulerTest to use a 1-second interval instead of 10ms, which is below Quarkus Scheduler's minimum supported value.

## Problem

The test workflow `every-start.yaml` was configured with a 10ms interval:
```yaml
schedule:
  every:
    milliseconds: 10
```

This triggered a warning from Quarkus Scheduler:
```
WARN [io.quarkus.scheduler.runtime.SimpleScheduler] An every() value less than 1000 ms is not supported - the scheduled job will be executed with a delay: null
```

The unpredictable behavior caused intermittent CI failures.

## Solution

- Updated workflow to use `seconds: 1` interval
- Increased test timeouts from 3.2s to 5s to account for CI delays
- Added explanatory comments

## Test Results

All scheduler tests pass consistently:
```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 1
```

No more scheduler warnings in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)