### PR TITLE
fix #495 - Add handler modes to structured logging

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
@@ -49,7 +49,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
@@ -360,8 +359,7 @@ class FlowProcessor {
     }
 
     @BuildStep
-    void detectQuarkusLoggingJson(CombinedIndexBuildItem index,
-            FlowStructuredLoggingConfig structuredLoggingConfig,
+    void detectQuarkusLoggingJson(FlowStructuredLoggingConfig structuredLoggingConfig,
             BuildProducer<RunTimeConfigurationDefaultBuildItem> configDefaults,
             LaunchModeBuildItem launchMode) {
 
@@ -372,6 +370,17 @@ class FlowProcessor {
         // Users can override these in application.properties if needed
         String loggerCategory = EventFormatter.class.getPackageName();
 
+        switch (structuredLoggingConfig.handler().mode()) {
+            case NONE -> LOG.info("Structured Logging enabled, but automatic logging handler disabled. " +
+                    "You have to configure the output via quarkus.log.* configuration for the category {}", loggerCategory);
+            case FILE -> createStructuredLoggingFileHandler(configDefaults, launchMode, loggerCategory);
+            case CONTAINER -> createStructuredLoggingStdoutHandler(configDefaults, loggerCategory);
+        }
+    }
+
+    private void createStructuredLoggingFileHandler(BuildProducer<RunTimeConfigurationDefaultBuildItem> configDefaults,
+            LaunchModeBuildItem launchMode,
+            String loggerCategory) {
         // Enable file handler by default when structured logging is enabled
         configDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
                 "quarkus.log.handler.file.\"" + DEFAULT_STRUCTURED_LOG_HANDLER + "\".enable",
@@ -406,4 +415,26 @@ class FlowProcessor {
                 DEFAULT_STRUCTURED_LOG_HANDLER);
     }
 
+    private void createStructuredLoggingStdoutHandler(BuildProducer<RunTimeConfigurationDefaultBuildItem> configDefaults,
+            String loggerCategory) {
+        // Enable console handler
+        configDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
+                "quarkus.log.handler.console.\"" + DEFAULT_STRUCTURED_LOG_HANDLER + "\".enable",
+                "true"));
+        // Set raw JSON format (no timestamps, just the event JSON)
+        configDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
+                "quarkus.log.handler.console.\"" + DEFAULT_STRUCTURED_LOG_HANDLER + "\".format",
+                "%s%n"));
+        // Assign this handler to the structured logging category
+        configDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
+                "quarkus.log.category.\"" + loggerCategory + "\".handlers",
+                DEFAULT_STRUCTURED_LOG_HANDLER));
+        // Prevent workflow events from appearing in parent console handler
+        configDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
+                "quarkus.log.category.\"" + loggerCategory + "\".use-parent-handlers",
+                "false"));
+
+        LOG.info("Quarkus Flow structured logging console handler auto-configured. " +
+                "Events will be written to stdout (containers mode)");
+    }
 }

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingContainerModeTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingContainerModeTest.java
@@ -1,0 +1,91 @@
+package io.quarkiverse.flow.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Test that structured logging works correctly in CONTAINER mode.
+ * <p>
+ * CONTAINER mode writes events to stdout instead of a file, which is appropriate
+ * for containerized deployments (Kubernetes, Docker) where logs are captured
+ * from the container's stdout by the runtime.
+ * <p>
+ * This test verifies that:
+ * 1. Workflow execution succeeds with CONTAINER mode enabled
+ * 2. No file handler is created (no target/quarkus-flow-events.log file)
+ * 3. Events are written to console handler (manual verification via logs)
+ * <p>
+ * Manual verification: Check test logs for JSON events from io.quarkiverse.flow.structuredlogging logger.
+ * Events should appear in console output.
+ * Expected log entries:
+ * - {"eventType":"io.serverlessworkflow.workflow.started.v1", "instanceId":"...", "workflowName":"hello", ...}
+ * - {"eventType":"io.serverlessworkflow.task.started.v1", "taskName":"...", ...}
+ * - {"eventType":"io.serverlessworkflow.workflow.completed.v1", ...}
+ */
+@QuarkusTest
+@TestProfile(StructuredLoggingContainerModeTest.ContainerModeProfile.class)
+@DisplayName("test_structured_logging_container_mode")
+public class StructuredLoggingContainerModeTest {
+
+    @Inject
+    HelloWorkflow helloWorkflow;
+
+    @BeforeEach
+    void cleanupDefaultLogFile() throws IOException {
+        // Clean up any leftover log file from previous tests
+        Path defaultFileLogPath = Paths.get("target/quarkus-flow-events.log");
+        Files.deleteIfExists(defaultFileLogPath);
+    }
+
+    @Test
+    @DisplayName("test_container_mode_writes_to_stdout_not_file")
+    void testContainerModeWritesToStdoutNotFile() {
+        // Execute workflow with structured logging in CONTAINER mode
+        // Events should be written to console (stdout) instead of a file
+        var result = helloWorkflow.startInstance().await().indefinitely();
+
+        // Verify workflow executed successfully
+        assertThat(result).isNotNull();
+
+        // Verify that the default file handler was NOT created
+        // (container mode uses console handler, not file handler)
+        Path defaultFileLogPath = Paths.get("target/quarkus-flow-events.log");
+        assertThat(defaultFileLogPath)
+                .withFailMessage(
+                        "CONTAINER mode should not create a file handler. " +
+                                "Found unexpected log file at: %s",
+                        defaultFileLogPath)
+                .doesNotExist();
+
+        // Manual verification: Check build logs for JSON events like:
+        // INFO [io.quarkiverse.flow.structuredlogging] {"eventType":"io.serverlessworkflow.workflow.started.v1",...}
+        //
+        // Events should appear in console output via console handler, NOT in a file
+    }
+
+    public static class ContainerModeProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.flow.structured-logging.enabled", "true",
+                    "quarkus.flow.structured-logging.handler.mode", "container",
+                    "quarkus.flow.structured-logging.events", "workflow.*",
+                    "quarkus.flow.structured-logging.log-level", "INFO");
+        }
+    }
+}

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingContainerModeTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingContainerModeTest.java
@@ -54,7 +54,7 @@ public class StructuredLoggingContainerModeTest {
 
     @Test
     @DisplayName("test_container_mode_writes_to_stdout_not_file")
-    void testContainerModeWritesToStdoutNotFile() {
+    void test_container_mode_writes_to_stdout_not_file() {
         // Execute workflow with structured logging in CONTAINER mode
         // Events should be written to console (stdout) instead of a file
         var result = helloWorkflow.startInstance().await().indefinitely();

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingFileModeTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingFileModeTest.java
@@ -1,0 +1,76 @@
+package io.quarkiverse.flow.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Test that structured logging works correctly in FILE mode (default).
+ * <p>
+ * FILE mode writes events to a dedicated file:
+ * - Dev/Test: target/quarkus-flow-events.log (or custom path)
+ * - Production: /var/log/quarkus-flow/events.log
+ * <p>
+ * This test explicitly sets the mode to FILE to verify the default behavior
+ * and that the configuration property works correctly.
+ * <p>
+ * Manual verification: Check for target/structured-logging-file-mode-test.log file containing JSON events.
+ * Also check build logs for:
+ * INFO [io.quarkiverse.flow.deployment.FlowProcessor] Quarkus Flow structured logging file handler auto-configured.
+ * Events will be written to: target/structured-logging-file-mode-test.log
+ */
+@QuarkusTest
+@TestProfile(StructuredLoggingFileModeTest.FileModeProfile.class)
+@DisplayName("test_structured_logging_file_mode")
+public class StructuredLoggingFileModeTest {
+
+    @Inject
+    HelloWorkflow helloWorkflow;
+
+    @Test
+    @DisplayName("test_file_mode_does_not_break_workflow_execution")
+    void testFileModeDoesNotBreakWorkflowExecution() {
+        // Execute workflow with structured logging in FILE mode (explicit)
+        // If this doesn't throw, FILE mode is working
+        var result = helloWorkflow.startInstance().await().indefinitely();
+
+        // Verify workflow executed successfully
+        assertThat(result)
+                .withFailMessage("Workflow should execute successfully with structured logging FILE mode enabled")
+                .isNotNull();
+
+        // Manual verification: Check build logs for:
+        // INFO [io.quarkiverse.flow.deployment.FlowProcessor] Quarkus Flow structured logging file handler auto-configured.
+        //      Events will be written to: target/structured-logging-file-mode-test.log
+        //
+        // Check target/structured-logging-file-mode-test.log for JSON events like:
+        // {"eventType":"io.serverlessworkflow.workflow.started.v1",...}
+        // {"eventType":"io.serverlessworkflow.task.started.v1",...}
+        // {"eventType":"io.serverlessworkflow.workflow.completed.v1",...}
+        //
+        // Note: When running tests in parallel, file handler output timing can vary,
+        // so we only verify the workflow executes successfully (similar to StructuredLoggingTest)
+    }
+
+    public static class FileModeProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.flow.structured-logging.enabled", "true",
+                    "quarkus.flow.structured-logging.handler.mode", "file",
+                    "quarkus.flow.structured-logging.events", "workflow.*",
+                    "quarkus.flow.structured-logging.log-level", "INFO",
+                    // Use a unique file path for this test
+                    "quarkus.log.handler.file.\"FLOW_EVENTS\".path", "target/structured-logging-file-mode-test.log");
+        }
+    }
+}

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingFileModeTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingFileModeTest.java
@@ -38,7 +38,7 @@ public class StructuredLoggingFileModeTest {
 
     @Test
     @DisplayName("test_file_mode_does_not_break_workflow_execution")
-    void testFileModeDoesNotBreakWorkflowExecution() {
+    void test_file_mode_does_not_break_workflow_execution() {
         // Execute workflow with structured logging in FILE mode (explicit)
         // If this doesn't throw, FILE mode is working
         var result = helloWorkflow.startInstance().await().indefinitely();

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingNoneModeTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingNoneModeTest.java
@@ -1,0 +1,94 @@
+package io.quarkiverse.flow.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Test that structured logging works correctly in NONE mode.
+ * <p>
+ * NONE mode disables automatic handler creation, allowing advanced users to
+ * manually configure handlers via standard Quarkus logging properties. Events
+ * are still emitted by StructuredLoggingListener, but no default handler is created.
+ * <p>
+ * This test verifies that:
+ * 1. Workflow execution succeeds with NONE mode enabled
+ * 2. No automatic handler is created (no file handler created)
+ * 3. StructuredLoggingListener is still active (bean is created)
+ * <p>
+ * Manual verification: Check build logs for the message:
+ * "Structured Logging enabled, but automatic logging handler disabled.
+ * You have to configure the output via quarkus.log.* configuration"
+ */
+@QuarkusTest
+@TestProfile(StructuredLoggingNoneModeTest.NoneModeProfile.class)
+@DisplayName("test_structured_logging_none_mode")
+public class StructuredLoggingNoneModeTest {
+
+    @Inject
+    HelloWorkflow helloWorkflow;
+
+    @BeforeEach
+    void cleanupDefaultLogFile() throws IOException {
+        // Clean up any leftover log file from previous tests
+        Path defaultFileLogPath = Paths.get("target/quarkus-flow-events.log");
+        Files.deleteIfExists(defaultFileLogPath);
+    }
+
+    @Test
+    @DisplayName("test_none_mode_workflow_execution_succeeds_without_handler")
+    void testNoneModeWorkflowExecutionSucceedsWithoutHandler() {
+        // Execute workflow with structured logging in NONE mode
+        // No automatic handler should be created, but workflow should execute successfully
+        var result = helloWorkflow.startInstance().await().indefinitely();
+
+        // Verify workflow executed successfully
+        assertThat(result)
+                .withFailMessage("Workflow should execute successfully even with handler.mode=none")
+                .isNotNull();
+
+        // Verify that NO automatic file handler was created
+        Path defaultFileLogPath = Paths.get("target/quarkus-flow-events.log");
+        assertThat(defaultFileLogPath)
+                .withFailMessage(
+                        "NONE mode should not create a file handler. " +
+                                "Found unexpected log file at: %s",
+                        defaultFileLogPath)
+                .doesNotExist();
+
+        // Manual verification: Check build logs for:
+        // INFO [io.quarkiverse.flow.deployment.FlowProcessor] Structured Logging enabled, but automatic logging handler disabled.
+        //      You have to configure the output via quarkus.log.* configuration for the category io.quarkiverse.flow.structuredlogging
+        //
+        // Verify that NO automatic handler is created (no file, no console handler)
+        // Events are emitted by StructuredLoggingListener but go nowhere without manual handler config
+        //
+        // To verify events ARE being emitted (just not captured), you could add manual handler config
+        // in the test profile and verify events appear there
+    }
+
+    public static class NoneModeProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.flow.structured-logging.enabled", "true",
+                    "quarkus.flow.structured-logging.handler.mode", "none",
+                    "quarkus.flow.structured-logging.events", "workflow.*",
+                    "quarkus.flow.structured-logging.log-level", "INFO");
+        }
+    }
+}

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingNoneModeTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingNoneModeTest.java
@@ -51,7 +51,7 @@ public class StructuredLoggingNoneModeTest {
 
     @Test
     @DisplayName("test_none_mode_workflow_execution_succeeds_without_handler")
-    void testNoneModeWorkflowExecutionSucceedsWithoutHandler() {
+    void test_none_mode_workflow_execution_succeeds_without_handler() {
         // Execute workflow with structured logging in NONE mode
         // No automatic handler should be created, but workflow should execute successfully
         var result = helloWorkflow.startInstance().await().indefinitely();

--- a/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowStructuredLoggingConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowStructuredLoggingConfig.java
@@ -152,4 +152,146 @@ public interface FlowStructuredLoggingConfig {
      * the application will fail at startup with {@link IllegalArgumentException}.
      */
     Optional<String> timestampPattern();
+
+    /**
+     * Configuration for the log handler used to output structured logging events.
+     * <p>
+     * Controls where workflow and task execution events are written (file, stdout, or custom).
+     * For containerized environments (Kubernetes, Docker), use {@code mode=container} to write to stdout.
+     * <p>
+     * See <a href="https://github.com/quarkiverse/quarkus-flow/issues/495">Issue #495</a> for details.
+     */
+    Handler handler();
+
+    interface Handler {
+
+        /**
+         * The log handler mode to use for structured logging events.
+         * <p>
+         * Determines where workflow and task execution events are written:
+         * <ul>
+         * <li>{@code file} - Writes to a dedicated file ({@code /var/log/quarkus-flow/events.log} in production,
+         * {@code target/quarkus-flow-events.log} in dev/test)</li>
+         * <li>{@code container} - Writes to stdout for containerized deployments (Kubernetes, Docker, cloud-native
+         * environments)</li>
+         * <li>{@code none} - Disables automatic handler creation; you must manually configure handlers via
+         * {@code quarkus.log.*} properties</li>
+         * </ul>
+         * <p>
+         * <strong>Example configurations:</strong>
+         *
+         * <pre>
+         * # File mode (default) - traditional deployments
+         * quarkus.flow.structured-logging.enabled=true
+         * quarkus.flow.structured-logging.handler.mode=file
+         *
+         * # Container mode - Kubernetes/Docker deployments
+         * quarkus.flow.structured-logging.enabled=true
+         * quarkus.flow.structured-logging.handler.mode=container
+         *
+         * # Custom mode - advanced users
+         * quarkus.flow.structured-logging.enabled=true
+         * quarkus.flow.structured-logging.handler.mode=none
+         * # Then manually configure via quarkus.log.* properties
+         * </pre>
+         * <p>
+         * Default: {@code file}
+         *
+         * @see <a href="https://github.com/quarkiverse/quarkus-flow/issues/495">Issue #495 - Handler Mode
+         *      Configuration</a>
+         */
+        @WithDefault("file")
+        Mode mode();
+
+        enum Mode {
+            /**
+             * Logs workflow and task execution events to the local filesystem.
+             * <p>
+             * <strong>Default behavior</strong> - Creates a file handler named {@code FLOW_EVENTS} that writes to:
+             * <ul>
+             * <li><strong>Production:</strong> {@code /var/log/quarkus-flow/events.log}</li>
+             * <li><strong>Dev/Test:</strong> {@code target/quarkus-flow-events.log}</li>
+             * </ul>
+             * <p>
+             * <strong>Use when:</strong>
+             * <ul>
+             * <li>Running on traditional servers or VMs</li>
+             * <li>You want events in a separate file from application logs</li>
+             * <li>You're using file-based log forwarders (e.g., Filebeat, FluentBit with file input)</li>
+             * </ul>
+             * <p>
+             * Events are formatted as raw JSON ({@code %s%n}), one event per line.
+             */
+            FILE,
+            /**
+             * Logs workflow and task execution events to stdout for containerized deployments.
+             * <p>
+             * Creates a console handler named {@code FLOW_EVENTS} that writes structured events to stdout.
+             * Events do not appear in the parent console handler to avoid duplication.
+             * <p>
+             * <strong>Use when:</strong>
+             * <ul>
+             * <li>Running in containers (Docker, Kubernetes, Podman)</li>
+             * <li>Using container runtime log collection ({@code kubectl logs}, Docker logs)</li>
+             * <li>Log aggregation tools collect from stdout (FluentBit, Fluentd, Promtail)</li>
+             * <li>File systems are ephemeral or read-only</li>
+             * <li>Following cloud-native logging best practices</li>
+             * </ul>
+             * <p>
+             * <strong>Benefits:</strong>
+             * <ul>
+             * <li>No file write permissions needed</li>
+             * <li>Logs automatically captured by container runtime</li>
+             * <li>Simpler configuration (3 lines vs 8 lines for manual workaround)</li>
+             * <li>Works with read-only filesystems</li>
+             * </ul>
+             * <p>
+             * Events are formatted as raw JSON ({@code %s%n}), compatible with JSON log parsers.
+             * <p>
+             * <strong>Example configuration:</strong>
+             *
+             * <pre>
+             * quarkus.flow.structured-logging.enabled=true
+             * quarkus.flow.structured-logging.handler.mode=container
+             * quarkus.flow.structured-logging.timestamp-format=epoch-seconds
+             * </pre>
+             *
+             * @see <a href="https://github.com/quarkiverse/quarkus-flow/issues/495">Issue #495 - Container Mode</a>
+             */
+            CONTAINER,
+            /**
+             * Disables automatic log handler creation for structured logging events.
+             * <p>
+             * When set to {@code NONE}, Quarkus Flow will <strong>not</strong> create any log handler
+             * (file or console). Structured events are still emitted via {@code StructuredLoggingListener},
+             * but you are responsible for configuring output handlers manually using standard Quarkus logging
+             * properties.
+             * <p>
+             * <strong>Use when:</strong>
+             * <ul>
+             * <li>You need full control over logging configuration</li>
+             * <li>You want to use custom handlers (e.g., syslog, GELF, custom formatters)</li>
+             * <li>You're integrating with specialized logging infrastructure</li>
+             * <li>Default handlers don't fit your deployment requirements</li>
+             * </ul>
+             * <p>
+             * <strong>Manual configuration example:</strong>
+             *
+             * <pre>
+             * # Disable automatic handler
+             * quarkus.flow.structured-logging.enabled=true
+             * quarkus.flow.structured-logging.handler.mode=none
+             *
+             * # Configure custom console handler manually
+             * quarkus.log.handler.console."CUSTOM_FLOW".enable=true
+             * quarkus.log.handler.console."CUSTOM_FLOW".format=%s%n
+             * quarkus.log.category."io.quarkiverse.flow.structuredlogging".handlers=CUSTOM_FLOW
+             * quarkus.log.category."io.quarkiverse.flow.structuredlogging".use-parent-handlers=false
+             * </pre>
+             * <p>
+             * The logger category for structured events is {@code io.quarkiverse.flow.structuredlogging}.
+             */
+            NONE;
+        }
+    }
 }

--- a/docs/modules/ROOT/pages/includes/quarkus-flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow.adoc
@@ -539,6 +539,56 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-structured-logging-handler-mode]] [.property-path]##link:#quarkus-flow_quarkus-flow-structured-logging-handler-mode[`+++quarkus.flow.structured-logging.handler.mode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.structured-logging.handler.mode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The log handler mode to use for structured logging events.
+
+Determines where workflow and task execution events are written:
+
+ - `file` - Writes to a dedicated file (`/var/log/quarkus-flow/events.log` in production, `target/quarkus-flow-events.log` in dev/test)
+ - `container` - Writes to stdout for containerized deployments (Kubernetes, Docker, cloud-native environments)
+ - `none` - Disables automatic handler creation; you must manually configure handlers via `quarkus.log.++*++` properties
+
+
+
+*Example configurations:*
+
+```
+# File mode (default) - traditional deployments
+quarkus.flow.structured-logging.enabled=true
+quarkus.flow.structured-logging.handler.mode=file
+
+# Container mode - Kubernetes/Docker deployments
+quarkus.flow.structured-logging.enabled=true
+quarkus.flow.structured-logging.handler.mode=container
+
+# Custom mode - advanced users
+quarkus.flow.structured-logging.enabled=true
+quarkus.flow.structured-logging.handler.mode=none
+# Then manually configure via quarkus.log.* properties
+```
+
+
+
+Default: `file`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_STRUCTURED_LOGGING_HANDLER_MODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_STRUCTURED_LOGGING_HANDLER_MODE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`file`, `container`, `none`
+|`+++file+++`
+
 a| [[quarkus-flow_quarkus-flow-http-client-connect-timeout]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-connect-timeout[`+++quarkus.flow.http.client.connect-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.http.client.connect-timeout+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.flow.adoc
@@ -539,6 +539,56 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-structured-logging-handler-mode]] [.property-path]##link:#quarkus-flow_quarkus-flow-structured-logging-handler-mode[`+++quarkus.flow.structured-logging.handler.mode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.structured-logging.handler.mode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The log handler mode to use for structured logging events.
+
+Determines where workflow and task execution events are written:
+
+ - `file` - Writes to a dedicated file (`/var/log/quarkus-flow/events.log` in production, `target/quarkus-flow-events.log` in dev/test)
+ - `container` - Writes to stdout for containerized deployments (Kubernetes, Docker, cloud-native environments)
+ - `none` - Disables automatic handler creation; you must manually configure handlers via `quarkus.log.++*++` properties
+
+
+
+*Example configurations:*
+
+```
+# File mode (default) - traditional deployments
+quarkus.flow.structured-logging.enabled=true
+quarkus.flow.structured-logging.handler.mode=file
+
+# Container mode - Kubernetes/Docker deployments
+quarkus.flow.structured-logging.enabled=true
+quarkus.flow.structured-logging.handler.mode=container
+
+# Custom mode - advanced users
+quarkus.flow.structured-logging.enabled=true
+quarkus.flow.structured-logging.handler.mode=none
+# Then manually configure via quarkus.log.* properties
+```
+
+
+
+Default: `file`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_STRUCTURED_LOGGING_HANDLER_MODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_STRUCTURED_LOGGING_HANDLER_MODE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`file`, `container`, `none`
+|`+++file+++`
+
 a| [[quarkus-flow_quarkus-flow-http-client-connect-timeout]] [.property-path]##link:#quarkus-flow_quarkus-flow-http-client-connect-timeout[`+++quarkus.flow.http.client.connect-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.http.client.connect-timeout+++[]

--- a/docs/modules/ROOT/pages/structured-logging.adoc
+++ b/docs/modules/ROOT/pages/structured-logging.adoc
@@ -54,7 +54,97 @@ quarkus.flow.structured-logging.timestamp-format=iso8601
 # quarkus.flow.structured-logging.timestamp-pattern=yyyy-MM-dd'T'HH:mm:ss.SSSXXX
 ----
 
-IMPORTANT: When you enable structured logging, Quarkus Flow **automatically configures** a separate file handler to write workflow events to a dedicated file. Events are written to `target/quarkus-flow-events.log` in dev/test mode, and `/var/log/quarkus-flow/events.log` in production. This ensures clean separation between application logs and event streams. See xref:#integration-with-quarkus-logging-json[Integration with quarkus-logging-json] for details.
+IMPORTANT: When you enable structured logging, Quarkus Flow **automatically configures** a log handler based on the `handler.mode` setting. By default, events are written to a file (`target/quarkus-flow-events.log` in dev/test mode, `/var/log/quarkus-flow/events.log` in production). For containerized deployments, use `handler.mode=container` to write to stdout instead. See xref:#handler-mode-configuration[Handler Mode Configuration] for details.
+
+=== Handler Mode Configuration
+
+Quarkus Flow provides three handler modes to control where structured logging events are written. This allows you to adapt the logging output to your deployment environment.
+
+==== FILE Mode (Default)
+
+Writes events to a dedicated file, separate from application logs:
+
+[source,properties]
+----
+quarkus.flow.structured-logging.enabled=true
+quarkus.flow.structured-logging.handler.mode=file  # Default, can be omitted
+----
+
+**File locations:**
+
+* **Dev/Test mode:** `target/quarkus-flow-events.log`
+* **Production mode:** `/var/log/quarkus-flow/events.log`
+
+**When to use FILE mode:**
+
+* Running on traditional servers or VMs
+* You want events in a separate file from application logs
+* Using file-based log forwarders (Filebeat, FluentBit with file input)
+* File system is writable and persistent
+
+==== CONTAINER Mode
+
+Writes events to stdout for containerized deployments (Kubernetes, Docker, Podman):
+
+[source,properties]
+----
+quarkus.flow.structured-logging.enabled=true
+quarkus.flow.structured-logging.handler.mode=container
+quarkus.flow.structured-logging.timestamp-format=epoch-seconds  # Recommended for container environments
+----
+
+**Benefits:**
+
+* No file write permissions needed
+* Logs automatically captured by container runtime (`kubectl logs`, `docker logs`)
+* Compatible with log aggregation tools (FluentBit, Fluentd, Promtail, Vector)
+* Works with read-only filesystems
+* Follows cloud-native logging best practices
+* Simpler configuration (3 lines vs 8 lines for manual workaround)
+
+**When to use CONTAINER mode:**
+
+* Running in containers (Docker, Kubernetes, Podman, OpenShift)
+* Using container runtime log collection
+* Log aggregation tools collect from stdout
+* File systems are ephemeral or read-only
+* Following twelve-factor app principles
+
+**Example Kubernetes deployment:**
+
+With CONTAINER mode, your logs flow like this:
+
+1. Quarkus Flow writes JSON events to stdout
+2. Container runtime captures stdout → `/var/log/containers/*.log`
+3. Log forwarder (FluentBit, Fluentd) reads from `/var/log/containers/`
+4. Events routed to destination (PostgreSQL, Elasticsearch, S3, Kafka)
+
+No special volume mounts or file permissions needed!
+
+==== NONE Mode
+
+Disables automatic handler creation for advanced use cases:
+
+[source,properties]
+----
+quarkus.flow.structured-logging.enabled=true
+quarkus.flow.structured-logging.handler.mode=none
+
+# You must manually configure handlers
+quarkus.log.handler.console."CUSTOM_FLOW".enable=true
+quarkus.log.handler.console."CUSTOM_FLOW".format=%s%n
+quarkus.log.category."io.quarkiverse.flow.structuredlogging".handlers=CUSTOM_FLOW
+quarkus.log.category."io.quarkiverse.flow.structuredlogging".use-parent-handlers=false
+----
+
+**When to use NONE mode:**
+
+* You need full control over logging configuration
+* Using custom handlers (syslog, GELF, custom formatters)
+* Integrating with specialized logging infrastructure
+* Default handlers don't fit your deployment requirements
+
+The logger category for structured events is `io.quarkiverse.flow.structuredlogging`.
 
 === Timestamp Format Configuration
 
@@ -313,11 +403,11 @@ Notice how the `message` field contains a JSON **string**, not a JSON **object**
 
 This "double serialization" defeats the purpose of structured logging.
 
-=== The Solution: Automatic Separate File Handler
+=== The Solution: Automatic Handler Configuration
 
-Quarkus Flow **automatically configures** a separate file handler when structured logging is enabled. No manual configuration required!
+Quarkus Flow **automatically configures** a log handler when structured logging is enabled. No manual configuration required!
 
-**Default Configuration:**
+**Default Configuration (FILE mode):**
 
 When you enable structured logging:
 [source,properties]
@@ -325,6 +415,7 @@ When you enable structured logging:
 # Enable Quarkus Flow structured logging
 quarkus.flow.structured-logging.enabled=true
 quarkus.flow.structured-logging.events=workflow.*
+# handler.mode=file is the default
 ----
 
 Quarkus Flow automatically:
@@ -335,6 +426,18 @@ Quarkus Flow automatically:
   * **Production mode**: `/var/log/quarkus-flow/events.log`
 - Uses raw JSON format (`%s%n` - no timestamps, just the event JSON)
 - Prevents events from appearing in console (no double logging)
+
+**Alternative: CONTAINER mode for containerized deployments:**
+
+If you're running in containers and want events in stdout instead:
+
+[source,properties]
+----
+quarkus.flow.structured-logging.enabled=true
+quarkus.flow.structured-logging.handler.mode=container
+----
+
+This writes events to stdout instead of a file. See xref:#handler-mode-configuration[Handler Mode Configuration] for details.
 
 **Customizing the Configuration:**
 
@@ -388,7 +491,11 @@ INFO  [io.qua.flo.dep.FlowProcessor] Quarkus Flow structured logging file handle
 
 === FluentBit Example
 
-FluentBit is a lightweight, high-performance log forwarder. Here's a basic configuration to route structured logs to PostgreSQL:
+FluentBit is a lightweight, high-performance log forwarder. Configuration depends on your handler mode:
+
+==== FILE Mode Configuration
+
+When using `handler.mode=file` (default), FluentBit reads from the log file:
 
 [source,conf]
 ----
@@ -415,6 +522,51 @@ FluentBit is a lightweight, high-performance log forwarder. Here's a basic confi
     Table             workflow_events
     Timestamp_Key     timestamp
 ----
+
+==== CONTAINER Mode Configuration (Recommended for Kubernetes/Docker)
+
+When using `handler.mode=container`, FluentBit collects logs from stdout via the container runtime:
+
+[source,conf]
+----
+[INPUT]
+    Name              tail
+    Path              /var/log/containers/*_${NAMESPACE}_${POD_NAME}-*.log
+    Parser            docker  # Or cri/containerd depending on runtime
+    Tag               kube.*
+
+[FILTER]
+    Name              kubernetes
+    Match             kube.*
+    Kube_URL          https://kubernetes.default.svc:443
+    Merge_Log         On
+    Keep_Log          Off
+
+[FILTER]
+    Name              grep
+    Match             kube.*
+    Regex             log {"eventType":"io.serverlessworkflow.*
+
+[OUTPUT]
+    Name              pgsql
+    Match             kube.*
+    Host              postgres.database.svc
+    Port              5432
+    User              flowuser
+    Password          ${DB_PASSWORD}
+    Database          workflow_data
+    Table             workflow_events
+    Timestamp_Key     timestamp
+----
+
+This configuration:
+
+1. Collects all container logs from `/var/log/containers/`
+2. Enriches with Kubernetes metadata (namespace, pod, labels)
+3. Filters for Quarkus Flow events using the `eventType` field
+4. Routes to PostgreSQL
+
+TIP: For container mode, the structured events are already JSON in the log stream, so FluentBit can parse them directly without additional processing.
 
 === Dual Output Pattern
 


### PR DESCRIPTION
## Description

<!-- Provide a clear description of what this PR does -->

Fixes #495

## Changes

<!-- List the main changes in this PR -->

- Add a new configuration for the structured logging feature where users can pick from `file`, `console`, or `none`
- Updated docs, tests to verify the feature

### Test Plan

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] Tested manually (describe below if applicable)
