### PR TITLE
Introduce a configuration property to allow users to choose between default and class-based naming strategies

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/DiscoveredWorkflowBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/DiscoveredWorkflowBuildItem.java
@@ -27,7 +27,7 @@ public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
     private Path absolute;
     private Path relativeToFlowDir;
     private WorkflowDefinitionId workflowDefinitionId;
-    private String regularIdentifier;
+    private String specIdentifier;
     private String className;
     private final From from;
     private byte[] content;
@@ -36,7 +36,7 @@ public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
         this.absolute = absolute;
         this.relativeToFlowDir = relativeToFlowDir;
         this.workflowDefinitionId = WorkflowDefinitionId.of(workflow);
-        this.regularIdentifier = WorkflowNameUtils.yamlDescriptorIdentifier(
+        this.specIdentifier = WorkflowNameUtils.yamlDescriptorIdentifier(
                 workflowDefinitionId.namespace(),
                 workflowDefinitionId.name());
         this.content = content;
@@ -90,8 +90,8 @@ public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
         return workflowDefinitionId.name();
     }
 
-    public String regularIdentifier() {
-        return regularIdentifier;
+    public String specIdentifier() {
+        return specIdentifier;
     }
 
     public WorkflowDefinitionId workflowDefinitionId() {

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowCollectorProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowCollectorProcessor.java
@@ -196,8 +196,7 @@ public class FlowCollectorProcessor {
 
     private static void tryAddUniqueWorkflow(DiscoveredWorkflowBuildItem item,
             Map<String, DiscoveredWorkflowBuildItem> uniqueWorkflows) {
-        String identifier = item.regularIdentifier();
-        if (uniqueWorkflows.put(identifier, item) != null) {
+        if (uniqueWorkflows.put(item.specIdentifier(), item) != null) {
             throw new IllegalStateException(String.format(
                     "Duplicate workflow detected %s", item.workflowDefinitionId()));
         }

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
@@ -10,13 +10,11 @@ import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Any;
-import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
-import org.objectweb.asm.Opcodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,11 +57,9 @@ import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldCreator;
-import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
 import io.quarkus.runtime.metrics.MetricsFactory;
 import io.serverlessworkflow.api.WorkflowFormat;
-import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.impl.WorkflowApplication;
 import io.serverlessworkflow.impl.WorkflowDefinition;
 import io.serverlessworkflow.impl.WorkflowException;
@@ -165,7 +161,7 @@ class FlowProcessor {
                 .filter(DiscoveredWorkflowBuildItem::fromSpec)
                 .toList();
         for (DiscoveredWorkflowBuildItem d : fromSpec) {
-            produceWorkflowBeanFromSpec(recorder, beans, identifiers, d);
+            produceWorkflowDefinitionBeanFromSpec(recorder, beans, identifiers, d);
         }
     }
 
@@ -185,68 +181,32 @@ class FlowProcessor {
         identifiers.produce(new FlowIdentifierBuildItem(Set.of(it.className())));
     }
 
-    private void produceWorkflowBeanFromSpec(WorkflowDefinitionRecorder recorder,
+    private void produceWorkflowDefinitionBeanFromSpec(WorkflowDefinitionRecorder recorder,
             BuildProducer<SyntheticBeanBuildItem> beans, BuildProducer<FlowIdentifierBuildItem> identifiers,
             DiscoveredWorkflowBuildItem workflow) {
         String flowSubclassIdentifier = WorkflowNamingConverter.generateFlowClassIdentifier(
                 workflow.namespace(), workflow.name(), this.flowDefinitionsConfig.namespace().prefix());
 
-        beans.produce(SyntheticBeanBuildItem.configure(WorkflowDefinition.class)
-                .scope(ApplicationScoped.class)
-                .unremovable()
-                .setRuntimeInit()
-                .addQualifier().annotation(DotNames.IDENTIFIER)
-                .addValue("value", workflow.regularIdentifier()).done()
-                .addQualifier().annotation(DotNames.IDENTIFIER)
-                .addValue("value", flowSubclassIdentifier).done()
-                .addInjectionPoint(ClassType.create(DotName.createSimple(WorkflowRegistry.class)))
-                .createWith(recorder.workflowDefinitionFromFileCreator(
-                        workflow.name(), workflow.content(), WorkflowFormat.fromFileName(workflow.name())))
-                .done());
+        String identifier = this.flowDefinitionsConfig.namingStrategy() == FlowDefinitionsConfig.NamingStrategy.SPEC
+                ? workflow.specIdentifier()
+                : flowSubclassIdentifier;
+
+        beans.produce(produceSyntheticWorkflowDefinitionBean(identifier, recorder, workflow));
 
         identifiers.produce(new FlowIdentifierBuildItem(
-                Set.of(flowSubclassIdentifier, workflow.regularIdentifier())));
+                Set.of(identifier)));
     }
 
     @BuildStep
     void produceGeneratedFlows(List<DiscoveredWorkflowBuildItem> workflows,
-            BuildProducer<GeneratedBeanBuildItem> classes,
-            FlowDefinitionsConfig definitionsConfig) {
+            BuildProducer<GeneratedBeanBuildItem> classes) {
 
         List<DiscoveredWorkflowBuildItem> fromSpec = workflows.stream().filter(DiscoveredWorkflowBuildItem::fromSpec)
                 .toList();
 
         GeneratedBeanGizmoAdaptor gizmo = new GeneratedBeanGizmoAdaptor(classes);
         for (DiscoveredWorkflowBuildItem workflow : fromSpec) {
-            String flowSubclassIdentifier = WorkflowNamingConverter.generateFlowClassIdentifier(
-                    workflow.namespace(), workflow.name(), definitionsConfig.namespace().prefix());
-
-            try (ClassCreator creator = ClassCreator.builder()
-                    .className(flowSubclassIdentifier)
-                    .superClass(DotNames.FLOW.toString())
-                    .classOutput(gizmo)
-                    .build()) {
-
-                creator.addAnnotation(Unremovable.class);
-                creator.addAnnotation(ApplicationScoped.class);
-                creator.addAnnotation(Identifier.class).add("value", flowSubclassIdentifier);
-
-                // workflowDefinition field
-                FieldCreator fieldCreator = creator.getFieldCreator("workflowDefinition",
-                        WorkflowDefinition.class.getName());
-                fieldCreator.setModifiers(Opcodes.ACC_PUBLIC);
-                fieldCreator.addAnnotation(Inject.class);
-                fieldCreator.addAnnotation(Identifier.class)
-                        .add("value", flowSubclassIdentifier);
-
-                // descriptor() method
-                var method = creator.getMethodCreator("descriptor", Workflow.class);
-                method.setModifiers(Opcodes.ACC_PUBLIC);
-                method.returnValue(
-                        method.invokeVirtualMethod(
-                                MethodDescriptor.ofMethod(WorkflowDefinition.class, "workflow", Workflow.class),
-                                method.readInstanceField(fieldCreator.getFieldDescriptor(), method.getThis())));
-            }
+            produceFlowGizmoBean(workflow, gizmo);
         }
 
     }
@@ -418,5 +378,78 @@ class FlowProcessor {
 
         LOG.info("Quarkus Flow structured logging console handler auto-configured. " +
                 "Events will be written to stdout (containers mode)");
+    }
+
+    private static SyntheticBeanBuildItem produceSyntheticWorkflowDefinitionBean(String identifier,
+            WorkflowDefinitionRecorder recorder, DiscoveredWorkflowBuildItem workflow) {
+        return SyntheticBeanBuildItem.configure(WorkflowDefinition.class)
+                .scope(ApplicationScoped.class)
+                .unremovable()
+                .setRuntimeInit()
+                .addQualifier().annotation(DotNames.IDENTIFIER)
+                .addValue("value", identifier).done()
+                .addInjectionPoint(ClassType.create(DotName.createSimple(WorkflowRegistry.class)))
+                .createWith(recorder.workflowDefinitionFromFileCreator(
+                        workflow.name(), workflow.content(), WorkflowFormat.fromFileName(workflow.name())))
+                .done();
+    }
+
+    /**
+     * Generates a CDI-managed subclass of {@code Flow} using Gizmo.
+     *
+     * <p>
+     * The generated class has this effective structure:
+     *
+     * <pre>
+     * {@code
+     * &#64;Unremovable
+     * &#64;ApplicationScoped
+     * &#64;Identifier(identifier)
+     * class {className} extends Flow {
+     *
+     *     &#64;Inject
+     *     &#64;Identifier(identifier)
+     *     public WorkflowDefinition workflowDefinition;
+     *
+     *     public Workflow descriptor() {
+     *         return this.workflowDefinition.workflow();
+     *     }
+     * }
+     * }
+     * </pre>
+     * <p>
+     * When {@code specIdentifier} is {@code false}, the CDI bean identifier is prefixed with
+     * {@code Normal}, but the injected {@code workflowDefinition} field still uses {@code className}
+     * as its {@code @Identifier} value.
+     */
+    private void produceFlowGizmoBean(DiscoveredWorkflowBuildItem workflow,
+            GeneratedBeanGizmoAdaptor gizmo) {
+
+        String flowSubclassIdentifier = WorkflowNamingConverter.generateFlowClassIdentifier(
+                workflow.namespace(), workflow.name(), this.flowDefinitionsConfig.namespace().prefix());
+
+        String identifier = flowDefinitionsConfig.namingStrategy() == FlowDefinitionsConfig.NamingStrategy.SPEC
+                ? workflow.specIdentifier()
+                : flowSubclassIdentifier;
+
+        try (ClassCreator creator = ClassCreator.builder()
+                .className(flowSubclassIdentifier)
+                .superClass(DotNames.FLOW.toString())
+                .classOutput(gizmo)
+                .build()) {
+
+            creator.addAnnotation(Unremovable.class);
+            creator.addAnnotation(ApplicationScoped.class);
+            creator.addAnnotation(Identifier.class).add("value", identifier);
+
+            // @Inject @Identifier(identifier) public WorkflowDefinition workflowDefinition;
+            FieldCreator fieldCreator = GizmoFlowHelper.addWorkflowDefinitionField(creator, identifier);
+
+            // public String identifier() { return identifier; }
+            GizmoFlowHelper.addIdentifierMethod(creator, identifier);
+
+            // public Workflow descriptor() method
+            GizmoFlowHelper.addDescriptorMethod(creator, fieldCreator);
+        }
     }
 }

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/GizmoFlowHelper.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/GizmoFlowHelper.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.flow.deployment;
+
+import jakarta.inject.Inject;
+
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.serverlessworkflow.api.types.Workflow;
+import io.serverlessworkflow.impl.WorkflowDefinition;
+import io.smallrye.common.annotation.Identifier;
+
+interface GizmoFlowHelper {
+
+    static FieldCreator addWorkflowDefinitionField(ClassCreator creator, String identifier) {
+        FieldCreator fieldCreator = creator.getFieldCreator("workflowDefinition",
+                WorkflowDefinition.class.getName());
+        fieldCreator.setModifiers(Opcodes.ACC_PUBLIC);
+        fieldCreator.addAnnotation(Inject.class);
+        fieldCreator.addAnnotation(Identifier.class)
+                .add("value", identifier);
+        return fieldCreator;
+    }
+
+    static void addIdentifierMethod(ClassCreator creator, String identifier) {
+        var identifierMethod = creator.getMethodCreator("identifier", String.class);
+        identifierMethod.setModifiers(Opcodes.ACC_PUBLIC);
+        identifierMethod.returnValue(identifierMethod.load(identifier));
+    }
+
+    static void addDescriptorMethod(ClassCreator creator, FieldCreator fieldCreator) {
+        var descriptor = creator.getMethodCreator("descriptor", Workflow.class);
+        descriptor.setModifiers(Opcodes.ACC_PUBLIC);
+        descriptor.returnValue(
+                descriptor.invokeVirtualMethod(
+                        MethodDescriptor.ofMethod(WorkflowDefinition.class, "workflow", Workflow.class),
+                        descriptor.readInstanceField(fieldCreator.getFieldDescriptor(), descriptor.getThis())));
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/FlowWorkflowFromFileDevModeTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/FlowWorkflowFromFileDevModeTest.java
@@ -17,6 +17,7 @@ public class FlowWorkflowFromFileDevModeTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource(new StringAsset("""
                             quarkus.flow.definitions.dir=src/main/resources/flow
+                            quarkus.flow.definitions.naming-strategy=spec
                             quarkus.flow.tracing.enabled=false
                             quarkus.http.test-port=0
                             """), "application.properties")
@@ -54,7 +55,7 @@ public class FlowWorkflowFromFileDevModeTest {
     @Test
     void should_reload_flow_identifier() {
 
-        String oldIdentifier = "default.WaitDurationInline";
+        String oldIdentifier = "default:wait-duration-inline";
         String path = "/identifier/flow";
 
         identifierMustMatch(path, oldIdentifier);
@@ -63,7 +64,7 @@ public class FlowWorkflowFromFileDevModeTest {
                 // replace name wait-duration-inline to wait-please
                 content -> content.replace("wait-duration-inline", "wait-please"));
 
-        identifierMustMatch(path, "default.WaitPlease");
+        identifierMustMatch(path, "default:wait-please");
 
         // Old identifier should no longer be available
         shouldNoLongerBeAvailable(path, oldIdentifier);

--- a/core/deployment/src/test/resources/application-naming-strategy-class.properties
+++ b/core/deployment/src/test/resources/application-naming-strategy-class.properties
@@ -1,0 +1,2 @@
+quarkus.flow.definitions.naming-strategy=class
+quarkus.flow.definitions.dir=src/main/resources/flow

--- a/core/integration-tests/src/main/java/io/quarkiverse/flow/it/EchoResource.java
+++ b/core/integration-tests/src/main/java/io/quarkiverse/flow/it/EchoResource.java
@@ -17,7 +17,7 @@ import io.smallrye.common.annotation.Identifier;
 public class EchoResource {
 
     @Inject
-    @Identifier("flow.EchoName")
+    @Identifier("flow:echo-name")
     Flow flow;
 
     @Inject

--- a/core/integration-tests/src/main/java/io/quarkiverse/flow/it/HelloResource.java
+++ b/core/integration-tests/src/main/java/io/quarkiverse/flow/it/HelloResource.java
@@ -16,18 +16,34 @@
  */
 package io.quarkiverse.flow.it;
 
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
 
 import org.jboss.resteasy.reactive.ResponseStatus;
 
+import io.quarkiverse.flow.Flow;
+import io.serverlessworkflow.impl.WorkflowDefinition;
+import io.smallrye.common.annotation.Identifier;
 import io.smallrye.mutiny.Uni;
 
 @Path("/hello")
 @ApplicationScoped
 public class HelloResource {
+
+    @Inject
+    @Identifier("flow:echo-name")
+    WorkflowDefinition workflowDefEcho;
+
+    @Inject
+    @Identifier("flow:echo-name")
+    Flow flowEcho;
 
     @Inject
     HelloWorkflow helloWorldWorkflow;
@@ -49,5 +65,23 @@ public class HelloResource {
         return problematicWorkflow.startInstance()
                 .onItem()
                 .transform(wf -> wf.as(Message.class).orElseThrow());
+    }
+
+    @GET
+    @Path("/workflow-def/echo-name")
+    public CompletableFuture<Message> workflowDefEchoName(@QueryParam(value = "name") @DefaultValue("John Doe") String name) {
+        return workflowDefEcho.instance(Map.of(
+                "name", name)).start()
+                .thenApply(model -> {
+                    return model.as(Message.class).orElseThrow();
+                });
+    }
+
+    @GET
+    @Path("/flow/echo-name")
+    public CompletableFuture<Message> flowEchoName(@QueryParam(value = "name") @DefaultValue("John Doe") String name) {
+        return flowEcho.instance(Map.of(
+                "name", name)).start()
+                .thenApply(model -> model.as(Message.class).orElseThrow());
     }
 }

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/HelloResourceTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/HelloResourceTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.is;
 
 import java.util.Map;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -23,7 +24,15 @@ import io.restassured.http.ContentType;
 public class HelloResourceTest {
 
     @Test
-    public void testHelloEndpoint() {
+    @DisplayName("Should inject WorkflowDefinition and Flow with normal identifier (flow:echo-name)")
+    public void should_inject_flow_with_normal_identifier() {
+        shouldExecuteGetRequestForEchoName("/hello/workflow-def/echo-name");
+        shouldExecuteGetRequestForEchoName("/hello/flow/echo-name");
+    }
+
+    @Test
+    @DisplayName("Should execute echo-name.yaml (src/test/flow) correctly")
+    public void test_hello_endpoint() {
         given()
                 .when().get("/hello")
                 .then()
@@ -33,13 +42,24 @@ public class HelloResourceTest {
     }
 
     @Test
-    public void testProblemDetails() {
+    @DisplayName("Should execute ProblematicWorkflow correctly (Problem Details + OpenAPI)")
+    public void test_problem_details() {
         given()
                 .when().get("/hello/problem-details")
                 .then()
                 .statusCode(503)
                 .contentType(ContentType.JSON)
                 .body("type", containsString("https://serverlessworkflow.io/spec/1.0.0/errors/communication"));
+    }
+
+    private static void shouldExecuteGetRequestForEchoName(String path) {
+        given()
+                .queryParam("name", "Matheus Cruz")
+                .get(path)
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("message", containsString("Matheus Cruz"));
     }
 
     public static class WireMockTestResource implements QuarkusTestResourceLifecycleManager {

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/HttpAsyncCompletionTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/HttpAsyncCompletionTest.java
@@ -43,7 +43,7 @@ public class HttpAsyncCompletionTest {
             """;
 
     @Inject
-    @Identifier("flow.HttpAsyncCompletion")
+    @Identifier("flow:http-async-completion")
     Flow httpAsyncCompletionFlow;
 
     @BeforeEach

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/NamedHttpMetadataPropagationTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/NamedHttpMetadataPropagationTest.java
@@ -46,7 +46,7 @@ public class NamedHttpMetadataPropagationTest {
             """;
 
     @Inject
-    @Identifier("flow.QuarkusFlow")
+    @Identifier("flow:quarkus-flow")
     Flow quarkusFlowFlow;
 
     @Inject

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingHttpAsyncTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingHttpAsyncTest.java
@@ -58,7 +58,7 @@ public class StructuredLoggingHttpAsyncTest {
             """;
 
     @Inject
-    @Identifier("flow.HttpAsyncCompletion")
+    @Identifier("flow:http-async-completion")
     Flow httpAsyncCompletionFlow;
 
     @BeforeEach

--- a/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowDefinitionsConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowDefinitionsConfig.java
@@ -15,6 +15,22 @@ import io.smallrye.config.WithDefault;
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public interface FlowDefinitionsConfig {
 
+    enum NamingStrategy {
+        SPEC("spec"),
+        CLASS("class");
+
+        private final String configValue;
+
+        NamingStrategy(String configValue) {
+            this.configValue = configValue;
+        }
+
+        @Override
+        public String toString() {
+            return configValue;
+        }
+    }
+
     String DEFAULT_FLOW_DIR = "src/main/flow";
     String ROOT_KEY = "quarkus.flow.definitions";
 
@@ -28,6 +44,19 @@ public interface FlowDefinitionsConfig {
      */
     @WithDefault(DEFAULT_FLOW_DIR)
     Optional<String> dir();
+
+    /**
+     * Naming strategy to be used when generating {@link Identifier#value()} for {@link io.quarkiverse.flow.Flow} and
+     * {@link io.serverlessworkflow.impl.WorkflowDefinition} beans generated from YAML/JSON DSL.
+     * <p>
+     * Given a workflow definition with namespace (<code>namespace: foo</code>) name (<code>name: bar</code>):
+     * <ul>
+     * <li>If the naming strategy is <code>class</code>, the generated identifier will be <code>foo.Bar</code>.</li>
+     * <li>If the naming strategy is <code>spec</code>, the generated identifier will be <code>foo:bar</code>.</li>
+     * </ul>
+     */
+    @WithDefault("spec")
+    NamingStrategy namingStrategy();
 
     NamespaceConfig namespace();
 

--- a/docs/modules/ROOT/examples/org/acme/EchoResource.java
+++ b/docs/modules/ROOT/examples/org/acme/EchoResource.java
@@ -16,7 +16,7 @@ import io.smallrye.mutiny.Uni;
 public class EchoResource {
 
     @Inject
-    @Identifier("company.EchoName") // <1>
+    @Identifier("company:echo-name") // <1>
     Flow flow;
 
     @GET

--- a/docs/modules/ROOT/pages/includes/quarkus-flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow.adoc
@@ -32,6 +32,32 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++src/main/flow+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-definitions-naming-strategy]] [.property-path]##link:#quarkus-flow_quarkus-flow-definitions-naming-strategy[`+++quarkus.flow.definitions.naming-strategy+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.definitions.naming-strategy+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Naming strategy to be used when generating `Identifier++#++value()` for `io.quarkiverse.flow.Flow` and `io.serverlessworkflow.impl.WorkflowDefinition` beans generated from YAML/JSON DSL.
+
+Given a workflow definition with namespace (`namespace: foo`) name (`name: bar`):
+
+ - If the naming strategy is `class`, the generated identifier will be `foo.Bar`.
+ - If the naming strategy is `spec`, the generated identifier will be `foo:bar`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DEFINITIONS_NAMING_STRATEGY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_DEFINITIONS_NAMING_STRATEGY+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`spec`, `class`
+|`+++spec+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-definitions-namespace-prefix]] [.property-path]##link:#quarkus-flow_quarkus-flow-definitions-namespace-prefix[`+++quarkus.flow.definitions.namespace.prefix+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.definitions.namespace.prefix+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.flow.adoc
@@ -32,6 +32,32 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++src/main/flow+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-definitions-naming-strategy]] [.property-path]##link:#quarkus-flow_quarkus-flow-definitions-naming-strategy[`+++quarkus.flow.definitions.naming-strategy+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.definitions.naming-strategy+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Naming strategy to be used when generating `Identifier++#++value()` for `io.quarkiverse.flow.Flow` and `io.serverlessworkflow.impl.WorkflowDefinition` beans generated from YAML/JSON DSL.
+
+Given a workflow definition with namespace (`namespace: foo`) name (`name: bar`):
+
+ - If the naming strategy is `class`, the generated identifier will be `foo.Bar`.
+ - If the naming strategy is `spec`, the generated identifier will be `foo:bar`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DEFINITIONS_NAMING_STRATEGY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_DEFINITIONS_NAMING_STRATEGY+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`spec`, `class`
+|`+++spec+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-definitions-namespace-prefix]] [.property-path]##link:#quarkus-flow_quarkus-flow-definitions-namespace-prefix[`+++quarkus.flow.definitions.namespace.prefix+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.definitions.namespace.prefix+++[]

--- a/docs/modules/ROOT/pages/workflow-definitions.adoc
+++ b/docs/modules/ROOT/pages/workflow-definitions.adoc
@@ -55,10 +55,35 @@ Only exact relative-path matches are overridden. For example, `src/test/flow/ech
 
 During the Quarkus build, the engine parses your YAML files and generates `WorkflowDefinition` and `Flow` CDI beans for them.
 
-Quarkus Flow uses the `document.namespace` and `document.name` fields from your YAML file to create a unique identifier for the bean. It generates two formats you can use:
+Quarkus Flow uses the `document.namespace` and `document.name` fields from your YAML file to create a unique identifier for the bean.
 
-* **Fully Qualified Class Name (Recommended):** `namespace.name` (e.g., if your YAML has `namespace: org.acme` and `name: EchoWorkflow`, the identifier is `org.acme.EchoWorkflow`. If your YAML has `namespace: org.acme` and `name: echo-workflow`, the identifier is also `org.acme.EchoWorkflow`).
-* **Regular:** `namespace:name` (e.g., `org.acme:EchoWorkflow`).
+=== 2.1. Naming Strategy
+
+You can choose between two identifier formats using the xref:configuration.adoc#quarkus-flow_quarkus-flow-definitions-naming-strategy[`quarkus.flow.definitions.naming-strategy`] property:
+
+[cols="1,2,3"]
+|===
+|Strategy |Format |Example
+
+|`regular` (default)
+|`namespace:name`
+|Given `namespace: company` and `name: echo-name`, the identifier is `company:echo-name`
+
+|`class`
+|`namespace.ClassName`
+|Given `namespace: company` and `name: echo-name`, the identifier is `company.EchoName` (name is converted to PascalCase)
+|===
+
+The `spec` strategy preserves the exact workflow name as defined in your YAML, while the `class` strategy converts the name to PascalCase for a Java class-like identifier.
+
+To use the `class` strategy, add this to your `application.properties`:
+
+[source,properties]
+----
+quarkus.flow.definitions.naming-strategy=class
+----
+
+=== 2.2. Inject and Execute the Workflow
 
 Create a JAX-RS resource that injects and runs the workflow using the generated identifier:
 
@@ -66,7 +91,7 @@ Create a JAX-RS resource that injects and runs the workflow using the generated 
 ----
 include::{examples-dir}org/acme/EchoResource.java[]
 ----
-<1> Use the `@Identifier` annotation with the *Fully Qualified Class Name* derived from your YAML file.
+<1> Use the `@Identifier` annotation with the identifier derived from your YAML file. With the default `spec` naming strategy, this follows the `namespace:name` format.
 
 [IMPORTANT]
 ====

--- a/examples/micrometer-prometheus/src/main/java/org/acme/TryWorkflowsResource.java
+++ b/examples/micrometer-prometheus/src/main/java/org/acme/TryWorkflowsResource.java
@@ -32,11 +32,11 @@ public class TryWorkflowsResource {
     EventWorkflow eventWorkflow;
 
     @Inject
-    @Identifier("test.RetryableExample")
+    @Identifier("test:retryable-example")
     Flow retryable;
 
     @Inject
-    @Identifier("test.EmitEvent")
+    @Identifier("test:emit-event")
     Flow emitWorkflow;
 
     @Inject

--- a/examples/suspend-resume-abort/src/main/java/org/acme/flow/FlowAPIResource.java
+++ b/examples/suspend-resume-abort/src/main/java/org/acme/flow/FlowAPIResource.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
 public class FlowAPIResource {
 
     @Inject
-    @Identifier("example.SwitchLoopWait")
+    @Identifier("example:SwitchLoopWait")
     WorkflowDefinition flow;
 
     /**


### PR DESCRIPTION
## Description

<!-- Provide a clear description of what this PR does -->

Fixes #497 

## Changes

<!-- List the main changes in this PR -->
Introduce a new property called `quarkus.flow.definitions.naming-strategy`.

### Motivation

To solve the issue #497 and after some investigation, we identified a limitation with the current approach:

The `@Identifier` annotation cannot be used more than once, as it is not repeatable.
As an alternative, we considered introducing a custom annotation, but this would add unnecessary complexity.

Based on these findings, we decided to introduce a new configuration property that allows users to choose the naming strategy (e.g., default or class-based).

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [X] Unit tests added/updated
- [X] Integration tests added/updated (if applicable)
- [X] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [x] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [x] Code follows the project's code conventions
- [x] Tests have been added/updated to cover the changes
- [x] Documentation has been updated (if user-facing changes)
- [x] Commit messages are clear and follow conventional commits style
- [x] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
