### PR TITLE
Lab 4: Add instruction to configure `org.acme.agentic.market-data.url` property

### DIFF
--- a/docs/modules/ROOT/pages/wk-lab-4-agentic-langchain4j.adoc
+++ b/docs/modules/ROOT/pages/wk-lab-4-agentic-langchain4j.adoc
@@ -74,6 +74,13 @@ Now we wire them together. This is the "Aha!" moment where the workflow coordina
 include::{examples-dir}org/acme/agentic/InvestmentMemoFlow.java[]
 ----
 
+Next, let's set the `org.acme.agentic.market-data.url` property in `application.properties` to point to our `MarketDataResource`:
+
+[source,properties]
+----
+org.acme.agentic.market-data.url=http://localhost:${quarkus.http.port}/market-data/{ticker}
+----
+
 === Understanding the Data Bridge (`outputAs`)
 Inside the `fetchMarketData` task, we use a lambda to bridge the tool and the agent:
 


### PR DESCRIPTION
This pull request adds documentation to clarify how to configure the `market-data.url` property in your application. The main change is the addition of instructions for setting the `org.acme.agentic.market-data.url` property in `application.properties` to ensure the application can connect to the `MarketDataResource`.

Configuration instructions:

* Added a section explaining how to set the `org.acme.agentic.market-data.url` property in `application.properties`, including an example value that points to the local `MarketDataResource`.