### PR TITLE
Remove system prompt command that converts json response

### DIFF
--- a/docs/modules/ROOT/examples/org/acme/agentic/InvestmentAnalystAgent.java
+++ b/docs/modules/ROOT/examples/org/acme/agentic/InvestmentAnalystAgent.java
@@ -25,14 +25,7 @@ import io.quarkiverse.langchain4j.RegisterAiService;
         - a stock ticker
         - a description of the investment objective
         - an investment horizon
-        - and a compact JSON snapshot of market data,
-
-        you MUST respond with a short JSON document that can be mapped to:
-          InvestmentMemo {
-            String summary;
-            String stance;      // BUY, HOLD or AVOID
-            List<String> keyRisks;
-          }
+        - and a compact JSON snapshot of market data
 
         Be concise and avoid marketing language.
         """)

--- a/examples/agentic-http/src/main/java/org/acme/agentic/InvestmentAnalystAgent.java
+++ b/examples/agentic-http/src/main/java/org/acme/agentic/InvestmentAnalystAgent.java
@@ -24,14 +24,7 @@ import jakarta.enterprise.context.ApplicationScoped;
         - a stock ticker
         - a description of the investment objective
         - an investment horizon
-        - and a compact JSON snapshot of market data,
-
-        you MUST respond with a short JSON document that can be mapped to:
-          InvestmentMemo {
-            String summary;
-            String stance;      // BUY, HOLD or AVOID
-            List<String> keyRisks;
-          }
+        - and a compact JSON snapshot of market data
 
         Be concise and avoid marketing language.
         """)


### PR DESCRIPTION
## Description

<!-- Provide a clear description of what this PR does -->

Removes the explicit instruction in the system prompt for the LLM to convert the output to JSON. This was removed because, when passing the object, the framework already adds this instruction automatically.

## Changes

<!-- List the main changes in this PR -->

- Removed the manual instruction to "produce JSON" from the system prompt in InvestmentAnalystAgent
- Relied on the framework's automatic handling of JSON output when returning objects
- Cleaned up prompt wording for clarity

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

- Verified that the agent still returns valid InvestmentMemo JSON objects without the explicit instruction in the prompt
- Confirmed that the framework correctly instructs the LLM to output JSON

## Checklist

Before submitting this PR, please ensure:

- [x] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [x] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [x] Documentation has been updated (if user-facing changes)
- [x] Commit messages are clear and follow conventional commits style
- [x] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
