### PR TITLE
Use unicode-safe encoding to handle non-Latin1 characters

### DIFF
--- a/core/deployment/src/main/resources/dev-ui/qwc-flow-workflows.js
+++ b/core/deployment/src/main/resources/dev-ui/qwc-flow-workflows.js
@@ -214,7 +214,10 @@ export class QwcFlow extends observeState(QwcHotReloadElement) {
             return;
         }
         let img = new Image(svgData.width.baseVal.value, svgData.height.baseVal.value);
-        img.src = `data:image/svg+xml;base64,${btoa(new XMLSerializer().serializeToString(svgData))}`;
+        const svgString = new XMLSerializer().serializeToString(svgData);
+        const utf8Bytes = new TextEncoder().encode(svgString);
+        const base64 = btoa(String.fromCharCode(...utf8Bytes));
+        img.src = `data:image/svg+xml;base64,${base64}`;
         img.onload = function () {
             let cnv = document.createElement('canvas');
             cnv.width = img.width;


### PR DESCRIPTION
# Changes

Add unicode-safe enconding to handle non-Latin1 characters when downloading diagram image.

https://github.com/user-attachments/assets/06645745-8824-4b39-9071-3a9ed5687f8b

Closes #464 