### PR TITLE
Add native support for yaml files

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowNativeProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowNativeProcessor.java
@@ -9,7 +9,6 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.LambdaCapturingTypeBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
-import io.serverlessworkflow.impl.WorkflowError;
 import io.serverlessworkflow.impl.WorkflowModelFactory;
 import io.serverlessworkflow.impl.additional.NamedWorkflowAdditionalObject;
 import io.serverlessworkflow.impl.auth.JWTConverter;
@@ -19,7 +18,6 @@ import io.serverlessworkflow.impl.executors.CallableTaskBuilder;
 import io.serverlessworkflow.impl.executors.TaskExecutorFactory;
 import io.serverlessworkflow.impl.executors.func.DataTypeConverter;
 import io.serverlessworkflow.impl.executors.http.HttpRequestDecorator;
-import io.serverlessworkflow.impl.executors.openapi.UnifiedOpenAPI;
 import io.serverlessworkflow.impl.expressions.ExpressionFactory;
 
 final class FlowNativeProcessor {
@@ -51,13 +49,8 @@ final class FlowNativeProcessor {
     @BuildStep
     ReflectiveClassBuildItem registerForReflection() {
         return ReflectiveClassBuildItem.builder(
-                WorkflowError.class,
-                UnifiedOpenAPI.class,
-                UnifiedOpenAPI.Server.class,
-                UnifiedOpenAPI.PathItem.class,
-                UnifiedOpenAPI.Operation.class,
-                UnifiedOpenAPI.Parameter.class,
-                UnifiedOpenAPI.Components.class)
+                "org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator",
+                "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator")
                 .constructors(true)
                 .methods(true)
                 .fields(true)

--- a/core/integration-tests/src/main/resources/application.properties
+++ b/core/integration-tests/src/main/resources/application.properties
@@ -9,4 +9,4 @@ quarkus.langchain4j.ollama.chat-model.top-p=1
 quarkus.langchain4j.ollama.chat-model.num-predict=8
 
 quarkus.native.resources.includes=openapi/problematic.json
-quarkus.native.additional-build-args=--initialize-at-run-time=io.quarkiverse.langchain4j.QuarkusJsonCodecFactory$ObjectMapperHolder
+quarkus.native.additional-build-args=--initialize-at-run-time=io.quarkiverse.langchain4j.QuarkusJsonCodecFactory$ObjectMapperHolder\\,io.quarkiverse.langchain4j.QuarkusJsonCodecFactory$SnakeCaseObjectMapperHolder

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/EchoResourceIT.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/EchoResourceIT.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.flow.it;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.RestAssured;
+
+@QuarkusIntegrationTest
+public class EchoResourceIT {
+
+    @Test
+    void inject_from_file_should_execute_using_Flow() {
+        RestAssured.given()
+                .queryParam("name", "Anakin Skywalker")
+                .get("/echo/from-flow")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("Anakin Skywalker"));
+    }
+
+    @Test
+    void inject_from_file_should_execute_using_WorkflowDefinition() {
+        RestAssured.given()
+                .queryParam("name", "Anakin Skywalker")
+                .get("/echo/from-workflow-def")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("Anakin Skywalker"));
+    }
+
+}


### PR DESCRIPTION
After https://github.com/serverlessworkflow/sdk-java/pull/1370, reading of yaml files on native mode should start working. 

This adds a native test that fails with the current sdk version, remove the native classes that are not declared by the SDK and add a new L4CJ temporary fix. 

Try this PR when Qflow is updated to the latest version
