### PR TITLE
Use $workflow.input for properly handling request

### DIFF
--- a/examples/suspend-resume-abort/src/main/flow/switch-loop-wait.yaml
+++ b/examples/suspend-resume-abort/src/main/flow/switch-loop-wait.yaml
@@ -11,7 +11,7 @@ do:
   - looping:
        switch:
          - loopCount:
-             when: .count < (.maxCount // 10000)
+             when: .count < ($workflow.input.maxCount // 10000)
              then: waitABit
          - default:
              then: exit

--- a/examples/suspend-resume-abort/src/main/java/org/acme/flow/FlowAPIResource.java
+++ b/examples/suspend-resume-abort/src/main/java/org/acme/flow/FlowAPIResource.java
@@ -1,12 +1,10 @@
 package org.acme.flow;
 
-import io.quarkiverse.flow.Flow;
 import io.quarkiverse.flow.internal.WorkflowApplicationReady;
 import io.serverlessworkflow.impl.WorkflowDefinition;
 import io.serverlessworkflow.impl.WorkflowInstance;
 import io.serverlessworkflow.impl.persistence.PersistenceInstanceHandlers;
 import io.smallrye.common.annotation.Identifier;
-import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;


### PR DESCRIPTION
There was a typo in the yaml file, the final comparison should be done against the initial input, not the current model. 
With previous version of the yaml file, regardless the provided `maxCount`, it never finish till the count reach 10000