### PR TITLE
Fix `extensionByInstanceId` event filtering in Quarkus Messaging + update `newsletter-drafter` example

### DIFF
--- a/examples/newsletter-drafter/src/main/java/org/acme/newsletter/NewsletterWorkflow.java
+++ b/examples/newsletter-drafter/src/main/java/org/acme/newsletter/NewsletterWorkflow.java
@@ -2,6 +2,7 @@ package org.acme.newsletter;
 
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.agent;
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.consume;
+import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.consumed;
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.emitJson;
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.function;
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.listen;
@@ -39,7 +40,8 @@ public class NewsletterWorkflow extends Flow {
         return FuncWorkflowBuilder.workflow("intelligent-newsletter")
                 .tasks(agent("draftAgent", draftAgent::write, NewsletterRequest.class),
                         emitJson("draftReady", "org.acme.email.review.required", NewsletterDraft.class),
-                        listen("waitHumanReview", toOne("org.acme.newsletter.review.done"))
+                        listen("waitHumanReview",
+                                toOne(consumed("org.acme.newsletter.review.done").extensionByInstanceId("flowinstanceid")))
                                 .outputAs((JsonNode node) -> node.isArray() ? node.get(0) : node),
                         switchWhenOrElse(h -> HumanReview.ReviewStatus.NEEDS_REVISION.equals(h.status()),
                                 "humanEditorAgent", "sendNewsletter", HumanReview.class),

--- a/examples/newsletter-drafter/src/main/java/org/acme/newsletter/web/NewsletterAPIResource.java
+++ b/examples/newsletter-drafter/src/main/java/org/acme/newsletter/web/NewsletterAPIResource.java
@@ -8,6 +8,7 @@ import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.jackson.JsonFormat;
 import io.serverlessworkflow.impl.WorkflowInstance;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
@@ -58,10 +59,12 @@ public class NewsletterAPIResource {
 
     @PUT
     @Path("/newsletter")
-    public Response sendReview(HumanReview review) throws JsonProcessingException {
+    public Response sendReview(HumanReview review, @HeaderParam("X-Flow-Instance-Id") String instanceId)
+            throws JsonProcessingException {
         byte[] body = objectMapper.writeValueAsBytes(review);
 
         CloudEvent ce = CloudEventBuilder.v1().withId(UUID.randomUUID().toString())
+                .withExtension("flowinstanceid", instanceId)
                 .withSource(URI.create("api:/newsletter")).withType("org.acme.newsletter.review.done")
                 .withDataContentType("application/json").withData(body).build();
 

--- a/examples/newsletter-drafter/src/main/resources/META-INF/resources/index.html
+++ b/examples/newsletter-drafter/src/main/resources/META-INF/resources/index.html
@@ -118,6 +118,8 @@
 
 <script>
     // --- State Management ---
+    let currentInstanceId = null;
+
     function showView(viewId) {
         // Add d-none to all sections to hide them completely
         document.querySelectorAll('.view-section').forEach(el => el.classList.add('d-none'));
@@ -174,8 +176,11 @@
             body: JSON.stringify(requestData)
         }).then(response => {
             if(response.ok) {
-                document.getElementById('loading-text').innerText = "AI Agents are crafting your newsletter...";
-                showView('loading-view');
+                return response.json().then(body => {
+                    currentInstanceId = body.instanceId;
+                    document.getElementById('loading-text').innerText = "AI Agents are crafting your newsletter...";
+                    showView('loading-view');
+                });
             } else {
                 alert("Failed to start workflow! Check server logs for Jackson mapping errors.");
                 console.error("Payload rejected:", requestData);
@@ -197,7 +202,10 @@
 
         fetch('/api/newsletter', {
             method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Flow-Instance-Id': currentInstanceId
+            },
             body: JSON.stringify(reviewData)
         }).then(response => {
             if(response.ok) {
@@ -219,6 +227,7 @@
 
     // 4. Reset App
     document.getElementById('btn-reset').addEventListener('click', () => {
+        currentInstanceId = null;
         document.getElementById('request-form').reset();
         showView('request-view');
     });

--- a/examples/newsletter-drafter/src/test/java/org/acme/newsletter/NewsletterWorkflowIT.java
+++ b/examples/newsletter-drafter/src/test/java/org/acme/newsletter/NewsletterWorkflowIT.java
@@ -152,7 +152,9 @@ public class NewsletterWorkflowIT {
     private void sendHumanReview(String instanceId, HumanReview review) {
         // REST wrapper sends CloudEvent to flow-in.
         // We pass the instanceId so the API can attach it as the 'flowinstanceid' CE extension.
-        given().contentType("application/json").body(review).when().put("/api/newsletter").then().statusCode(202);
+        given()
+                .header("X-Flow-Instance-Id", instanceId)
+                .contentType("application/json").body(review).when().put("/api/newsletter").then().statusCode(202);
     }
 
     private NewsletterDraft parseNewsletterDraft(CloudEvent ce) {

--- a/messaging/deployment/pom.xml
+++ b/messaging/deployment/pom.xml
@@ -20,6 +20,10 @@
             <artifactId>quarkus-messaging-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-deployment</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.flow</groupId>
             <artifactId>quarkus-flow-messaging</artifactId>
             <version>${project.version}</version>

--- a/messaging/deployment/src/main/java/io/quarkiverse/flow/messaging/deployment/FlowMessagingProcessor.java
+++ b/messaging/deployment/src/main/java/io/quarkiverse/flow/messaging/deployment/FlowMessagingProcessor.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import io.quarkiverse.flow.messaging.FlowDomainEventsPublisher;
 import io.quarkiverse.flow.messaging.FlowLifecycleEventsPublisher;
 import io.quarkiverse.flow.messaging.FlowMessagingConsumer;
+import io.quarkiverse.flow.messaging.ObjectMapperCloudEventCustomizer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -53,6 +54,11 @@ public class FlowMessagingProcessor {
         }
 
         beans.produce(builder.setUnremovable().build());
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem additionalBean() {
+        return AdditionalBeanBuildItem.unremovableOf(ObjectMapperCloudEventCustomizer.class);
     }
 
 }

--- a/messaging/runtime/pom.xml
+++ b/messaging/runtime/pom.xml
@@ -16,6 +16,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-messaging</artifactId>
         </dependency>
         <dependency>

--- a/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/ObjectMapperCloudEventCustomizer.java
+++ b/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/ObjectMapperCloudEventCustomizer.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.flow.messaging;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.cloudevents.jackson.JsonFormat;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+@ApplicationScoped
+public class ObjectMapperCloudEventCustomizer implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        objectMapper.registerModule(JsonFormat.getCloudEventJacksonModule());
+    }
+}


### PR DESCRIPTION
# Changes

## Register CloudEvent Jackson module

Added `ObjectMapperCloudEventCustomizer`, a Quarkus `ObjectMapperCustomizer` that registers
`JsonFormat.getCloudEventJacksonModule()` on the application-wide `ObjectMapper`.

## Use `extensionByInstanceId` in `NewsletterWorkflow`

Replaced the previous event-matching strategy with `consumed(...).extensionByInstanceId("flowinstanceid")`
so that the `waitHumanReview` listen task only resumes the workflow instance that originally
requested the review, correctly correlating events in concurrent runs.

Updated the frontend (`index.html`) to:
- capture the `instanceId` returned by `POST /api/newsletter`
- forward it as the `X-Flow-Instance-Id` header on `PUT /api/newsletter`, so the backend
  can embed it in the outgoing CloudEvent and the workflow can filter by it

## Why it was necessary to register CloudEvent module?

`JacksonModel.convert(Class<T>)` delegates to `JsonUtils.mapper()`.
In a Quarkus application, that call resolves to the **Quarkus-managed `ObjectMapper`** bean —
the same one used by RESTEasy, JSON-B, etc.

That mapper does **not** know how to deserialize `CloudEvent` by default, because
`io.cloudevents.CloudEvent` is an **interface** with no built-in Jackson deserializer.
Without the CloudEvents module, Jackson throws:

```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException:
  Cannot construct instance of `io.cloudevents.CloudEvent`
  (no Creators, like default constructor, exist): abstract types either need to be
  mapped to concrete types, have custom deserializer, or contain additional type information
```

Closes #273
