### PR TITLE
issue-509 - bug:durable-k8s-kind.yml is still deploying redis for tes…

### DIFF
--- a/.github/workflows/durable-k8s-kind.yml
+++ b/.github/workflows/durable-k8s-kind.yml
@@ -38,9 +38,9 @@ jobs:
           kubectl cluster-info
           kubectl get nodes -o wide
 
-      - name: Deploy Redis
+      - name: Deploy Valkey
         run: |
-          kubectl apply -f examples/durable-workflows-k8s/manifests/redis.yaml
+          kubectl apply -f examples/durable-workflows-k8s/manifests/valkey.yaml
           kubectl wait --for=condition=Ready pod -l app=redis --timeout=120s -n default
 
       - name: Build + deploy example to Kind (from repo root, single-threaded)

--- a/examples/durable-workflows-k8s/manifests/valkey.yaml
+++ b/examples/durable-workflows-k8s/manifests/valkey.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: redis:7.2-alpine
+          image: valkey/valkey:7.2-alpine
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 6379


### PR DESCRIPTION
…ting

## Description

- Valkey image valkey/valkey:7.2-alpine is a drop-in replacement for Redis
- All ports (6379), labels, and configurations preserved for backward compatibility
- Workflow now deploys Valkey instead of Redis while maintaining full compatibility

Fixes #509 

## Changes

* `examples/durable-workflows-k8s/manifests/redis.yaml` - Docker image updated from redis:7.2-alpine to [valkey/valkey:7.2-alpine](https://hub.docker.com/layers/valkey/valkey/7.2-alpine/images/sha256-a2d812e8831ac337b0a9ac1ceb7618684ca27f5393f603693ac3eb703444057f)
* `.github/workflows/durable-k8s-kind.yml` - Step name changed from "Deploy Redis" to "Deploy Valkey" and manifest reference updated to valkey.yaml



## Testing

Workflow should pass in CI checks

### Test Plan

Updates the workflow that executes tests

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [x] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [x] Code follows the project's code conventions
- [x] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [x] Commit messages are clear and follow conventional commits style
- [x] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
