### PR TITLE
Avoid recording workflow file reads at runtime (use build-time resolu…

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/DiscoveredWorkflowBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/DiscoveredWorkflowBuildItem.java
@@ -24,20 +24,22 @@ public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
         SPEC
     }
 
-    private Path workflowPath;
-    private String relativeFlowPath;
+    private Path absolute;
+    private Path relativeToFlowDir;
     private WorkflowDefinitionId workflowDefinitionId;
     private String regularIdentifier;
     private String className;
     private final From from;
+    private byte[] content;
 
-    private DiscoveredWorkflowBuildItem(Path workflowPath, Workflow workflow, String relativeFlowPath) {
-        this.workflowPath = workflowPath;
-        this.relativeFlowPath = relativeFlowPath;
+    private DiscoveredWorkflowBuildItem(Path absolute, Path relativeToFlowDir, Workflow workflow, byte[] content) {
+        this.absolute = absolute;
+        this.relativeToFlowDir = relativeToFlowDir;
         this.workflowDefinitionId = WorkflowDefinitionId.of(workflow);
         this.regularIdentifier = WorkflowNameUtils.yamlDescriptorIdentifier(
                 workflowDefinitionId.namespace(),
                 workflowDefinitionId.name());
+        this.content = content;
         this.from = From.SPEC;
     }
 
@@ -49,13 +51,16 @@ public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
     /**
      * Creates a build item for a workflow discovered from a specification file.
      *
-     * @param workflowPath the path to the workflow specification file
+     * @param absolute the path to the workflow specification file
      * @param workflow the parsed workflow model
-     * @param relativeFlowPath the relative path from the flow directory
+     * @param relativeToFlowDir the relative path from the flow directory
+     * @param content the workflow file content
+     *
      * @return a new {@link DiscoveredWorkflowBuildItem}
      */
-    public static DiscoveredWorkflowBuildItem fromSpec(Path workflowPath, Workflow workflow, String relativeFlowPath) {
-        return new DiscoveredWorkflowBuildItem(workflowPath, workflow, relativeFlowPath);
+    public static DiscoveredWorkflowBuildItem fromSpec(Path absolute, Path relativeToFlowDir, Workflow workflow,
+            byte[] content) {
+        return new DiscoveredWorkflowBuildItem(absolute, relativeToFlowDir, workflow, content);
     }
 
     /**
@@ -69,12 +74,12 @@ public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
     }
 
     /**
-     * Returns the location of the workflow specification on disk.
+     * Returns the absolute location of the workflow specification on disk.
      *
      * @return the workflow file location
      */
-    public String location() {
-        return this.workflowPath.toString();
+    public String absolutePath() {
+        return this.absolute.toString();
     }
 
     public String namespace() {
@@ -124,7 +129,11 @@ public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
      *
      * @return the relative flow path, or {@code null} if discovered from source
      */
-    public String relativeFlowPath() {
-        return relativeFlowPath;
+    public String relativeToFlowDir() {
+        return relativeToFlowDir.toString();
+    }
+
+    public byte[] content() {
+        return content;
     }
 }

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowCollectorProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowCollectorProcessor.java
@@ -43,7 +43,7 @@ public class FlowCollectorProcessor {
      */
     private static Path findModuleRootFromTarget(Path outputDir) {
         Path targetDir = outputDir;
-        while (targetDir != null && !"target".equals(targetDir.getFileName().toString())) {
+        while (targetDir != null && targetDir.getFileName() != null && !"target".equals(targetDir.getFileName().toString())) {
             targetDir = targetDir.getParent();
         }
 
@@ -114,8 +114,10 @@ public class FlowCollectorProcessor {
                     .forEach(file -> {
                         try {
                             Workflow workflow = WorkflowReader.readWorkflow(file);
+                            byte[] content = Files.readAllBytes(file);
                             items.add(
-                                    DiscoveredWorkflowBuildItem.fromSpec(file, workflow, flowDir.relativize(file).toString()));
+                                    DiscoveredWorkflowBuildItem.fromSpec(file, flowDir.relativize(file), workflow,
+                                            content));
                         } catch (IOException e) {
                             LOG.error("Failed to parse workflow file at path: {}", file, e);
                             throw new UncheckedIOException("Error while parsing workflow file: " + file, e);
@@ -164,7 +166,7 @@ public class FlowCollectorProcessor {
             if (Files.exists(testFlowDir)) {
                 for (DiscoveredWorkflowBuildItem item : collectWorkflowFileData(testFlowDir)) {
                     tryAddUniqueWorkflow(item, workflowsMap);
-                    collectedInTest.add(item.relativeFlowPath());
+                    collectedInTest.add(item.relativeToFlowDir());
                 }
             }
         }
@@ -177,7 +179,7 @@ public class FlowCollectorProcessor {
             for (DiscoveredWorkflowBuildItem collectedInMain : collectWorkflowFileData(mainFlowDir)) {
                 if (skipIfSameRelativePath(collectedInMain, collectedInTest)) {
                     LOG.debug("Skipping workflow from src/main/* {} (overridden by test resource with same relative path)",
-                            collectedInMain.location());
+                            collectedInMain.absolutePath());
                     continue;
                 }
 
@@ -189,7 +191,7 @@ public class FlowCollectorProcessor {
     }
 
     private static boolean skipIfSameRelativePath(DiscoveredWorkflowBuildItem collectedInMain, Set<String> collectedInTest) {
-        return collectedInTest.contains(collectedInMain.relativeFlowPath());
+        return collectedInTest.contains(collectedInMain.relativeToFlowDir());
     }
 
     private static void tryAddUniqueWorkflow(DiscoveredWorkflowBuildItem item,

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
@@ -63,6 +63,7 @@ import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
 import io.quarkus.runtime.metrics.MetricsFactory;
+import io.serverlessworkflow.api.WorkflowFormat;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.impl.WorkflowApplication;
 import io.serverlessworkflow.impl.WorkflowDefinition;
@@ -195,7 +196,8 @@ class FlowProcessor {
                 .addValue("value", workflow.regularIdentifier()).done()
                 .addQualifier().annotation(DotNames.IDENTIFIER)
                 .addValue("value", flowSubclassIdentifier).done()
-                .supplier(recorder.workflowDefinitionFromFileSupplier(workflow.location()))
+                .supplier(recorder.workflowDefinitionFromFileSupplier(
+                        workflow.name(), workflow.content(), WorkflowFormat.fromFileName(workflow.name())))
                 .done());
 
         identifiers.produce(new FlowIdentifierBuildItem(
@@ -292,11 +294,11 @@ class FlowProcessor {
     public void watchChanges(List<DiscoveredWorkflowBuildItem> workflows,
             BuildProducer<HotDeploymentWatchedFileBuildItem> watchedFiles) {
 
-        List<String> specLocations = workflows.stream().filter(DiscoveredWorkflowBuildItem::fromSpec)
-                .map(DiscoveredWorkflowBuildItem::location)
+        List<String> locations = workflows.stream().filter(DiscoveredWorkflowBuildItem::fromSpec)
+                .map(DiscoveredWorkflowBuildItem::absolutePath)
                 .toList();
 
-        for (String location : specLocations) {
+        for (String location : locations) {
             watchedFiles.produce(HotDeploymentWatchedFileBuildItem.builder()
                     .setLocation(location)
                     .setRestartNeeded(true)

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/FlowWorkflowFromFileProdTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/FlowWorkflowFromFileProdTest.java
@@ -1,0 +1,81 @@
+package io.quarkiverse.flow.deployment.test;
+
+import static org.assertj.core.api.Fail.fail;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.flow.deployment.DiscoveredWorkflowBuildItem;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdModeTestBuildStep;
+import io.quarkus.test.QuarkusProdModeTest;
+import io.restassured.RestAssured;
+import io.serverlessworkflow.api.WorkflowFormat;
+import io.serverlessworkflow.api.WorkflowReader;
+import io.serverlessworkflow.api.types.Workflow;
+
+public class FlowWorkflowFromFileProdTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest devModeTest = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(IdentifierResource.class))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-rest-jackson", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-vertx-http", Version.getVersion())))
+            .addBuildChainCustomizerEntries(
+                    new QuarkusProdModeTest.BuildChainCustomizerEntry(FlowWorkflowFromFileProdTestBuildStep.class,
+                            Collections.singletonList(DiscoveredWorkflowBuildItem.class), Collections.emptyList()))
+            .setRun(true);
+
+    @Test
+    void should_have_a_bean_recorded_when_running_prod_mode() {
+        RestAssured.given()
+                .queryParam("identifier", "default:call-http")
+                .get("/identifier/workflow-def")
+                .then()
+                .statusCode(200);
+    }
+
+    public static class FlowWorkflowFromFileProdTestBuildStep extends ProdModeTestBuildStep {
+
+        public FlowWorkflowFromFileProdTestBuildStep(Map<String, Object> testContext) {
+            super(testContext);
+        }
+
+        @Override
+        public void execute(BuildContext context) {
+            Path dummy = Path.of("flow/flow.yaml");
+            byte[] bytes = """
+                    document:
+                      dsl: '1.0.0'
+                      namespace: default
+                      name: call-http
+                      version: '1.0.0'
+                    do:
+                      - wait30Seconds:
+                          wait:
+                            seconds: 30
+                    """.getBytes(StandardCharsets.UTF_8);
+            try {
+                Workflow workflow = WorkflowReader.readWorkflow(bytes, WorkflowFormat.YAML);
+                context.produce(DiscoveredWorkflowBuildItem.fromSpec(
+                        dummy, dummy, workflow, bytes));
+            } catch (IOException e) {
+                fail(e);
+            }
+        }
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/flow/recorders/WorkflowDefinitionRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/recorders/WorkflowDefinitionRecorder.java
@@ -2,7 +2,6 @@ package io.quarkiverse.flow.recorders;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.Paths;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.inject.Any;
@@ -12,6 +11,7 @@ import io.quarkiverse.flow.internal.WorkflowRegistry;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.runtime.annotations.Recorder;
+import io.serverlessworkflow.api.WorkflowFormat;
 import io.serverlessworkflow.api.WorkflowReader;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.impl.WorkflowDefinition;
@@ -44,14 +44,15 @@ public class WorkflowDefinitionRecorder {
         };
     }
 
-    public Supplier<WorkflowDefinition> workflowDefinitionFromFileSupplier(String location) {
+    public Supplier<WorkflowDefinition> workflowDefinitionFromFileSupplier(String filename, byte[] content,
+            WorkflowFormat workflowFormat) {
         return () -> {
             final WorkflowRegistry registry = Arc.container().instance(WorkflowRegistry.class).get();
             try {
-                Workflow workflow = WorkflowReader.readWorkflow(Paths.get(location));
+                Workflow workflow = WorkflowReader.readWorkflow(content, workflowFormat);
                 return registry.register(workflow);
             } catch (IOException e) {
-                throw new UncheckedIOException("Failed to create WorkflowDefinition for workflow at " + location, e);
+                throw new UncheckedIOException("Failed to create WorkflowDefinition for workflow at " + filename, e);
             }
         };
     }


### PR DESCRIPTION
# Changes

This pull request avoid recording workflow file reads at runtime (use build-time resolution). With this changes we are following the build-time principle instead doing stuff at runtime.

Closes #472 