### PR TITLE
[NO-ISSUE] Solve issue related main/test flow resources

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/DiscoveredWorkflowBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/DiscoveredWorkflowBuildItem.java
@@ -25,13 +25,15 @@ public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
     }
 
     private Path workflowPath;
+    private String relativeFlowPath;
     private WorkflowDefinitionId workflowDefinitionId;
     private String regularIdentifier;
     private String className;
     private final From from;
 
-    private DiscoveredWorkflowBuildItem(Path workflowPath, Workflow workflow) {
+    private DiscoveredWorkflowBuildItem(Path workflowPath, Workflow workflow, String relativeFlowPath) {
         this.workflowPath = workflowPath;
+        this.relativeFlowPath = relativeFlowPath;
         this.workflowDefinitionId = WorkflowDefinitionId.of(workflow);
         this.regularIdentifier = WorkflowNameUtils.yamlDescriptorIdentifier(
                 workflowDefinitionId.namespace(),
@@ -49,10 +51,11 @@ public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
      *
      * @param workflowPath the path to the workflow specification file
      * @param workflow the parsed workflow model
+     * @param relativeFlowPath the relative path from the flow directory
      * @return a new {@link DiscoveredWorkflowBuildItem}
      */
-    public static DiscoveredWorkflowBuildItem fromSpec(Path workflowPath, Workflow workflow) {
-        return new DiscoveredWorkflowBuildItem(workflowPath, workflow);
+    public static DiscoveredWorkflowBuildItem fromSpec(Path workflowPath, Workflow workflow, String relativeFlowPath) {
+        return new DiscoveredWorkflowBuildItem(workflowPath, workflow, relativeFlowPath);
     }
 
     /**
@@ -111,5 +114,17 @@ public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
      */
     public boolean fromSpec() {
         return From.SPEC == this.from;
+    }
+
+    /**
+     * Returns the relative path of the workflow specification file from the flow directory.
+     * <p>
+     * This is used for test resource override: a test workflow file overrides
+     * a main workflow file only if they have the same relative path.
+     *
+     * @return the relative flow path, or {@code null} if discovered from source
+     */
+    public String relativeFlowPath() {
+        return relativeFlowPath;
     }
 }

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowCollectorProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowCollectorProcessor.java
@@ -58,33 +58,48 @@ public class FlowCollectorProcessor {
     }
 
     /**
-     * Resolves the flow resource path based on the configured path and whether we want test or main resources.
+     * Resolves the main flow resource path based on the output directory and configured path.
      * <p>
-     * The configured path (e.g., {@code src/main/flow}) is relative to main resources.
-     * When {@code isTestResources=true}, the equivalent test resources path is computed
-     * by replacing {@code src/main/} with {@code src/test/} (e.g., {@code src/test/flow}).
+     * If the configured path is absolute, it is returned as-is. Otherwise, it is resolved
+     * relative to the module root directory (derived from the output directory).
      *
      * @param outputDir the output directory from OutputTargetBuildItem
      * @param flowDir the configured flow directory path (relative to main resources)
-     * @param launchMode the current launch mode to determine if we are in test mode
-     * @return the resolved flow resource path
+     * @return the resolved main flow resource path
      */
-    private static Path resolveFlowResourceDir(Path outputDir, Path flowDir, LaunchMode launchMode) {
+    private static Path resolveMainFlowResourceDir(Path outputDir, Path flowDir) {
         if (flowDir.isAbsolute()) {
             return flowDir;
         }
         Path moduleRoot = findModuleRootFromTarget(outputDir);
+        return moduleRoot.resolve(flowDir).normalize();
+    }
 
-        if (launchMode == LaunchMode.TEST) {
-            // Convert main resources path to test resources path
-            // e.g., src/main/flow -> src/test/flow
-            //       src/main/workflows/custom -> src/test/workflows/custom
-            Path flowDirNormalized = flowDir.normalize();
-            Path srcMain = Paths.get("src", "main");
-            if (flowDirNormalized.startsWith(srcMain)) {
-                Path relative = srcMain.relativize(flowDirNormalized);
-                return moduleRoot.resolve(Paths.get("src", "test").resolve(relative)).normalize();
-            }
+    /**
+     * Resolves the test flow resource path based on the output directory and configured path.
+     * <p>
+     * If the configured path is absolute, it is returned as-is. Otherwise, it is resolved
+     * relative to the module root directory and converted to test resources path
+     * by replacing {@code src/main/} with {@code src/test/} (e.g., {@code src/test/flow}).
+     *
+     * @param outputDir the output directory from OutputTargetBuildItem
+     * @param flowDir the configured flow directory path (relative to main resources)
+     * @return the resolved test flow resource path
+     */
+    private static Path resolveTestFlowResourceDir(Path outputDir, Path flowDir) {
+        if (flowDir.isAbsolute()) {
+            return flowDir;
+        }
+        Path moduleRoot = findModuleRootFromTarget(outputDir);
+        
+        // Convert main resources path to test resources path
+        // e.g., src/main/flow -> src/test/flow
+        //       src/main/workflows/custom -> src/test/workflows/custom
+        Path flowDirNormalized = flowDir.normalize();
+        Path srcMain = Paths.get("src", "main");
+        if (flowDirNormalized.startsWith(srcMain)) {
+            Path relative = srcMain.relativize(flowDirNormalized);
+            return moduleRoot.resolve(Paths.get("src", "test").resolve(relative)).normalize();
         }
 
         return moduleRoot.resolve(flowDir).normalize();
@@ -143,8 +158,8 @@ public class FlowCollectorProcessor {
         Set<String> collectedInTest = new HashSet<>();
 
         if (launchMode.getLaunchMode() == LaunchMode.TEST) {
-            Path testFlowDir = resolveFlowResourceDir(
-                    outputTarget.getOutputDirectory(), flowDir, launchMode.getLaunchMode());
+            Path testFlowDir = resolveTestFlowResourceDir(
+                    outputTarget.getOutputDirectory(), flowDir);
 
             if (Files.exists(testFlowDir)) {
                 for (DiscoveredWorkflowBuildItem item : collectWorkflowFileData(testFlowDir)) {
@@ -155,8 +170,8 @@ public class FlowCollectorProcessor {
         }
 
         // Scan main resources (lower priority - skip files that exist in test resources with same relative path)
-        Path mainFlowDir = resolveFlowResourceDir(
-                outputTarget.getOutputDirectory(), flowDir, LaunchMode.NORMAL);
+        Path mainFlowDir = resolveMainFlowResourceDir(
+                outputTarget.getOutputDirectory(), flowDir);
 
         if (Files.exists(mainFlowDir)) {
             for (DiscoveredWorkflowBuildItem collectedInMain : collectWorkflowFileData(mainFlowDir)) {

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowCollectorProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowCollectorProcessor.java
@@ -6,9 +6,12 @@ import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 
 import org.jboss.jandex.ClassInfo;
 import org.slf4j.Logger;
@@ -18,10 +21,11 @@ import io.quarkiverse.flow.config.FlowDefinitionsConfig;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.runtime.LaunchMode;
 import io.serverlessworkflow.api.WorkflowReader;
 import io.serverlessworkflow.api.types.Workflow;
-import io.serverlessworkflow.impl.WorkflowDefinitionId;
 
 /**
  * Processor responsible for reading Workflow definitions and producing necessary build items.
@@ -53,37 +57,60 @@ public class FlowCollectorProcessor {
         return outputDir;
     }
 
-    private static Set<DiscoveredWorkflowBuildItem> collectUniqueWorkflowFileData(
-            Path flowDir) {
-        Set<DiscoveredWorkflowBuildItem> items = new HashSet<>();
+    /**
+     * Resolves the flow resource path based on the configured path and whether we want test or main resources.
+     * <p>
+     * The configured path (e.g., {@code src/main/flow}) is relative to main resources.
+     * When {@code isTestResources=true}, the equivalent test resources path is computed
+     * by replacing {@code src/main/} with {@code src/test/} (e.g., {@code src/test/flow}).
+     *
+     * @param outputDir the output directory from OutputTargetBuildItem
+     * @param configuredPath the configured flow directory path (relative to main resources)
+     * @param isTestResources whether to resolve test resources path instead of main
+     * @return the resolved flow resource path
+     */
+    private static Path resolveFlowResourcePath(Path outputDir, Path configuredPath, boolean isTestResources) {
+        if (configuredPath.isAbsolute()) {
+            return configuredPath;
+        }
+        Path moduleRoot = findModuleRootFromTarget(outputDir);
+
+        if (isTestResources) {
+            // Convert main resources path to test resources path
+            // e.g., src/main/flow -> src/test/flow
+            //       src/main/workflows/custom -> src/test/workflows/custom
+            // Normalize to forward slashes for cross-platform compatibility
+            String pathStr = configuredPath.toString().replace('\\', '/');
+            if (pathStr.startsWith("src/main/")) {
+                return moduleRoot.resolve(Paths.get(pathStr.replace("src/main/", "src/test/"))).normalize();
+            }
+        }
+
+        return moduleRoot.resolve(configuredPath).normalize();
+    }
+
+    private static List<DiscoveredWorkflowBuildItem> collectWorkflowFileData(Path flowDir) {
+        List<DiscoveredWorkflowBuildItem> items = new ArrayList<>();
 
         try (var stream = Files.walk(flowDir)) {
             stream.filter(file -> Files.isRegularFile(file) && SUPPORTED_WORKFLOW_FILE_EXTENSIONS.stream()
                     .anyMatch(ext -> file.getFileName().toString().endsWith(ext)))
-                    .forEach(consumeWorkflowFile(items));
+                    .forEach(file -> {
+                        try {
+                            Workflow workflow = WorkflowReader.readWorkflow(file);
+                            String relativePath = flowDir.relativize(file).toString();
+                            items.add(DiscoveredWorkflowBuildItem.fromSpec(file, workflow, relativePath));
+                        } catch (IOException e) {
+                            LOG.error("Failed to parse workflow file at path: {}", file, e);
+                            throw new UncheckedIOException("Error while parsing workflow file: " + file, e);
+                        }
+                    });
         } catch (IOException e) {
             LOG.error("Failed to scan flow resources in path: {}", flowDir, e);
             throw new UncheckedIOException(
                     "Error while scanning flow resources in path: " + flowDir, e);
         }
         return items;
-    }
-
-    private static Consumer<Path> consumeWorkflowFile(Set<DiscoveredWorkflowBuildItem> workflowsSet) {
-        return file -> {
-            try {
-                Workflow workflow = WorkflowReader.readWorkflow(file);
-                DiscoveredWorkflowBuildItem buildItem = DiscoveredWorkflowBuildItem.fromSpec(file, workflow);
-                if (!workflowsSet.add(buildItem)) {
-                    WorkflowDefinitionId id = buildItem.workflowDefinitionId();
-                    throw new IllegalStateException(String.format(
-                            "Duplicate workflow detected %s", id));
-                }
-            } catch (IOException e) {
-                LOG.error("Failed to parse workflow file at path: {}", file, e);
-                throw new UncheckedIOException("Error while parsing workflow file: " + file, e);
-            }
-        };
     }
 
     /**
@@ -105,17 +132,54 @@ public class FlowCollectorProcessor {
      */
     @BuildStep
     public void collectUniqueWorkflowFileData(OutputTargetBuildItem outputTarget,
+            LaunchModeBuildItem launchMode,
             FlowDefinitionsConfig flowDefinitionsConfig,
             BuildProducer<DiscoveredWorkflowBuildItem> workflows) {
 
         final Path configuredPath = Paths.get(flowDefinitionsConfig.dir().orElse(FlowDefinitionsConfig.DEFAULT_FLOW_DIR));
-        final Path flowResourcesPath = configuredPath.isAbsolute()
-                ? configuredPath
-                : findModuleRootFromTarget(outputTarget.getOutputDirectory()).resolve(configuredPath).normalize();
 
-        if (Files.exists(flowResourcesPath)) {
-            Set<DiscoveredWorkflowBuildItem> uniqueBuildItems = collectUniqueWorkflowFileData(flowResourcesPath);
-            uniqueBuildItems.forEach(workflows::produce);
+        Map<String, DiscoveredWorkflowBuildItem> uniqueWorkflows = new HashMap<>();
+        Set<String> testRelativePaths = new HashSet<>();
+
+        // In test mode, scan test resources first (higher priority)
+        if (launchMode.getLaunchMode() == LaunchMode.TEST) {
+            Path testResourcesPath = resolveFlowResourcePath(
+                    outputTarget.getOutputDirectory(), configuredPath, true);
+            if (Files.exists(testResourcesPath)) {
+                for (DiscoveredWorkflowBuildItem testItem : collectWorkflowFileData(testResourcesPath)) {
+                    String identifier = testItem.regularIdentifier();
+                    if (uniqueWorkflows.containsKey(identifier)) {
+                        throw new IllegalStateException(String.format(
+                                "Duplicate workflow detected %s", testItem.workflowDefinitionId()));
+                    }
+                    uniqueWorkflows.put(identifier, testItem);
+                    testRelativePaths.add(testItem.relativeFlowPath());
+                }
+            }
         }
+
+        // Scan main resources (lower priority - skip files that exist in test resources with same relative path)
+        Path mainResourcesPath = resolveFlowResourcePath(
+                outputTarget.getOutputDirectory(), configuredPath, false);
+
+        if (Files.exists(mainResourcesPath)) {
+            for (DiscoveredWorkflowBuildItem mainItem : collectWorkflowFileData(mainResourcesPath)) {
+                // Skip if same relative path exists in test resources
+                if (testRelativePaths.contains(mainItem.relativeFlowPath())) {
+                    LOG.debug("Skipping workflow from src/main/* {} (overridden by test resource with same relative path)",
+                            mainItem.location());
+                    continue;
+                }
+                // Check for duplicate regularIdentifier
+                String identifier = mainItem.regularIdentifier();
+                if (uniqueWorkflows.containsKey(identifier)) {
+                    throw new IllegalStateException(String.format(
+                            "Duplicate workflow detected %s", mainItem.workflowDefinitionId()));
+                }
+                uniqueWorkflows.put(identifier, mainItem);
+            }
+        }
+
+        uniqueWorkflows.values().forEach(workflows::produce);
     }
 }

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowCollectorProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowCollectorProcessor.java
@@ -65,28 +65,29 @@ public class FlowCollectorProcessor {
      * by replacing {@code src/main/} with {@code src/test/} (e.g., {@code src/test/flow}).
      *
      * @param outputDir the output directory from OutputTargetBuildItem
-     * @param configuredPath the configured flow directory path (relative to main resources)
-     * @param isTestResources whether to resolve test resources path instead of main
+     * @param flowDir the configured flow directory path (relative to main resources)
+     * @param launchMode the current launch mode to determine if we are in test mode
      * @return the resolved flow resource path
      */
-    private static Path resolveFlowResourcePath(Path outputDir, Path configuredPath, boolean isTestResources) {
-        if (configuredPath.isAbsolute()) {
-            return configuredPath;
+    private static Path resolveFlowResourceDir(Path outputDir, Path flowDir, LaunchMode launchMode) {
+        if (flowDir.isAbsolute()) {
+            return flowDir;
         }
         Path moduleRoot = findModuleRootFromTarget(outputDir);
 
-        if (isTestResources) {
+        if (launchMode == LaunchMode.TEST) {
             // Convert main resources path to test resources path
             // e.g., src/main/flow -> src/test/flow
             //       src/main/workflows/custom -> src/test/workflows/custom
-            // Normalize to forward slashes for cross-platform compatibility
-            String pathStr = configuredPath.toString().replace('\\', '/');
-            if (pathStr.startsWith("src/main/")) {
-                return moduleRoot.resolve(Paths.get(pathStr.replace("src/main/", "src/test/"))).normalize();
+            Path flowDirNormalized = flowDir.normalize();
+            Path srcMain = Paths.get("src", "main");
+            if (flowDirNormalized.startsWith(srcMain)) {
+                Path relative = srcMain.relativize(flowDirNormalized);
+                return moduleRoot.resolve(Paths.get("src", "test").resolve(relative)).normalize();
             }
         }
 
-        return moduleRoot.resolve(configuredPath).normalize();
+        return moduleRoot.resolve(flowDir).normalize();
     }
 
     private static List<DiscoveredWorkflowBuildItem> collectWorkflowFileData(Path flowDir) {
@@ -98,8 +99,8 @@ public class FlowCollectorProcessor {
                     .forEach(file -> {
                         try {
                             Workflow workflow = WorkflowReader.readWorkflow(file);
-                            String relativePath = flowDir.relativize(file).toString();
-                            items.add(DiscoveredWorkflowBuildItem.fromSpec(file, workflow, relativePath));
+                            items.add(
+                                    DiscoveredWorkflowBuildItem.fromSpec(file, workflow, flowDir.relativize(file).toString()));
                         } catch (IOException e) {
                             LOG.error("Failed to parse workflow file at path: {}", file, e);
                             throw new UncheckedIOException("Error while parsing workflow file: " + file, e);
@@ -136,50 +137,52 @@ public class FlowCollectorProcessor {
             FlowDefinitionsConfig flowDefinitionsConfig,
             BuildProducer<DiscoveredWorkflowBuildItem> workflows) {
 
-        final Path configuredPath = Paths.get(flowDefinitionsConfig.dir().orElse(FlowDefinitionsConfig.DEFAULT_FLOW_DIR));
+        final Path flowDir = Paths.get(flowDefinitionsConfig.dir().orElse(FlowDefinitionsConfig.DEFAULT_FLOW_DIR));
 
-        Map<String, DiscoveredWorkflowBuildItem> uniqueWorkflows = new HashMap<>();
-        Set<String> testRelativePaths = new HashSet<>();
+        Map<String, DiscoveredWorkflowBuildItem> workflowsMap = new HashMap<>();
+        Set<String> collectedInTest = new HashSet<>();
 
-        // In test mode, scan test resources first (higher priority)
         if (launchMode.getLaunchMode() == LaunchMode.TEST) {
-            Path testResourcesPath = resolveFlowResourcePath(
-                    outputTarget.getOutputDirectory(), configuredPath, true);
-            if (Files.exists(testResourcesPath)) {
-                for (DiscoveredWorkflowBuildItem testItem : collectWorkflowFileData(testResourcesPath)) {
-                    String identifier = testItem.regularIdentifier();
-                    if (uniqueWorkflows.containsKey(identifier)) {
-                        throw new IllegalStateException(String.format(
-                                "Duplicate workflow detected %s", testItem.workflowDefinitionId()));
-                    }
-                    uniqueWorkflows.put(identifier, testItem);
-                    testRelativePaths.add(testItem.relativeFlowPath());
+            Path testFlowDir = resolveFlowResourceDir(
+                    outputTarget.getOutputDirectory(), flowDir, launchMode.getLaunchMode());
+
+            if (Files.exists(testFlowDir)) {
+                for (DiscoveredWorkflowBuildItem item : collectWorkflowFileData(testFlowDir)) {
+                    tryAddUniqueWorkflow(item, workflowsMap);
+                    collectedInTest.add(item.relativeFlowPath());
                 }
             }
         }
 
         // Scan main resources (lower priority - skip files that exist in test resources with same relative path)
-        Path mainResourcesPath = resolveFlowResourcePath(
-                outputTarget.getOutputDirectory(), configuredPath, false);
+        Path mainFlowDir = resolveFlowResourceDir(
+                outputTarget.getOutputDirectory(), flowDir, LaunchMode.NORMAL);
 
-        if (Files.exists(mainResourcesPath)) {
-            for (DiscoveredWorkflowBuildItem mainItem : collectWorkflowFileData(mainResourcesPath)) {
-                // Skip if same relative path exists in test resources
-                if (testRelativePaths.contains(mainItem.relativeFlowPath())) {
+        if (Files.exists(mainFlowDir)) {
+            for (DiscoveredWorkflowBuildItem collectedInMain : collectWorkflowFileData(mainFlowDir)) {
+                if (skipIfSameRelativePath(collectedInMain, collectedInTest)) {
                     LOG.debug("Skipping workflow from src/main/* {} (overridden by test resource with same relative path)",
-                            mainItem.location());
+                            collectedInMain.location());
                     continue;
                 }
-                // Check for duplicate regularIdentifier
-                String identifier = mainItem.regularIdentifier();
-                if (uniqueWorkflows.containsKey(identifier)) {
-                    throw new IllegalStateException(String.format(
-                            "Duplicate workflow detected %s", mainItem.workflowDefinitionId()));
-                }
-                uniqueWorkflows.put(identifier, mainItem);
+
+                tryAddUniqueWorkflow(collectedInMain, workflowsMap);
             }
         }
 
-        uniqueWorkflows.values().forEach(workflows::produce);
+        workflowsMap.values().forEach(workflows::produce);
+    }
+
+    private static boolean skipIfSameRelativePath(DiscoveredWorkflowBuildItem collectedInMain, Set<String> collectedInTest) {
+        return collectedInTest.contains(collectedInMain.relativeFlowPath());
+    }
+
+    private static void tryAddUniqueWorkflow(DiscoveredWorkflowBuildItem item,
+            Map<String, DiscoveredWorkflowBuildItem> uniqueWorkflows) {
+        String identifier = item.regularIdentifier();
+        if (uniqueWorkflows.put(identifier, item) != null) {
+            throw new IllegalStateException(String.format(
+                    "Duplicate workflow detected %s", item.workflowDefinitionId()));
+        }
     }
 }

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowCollectorProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowCollectorProcessor.java
@@ -91,7 +91,7 @@ public class FlowCollectorProcessor {
             return flowDir;
         }
         Path moduleRoot = findModuleRootFromTarget(outputDir);
-        
+
         // Convert main resources path to test resources path
         // e.g., src/main/flow -> src/test/flow
         //       src/main/workflows/custom -> src/test/workflows/custom

--- a/core/integration-tests/src/test/flow/echo-name.yaml
+++ b/core/integration-tests/src/test/flow/echo-name.yaml
@@ -1,0 +1,9 @@
+document:
+  dsl: '1.0.0'
+  namespace: flow
+  name: echo-name
+  version: '0.1.0'
+do:
+  - setEcho:
+      set:
+        message: '${ "Echo from test: " + .name }'

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/EchoResourceTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/EchoResourceTest.java
@@ -16,7 +16,7 @@ public class EchoResourceTest {
                 .get("/echo/from-flow")
                 .then()
                 .statusCode(200)
-                .body(Matchers.containsString("Anakin Skywalker"));
+                .body(Matchers.containsString("Echo from test: Anakin Skywalker"));
     }
 
     @Test
@@ -26,7 +26,7 @@ public class EchoResourceTest {
                 .get("/echo/from-workflow-def")
                 .then()
                 .statusCode(200)
-                .body(Matchers.containsString("Anakin Skywalker"));
+                .body(Matchers.containsString("Echo from test: Anakin Skywalker"));
     }
 
 }

--- a/docs/modules/ROOT/pages/workflow-definitions.adoc
+++ b/docs/modules/ROOT/pages/workflow-definitions.adoc
@@ -37,6 +37,20 @@ You can customize the discovery directory by setting the xref:configuration.adoc
 It accepts an absolute path or a path relative to the Maven module root. All `*.yaml` and `*.yml` files in the resolved directory are discovered automatically.
 ====
 
+[IMPORTANT]
+====
+In test mode, if the same workflow file exists in both `src/main/flow` and `src/test/flow` with the same relative path, the `src/test/flow` file takes precedence.
+
+Example:
+
+* `src/main/flow/echo.yaml`
+* `src/test/flow/echo.yaml`
+
+In this case, Quarkus Flow uses `src/test/flow/echo.yaml` during tests.
+
+Only exact relative-path matches are overridden. For example, `src/test/flow/echo.yaml` does *not* override `src/main/flow/workflows/echo.yaml`.
+====
+
 == 2. Inject the `Flow` bean
 
 During the Quarkus build, the engine parses your YAML files and generates `WorkflowDefinition` and `Flow` CDI beans for them.


### PR DESCRIPTION
# Changes

This pull request introduces override support for workflow YAML files.

When the same workflow file exists in both:

* `src/main/flow/echo.yaml`
* `src/test/flow/echo.yaml`

The version located in src/test/flow/ now takes precedence during test execution.

This allows test-specific workflows (e.g., echo.yaml) to override the default definitions from `src/main/flow/echo.yaml`, enabling more controlled and isolated testing scenarios.