### PR TITLE
Refactor(persistence): Override all Redis-based ITs to Valkey image, update docs

### DIFF
--- a/docs/modules/ROOT/pages/persistence.adoc
+++ b/docs/modules/ROOT/pages/persistence.adoc
@@ -53,6 +53,8 @@ Configure the Redis connection in your `application.properties`:
 quarkus.redis.hosts=redis://localhost:6379
 ----
 
+Note: Our integration tests use Valkey image instead.
+
 === Option B: JPA (Relational Databases)
 JPA allows you to store workflow state in a standard relational database (e.g., PostgreSQL, MySQL). This is ideal if your enterprise architecture already relies heavily on a relational database.
 

--- a/docs/modules/ROOT/pages/persistence.adoc
+++ b/docs/modules/ROOT/pages/persistence.adoc
@@ -53,7 +53,7 @@ Configure the Redis connection in your `application.properties`:
 quarkus.redis.hosts=redis://localhost:6379
 ----
 
-Note: Our integration tests use Valkey image instead.
+NOTE: Our integration tests use Valkey image instead.
 
 === Option B: JPA (Relational Databases)
 JPA allows you to store workflow state in a standard relational database (e.g., PostgreSQL, MySQL). This is ideal if your enterprise architecture already relies heavily on a relational database.

--- a/examples/durable-workflows-k8s/src/main/resources/application.properties
+++ b/examples/durable-workflows-k8s/src/main/resources/application.properties
@@ -6,3 +6,6 @@ quarkus.flow.durable.kube.pool.name=durable-flow
 
 org.acme.flow.durable.kube.sleep-seconds=30
 org.acme.flow.durable.kube.service-host=http://localhost:8080
+
+# Overriding the default Redis image with Valkey
+quarkus.redis.devservices.image-name=valkey/valkey:latest

--- a/persistence/redis/integration-tests/src/main/resources/application.properties
+++ b/persistence/redis/integration-tests/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# Overriding the default Redis image with Valkey
+quarkus.redis.devservices.image-name=valkey/valkey:latest


### PR DESCRIPTION
## Description

Pull request overrides Redis image to Valkey for `Persistence :: Redis IT` and `Examples :: Durable Workflows on Kubernete`, updates corresponding docs mentioning usage of Valkey image.

Fixes issue #418.

## Changes

- Adds `application.properties` to `Persistence :: Redis IT` and `Examples :: Durable Workflows on Kubernete` to replace Redis image with Valkey for internal integration testing
- Updates [corresponding](https://docs.quarkiverse.io/quarkus-flow/dev/persistence.html#_option_a_redis_recommended_for_distributed_workloads) page, noting about Valkey usage 

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] Tested manually (describe below if applicable)

### Manual Testing
1. Run `./mvnw quarkus:dev` or `./mvnw clean install -DskipITs=false`
2. Run `docker ps` and verify that during particular IT tests Docker is running `valkey/valkey:latest` image instead of `redis:7`

## Checklist

Before submitting this PR, please ensure:

- [x] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [x] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [x] Documentation has been updated (if user-facing changes)
- [x] Commit messages are clear and follow conventional commits style
- [x] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional notes

Please, double-check for any potentially missed Redis image uses that I didn't cover.