### PR TITLE
Use WireMock instead mockwebserver for mocking REST

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -86,12 +86,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver</artifactId>
-            <version>${mockwebserver.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
             <scope>test</scope>
@@ -111,6 +105,10 @@
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-fault-tolerance-standalone</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
         </dependency>
     </dependencies>
 

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/http/HttpFlowClientConfigTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/http/HttpFlowClientConfigTest.java
@@ -1,11 +1,15 @@
 package io.quarkiverse.flow.deployment.test.http;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static io.quarkiverse.flow.providers.MetadataPropagationRequestDecorator.X_FLOW_INSTANCE_ID;
 import static io.quarkiverse.flow.providers.MetadataPropagationRequestDecorator.X_FLOW_TASK_ID;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.util.Map;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -15,31 +19,37 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
 import io.quarkus.arc.Arc;
 import io.quarkus.test.QuarkusUnitTest;
 import io.serverlessworkflow.impl.WorkflowDefinition;
 import io.serverlessworkflow.impl.WorkflowInstance;
 import io.serverlessworkflow.impl.WorkflowModel;
 import io.smallrye.common.annotation.Identifier;
-import mockwebserver3.MockResponse;
-import mockwebserver3.MockWebServer;
-import mockwebserver3.RecordedRequest;
-import okhttp3.Headers;
 
 public class HttpFlowClientConfigTest {
 
-    private static MockWebServer mockServer;
+    private static WireMockServer wireMockServer;
 
     @BeforeAll
-    static void startMockServer() throws IOException {
-        // Use a fixed port so we can wire it via overrideConfigKey
-        mockServer = new MockWebServer();
-        mockServer.start(1080);
+    static void startMockServer() {
+        wireMockServer = new WireMockServer(options().port(1080));
+        wireMockServer.start();
+
+        wireMockServer.stubFor(post(urlEqualTo("/echo"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{ \"message\": \"ok\" }")));
     }
 
     @AfterAll
     static void stopMockServer() {
-        mockServer.close();
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
     }
 
     @RegisterExtension
@@ -53,11 +63,7 @@ public class HttpFlowClientConfigTest {
             .overrideConfigKey("quarkus.flow.http.client.user-agent", "HttpFlowClientConfigTest");
 
     @Test
-    void http_client_uses_flow_http_config() throws InterruptedException {
-        mockServer.enqueue(new MockResponse(200, Headers.of(Map.of("Content-Type", "application/json")), """
-                { "message": "ok" }
-                """));
-
+    void http_client_uses_flow_http_config() {
         WorkflowDefinition definition = Arc.container()
                 .instance(WorkflowDefinition.class, Identifier.Literal.of(HttpRestFlow.class.getName()))
                 .get();
@@ -68,20 +74,19 @@ public class HttpFlowClientConfigTest {
         WorkflowModel model = instance.start().join();
 
         String out = model.as(String.class).orElseThrow();
-        assertEquals("{\"message\":\"ok\"}", out);
+        assertThat(out).isEqualTo("{\"message\":\"ok\"}");
 
-        RecordedRequest recordedRequest = mockServer.takeRequest();
-        assertEquals("POST", recordedRequest.getMethod());
-        assertEquals("/echo", recordedRequest.getUrl().uri().getPath());
+        // Verify the request was made with the correct method and path
+        wireMockServer.verify(1, postRequestedFor(urlEqualTo("/echo"))
+                .withHeader("X-Flow-Client", equalTo("flow-default")));
 
-        assertEquals(1, mockServer.getRequestCount());
-        assertEquals("flow-default", recordedRequest.getHeaders().get("X-Flow-Client"));
+        // Get the logged request to verify additional headers
+        LoggedRequest recordedRequest = wireMockServer.findAll(postRequestedFor(urlEqualTo("/echo"))).get(0);
 
-        String xFlowInstanceId = recordedRequest.getHeaders().get(X_FLOW_INSTANCE_ID);
-        assertEquals(instance.id(), xFlowInstanceId);
+        String xFlowInstanceId = recordedRequest.getHeader(X_FLOW_INSTANCE_ID);
+        assertThat(xFlowInstanceId).isEqualTo(instance.id());
 
-        String xFlowTaskId = recordedRequest.getHeaders().get(X_FLOW_TASK_ID);
-        assertNotNull(xFlowTaskId);
-
+        String xFlowTaskId = recordedRequest.getHeader(X_FLOW_TASK_ID);
+        assertThat(xFlowTaskId).isNotNull();
     }
 }

--- a/core/integration-tests/pom.xml
+++ b/core/integration-tests/pom.xml
@@ -12,7 +12,6 @@
 
     <properties>
         <skipITs>true</skipITs>
-        <version.wiremock-jre8-standalone>2.35.2</version.wiremock-jre8-standalone>
     </properties>
 
     <dependencies>
@@ -76,20 +75,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver3</artifactId>
-            <version>${mockwebserver.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>${version.wiremock-jre8-standalone}</version>
             <scope>test</scope>
         </dependency>
 
@@ -99,6 +86,11 @@
             <artifactId>quarkus-flow-deployment</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
         </dependency>
     </dependencies>
 

--- a/examples/langchain4j-agentic-workflow/pom.xml
+++ b/examples/langchain4j-agentic-workflow/pom.xml
@@ -17,10 +17,9 @@
         <quarkus.flow.version>1.0.0-SNAPSHOT</quarkus.flow.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.5</surefire-plugin.version>
-
         <io.quarkiverse.langchain4j.version>1.8.4</io.quarkiverse.langchain4j.version>
         <version.assertj>3.27.7</version.assertj>
-        <version.wiremock-jre8-standalone>2.35.2</version.wiremock-jre8-standalone>
+        <org.wiremock.version>3.13.2</org.wiremock.version>
     </properties>
 
     <dependencyManagement>
@@ -71,9 +70,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>${version.wiremock-jre8-standalone}</version>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>${org.wiremock.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/examples/petstore-openapi/pom.xml
+++ b/examples/petstore-openapi/pom.xml
@@ -21,10 +21,8 @@
         <quarkus.flow.version>1.0.0-SNAPSHOT</quarkus.flow.version>
         <surefire-plugin.version>3.5.5</surefire-plugin.version>
         <failsafe-plugin.version>3.5.4</failsafe-plugin.version>
-
         <version.assertj>3.27.7</version.assertj>
-        <version.wiremock-jre8-standalone>2.35.2</version.wiremock-jre8-standalone>
-
+        <org.wiremock.version>3.13.2</org.wiremock.version>
         <skipITs>true</skipITs>
     </properties>
 
@@ -67,9 +65,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>${version.wiremock-jre8-standalone}</version>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>${org.wiremock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/langchain4j/integration-tests/pom.xml
+++ b/langchain4j/integration-tests/pom.xml
@@ -11,7 +11,6 @@
 
     <properties>
         <skipITs>true</skipITs>
-        <version.wiremock-jre8-standalone>2.35.2</version.wiremock-jre8-standalone>
     </properties>
 
     <dependencies>
@@ -42,9 +41,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>${version.wiremock-jre8-standalone}</version>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Forced dependency to run mvn in parallel -->

--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,10 @@
         <!-- Tests and Docs -->
         <org.assertj.version>3.27.7</org.assertj.version>
         <quarkus-antora.version>3.25.0</quarkus-antora.version>
-        <mockserver.version>5.15.0</mockserver.version>
-        <mockwebserver.version>5.3.2</mockwebserver.version>
         <version.org.jacoco>0.8.14</version.org.jacoco>
         <io.quarkiverse.playwright>2.3.3</io.quarkiverse.playwright>
         <com.h2database.version>2.4.240</com.h2database.version>
+        <org.wiremock.version>3.13.2</org.wiremock.version>
     </properties>
 
     <dependencyManagement>
@@ -97,6 +96,12 @@
                 <groupId>com.h2database</groupId>
                 <artifactId>h2-mvstore</artifactId>
                 <version>${com.h2database.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wiremock</groupId>
+                <artifactId>wiremock</artifactId>
+                <version>${org.wiremock.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This pull request migrates HTTP mocking in tests from `mockwebserver` to `wiremock`, updates related dependencies, and adjusts test code accordingly. It also includes minor configuration improvements. The main themes are test framework migration, dependency cleanup, and configuration enhancements.

**Test Framework Migration:**

* Replaced `mockwebserver` with `wiremock` in `HttpFlowClientConfigTest.java`, updating imports, setup/teardown logic, and test assertions to use `WireMockServer` and `WireMock` APIs instead of `MockWebServer`. (`core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/http/HttpFlowClientConfigTest.java`) [[1]](diffhunk://#diff-a7bc79e9ae1eac7eb05f4a2c8aa73d955a8808738d9ee7248cd80ec638e75cafR3-L8) [[2]](diffhunk://#diff-a7bc79e9ae1eac7eb05f4a2c8aa73d955a8808738d9ee7248cd80ec638e75cafR22-R52) [[3]](diffhunk://#diff-a7bc79e9ae1eac7eb05f4a2c8aa73d955a8808738d9ee7248cd80ec638e75cafL56-R66) [[4]](diffhunk://#diff-a7bc79e9ae1eac7eb05f4a2c8aa73d955a8808738d9ee7248cd80ec638e75cafL71-R90)

**Dependency and Version Management:**

* Removed `mockwebserver` and `mockwebserver3` dependencies from `core/deployment/pom.xml` and `core/integration-tests/pom.xml`; added `wiremock-jre8-standalone` as a test dependency in `core/deployment/pom.xml`. (`core/deployment/pom.xml`, `core/integration-tests/pom.xml`) [[1]](diffhunk://#diff-e68de4ebf5bc0137c10977474f21321913684eb3cc393978b7f7a291ad401a10L88-L93) [[2]](diffhunk://#diff-e68de4ebf5bc0137c10977474f21321913684eb3cc393978b7f7a291ad401a10R109-R114) [[3]](diffhunk://#diff-0aab6358c974db26f1d4b600569b4c9a7adcc2debe94966ffd92e5a5dcd602f2L78-L83)
* Cleaned up unused `wiremock-jre8-standalone` version properties from module-level POMs and added it to the root `pom.xml` for centralized version management. (`core/integration-tests/pom.xml`, `examples/langchain4j-agentic-workflow/pom.xml`, `langchain4j/integration-tests/pom.xml`, `pom.xml`) [[1]](diffhunk://#diff-0aab6358c974db26f1d4b600569b4c9a7adcc2debe94966ffd92e5a5dcd602f2L15) [[2]](diffhunk://#diff-4636e5c903802c5102504f5ad0f0b079c739c51155748d9654410040decc39f7L23) [[3]](diffhunk://#diff-68d9a8fa7e3ed38763330ccef55b75e7d356a27c24dce631d0b0adce67ccd09aL14) [[4]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R54)

**Configuration Improvements:**

* Set `quarkus.http.test-port=0` in `examples/http-basic-auth` test properties to enable dynamic port assignment for tests. (`examples/http-basic-auth/src/test/resources/application.properties`)

Closes #367 