### PR TITLE
docs: add Java example for invoking subflows

### DIFF
--- a/docs/modules/ROOT/pages/quarkus-flow-cookbook.adoc
+++ b/docs/modules/ROOT/pages/quarkus-flow-cookbook.adoc
@@ -338,6 +338,10 @@ do:
 == 11. Invoking Subflows
 To keep your definitions clean and modular, complex logic can be broken down into smaller, reusable workflows using the `run` directive.
 
+[tabs]
+====
+YAML::
++
 [source,yaml]
 ----
 document:
@@ -355,6 +359,22 @@ do:
           input:
             customer: .user
 ----
+
+Java::
++
+[source,java]
+----
+import io.serverlessworkflow.api.fluent.FuncWorkflowBuilder;
+
+var workflow = FuncWorkflowBuilder.newWorkflow("run-subflow")
+    .startWith(
+        step("registerCustomer")
+            .runWorkflow("test", "register-customer", "0.1.0")
+            .input("customer", from(".user"))
+    )
+    .build();
+----
+====
 
 == 12. Business Logic Error Handling (`try` / `catch`)
 While transient infrastructure errors are handled by Quarkus Flow's built-in Fault Tolerance, the workflow DSL's `try` and `catch` constructs are specifically designed for compensatory business logic.


### PR DESCRIPTION
## Description

Adds a Java DSL example for the "Invoking Subflows" section in the cookbook.

Previously, this section only included a YAML example. This PR converts it into a tabbed format (YAML + Java) and adds a corresponding Java DSL implementation using FuncWorkflowBuilder.

Fixes #428

## Changes

<!-- List the main changes in this PR -->

- Converted Section 11 (Invoking Subflows) to tabbed format
- Added Java DSL example alongside existing YAML
- Kept YAML unchanged for consistency

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] Tested manually

### Manual Testing

- Verified the documentation renders correctly
- Confirmed tabbed format (YAML + Java) is consistent with other sections

## Checklist

Before submitting this PR, please ensure:

- [ ] I ran the full build with integration tests locally
- [x] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [x] Documentation has been updated (if user-facing changes)
- [x] Commit messages are clear and follow conventional commits style
- [x] I have read and followed the Contributing Guide
- [x] I have read and comply with the LLM Usage Policy (if applicable)

## Additional Notes

This change improves developer experience by providing a Java DSL equivalent for subflow invocation.