### PR TITLE
Replace Redis Docker image in test classes with a specific version for consistency

### DIFF
--- a/persistence/redis/deployment/pom.xml
+++ b/persistence/redis/deployment/pom.xml
@@ -7,7 +7,7 @@
         <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>quarkus-flow-redis-deployment</artifactId>
+  <artifactId>quarkus-flow-redis-deployment</artifactId>
     <name>Quarkus Flow :: Persistence :: Redis :: Deployment</name>
 
     <dependencies>
@@ -46,6 +46,14 @@
 
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <redis.test.image-name>${redis.test.image-name}</redis.test.image-name>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>

--- a/persistence/redis/deployment/src/test/java/io/quarkiverse/flow/persistence/redis/deployment/RedisDurableCrashRecoveryIT.java
+++ b/persistence/redis/deployment/src/test/java/io/quarkiverse/flow/persistence/redis/deployment/RedisDurableCrashRecoveryIT.java
@@ -12,19 +12,19 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import io.quarkiverse.flow.persistence.test.AbstractDurableListenWorkflowIT;
-import io.quarkiverse.flow.persistence.test.durable.DurableResource;
-import io.quarkiverse.flow.persistence.test.durable.EmitWorkflow;
-import io.quarkiverse.flow.persistence.test.durable.ListenWorkflow;
+import io.quarkiverse.flow.persistence.test.AbstractDurableCrashRecoveryIT;
+import io.quarkiverse.flow.persistence.test.durable.RecoveryEmitWorkflow;
+import io.quarkiverse.flow.persistence.test.durable.RecoveryResource;
+import io.quarkiverse.flow.persistence.test.durable.RecoveryWorkflow;
 import io.quarkus.logging.Log;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
-@QuarkusTestResource(RedisDurableListenWorkflowIT.RedisResource.class)
+@QuarkusTestResource(RedisDurableCrashRecoveryIT.RedisResource.class)
 @DisabledOnOs(OS.WINDOWS)
-public class RedisDurableListenWorkflowIT extends AbstractDurableListenWorkflowIT {
-    private static final String REDIS_IMAGE_NAME = System.getProperty("redis.test.image-name");
+public class RedisDurableCrashRecoveryIT extends AbstractDurableCrashRecoveryIT {
+    private static final String REDIS_IMAGE_NAME = System.getProperty("redis.test.image-name", "valkey/valkey:7.2-alpine");
 
     private static String redisImageName() {
         return REDIS_IMAGE_NAME;
@@ -33,19 +33,24 @@ public class RedisDurableListenWorkflowIT extends AbstractDurableListenWorkflowI
     @RegisterExtension
     static QuarkusDevModeTest devMode = new QuarkusDevModeTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(ListenWorkflow.class, EmitWorkflow.class, DurableResource.class)
-                    .addAsResource("durable-application.properties", "application.properties"));
+                    .addClasses(RecoveryWorkflow.class, RecoveryEmitWorkflow.class, RecoveryResource.class)
+                    .addAsResource("durable-recovery-application.properties", "application.properties"));
 
     @Override
     protected QuarkusDevModeTest getDevModeTest() {
         return devMode;
     }
 
+    @Override
+    protected void resetCounters() {
+        RecoveryResource.reset();
+    }
+
     public static class RedisResource implements QuarkusTestResourceLifecycleManager {
         private static final Logger LOGGER = LoggerFactory.getLogger(RedisResource.class);
 
         static final GenericContainer<?> REDIS = new GenericContainer<>(
-                DockerImageName.parse(RedisDurableListenWorkflowIT.redisImageName()))
+                DockerImageName.parse(RedisDurableCrashRecoveryIT.redisImageName()))
                 .withLogConsumer(outputFrame -> {
                     Log.info(outputFrame.getBytes());
                 })

--- a/persistence/redis/integration-tests/pom.xml
+++ b/persistence/redis/integration-tests/pom.xml
@@ -38,8 +38,14 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <plugins>
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
@@ -63,12 +69,12 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <systemPropertyVariables>
-                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner
-                        </native.image.path>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <maven.home>${maven.home}</maven.home>
-                    </systemPropertyVariables>
+        <systemPropertyVariables>
+          <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+          <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+          <maven.home>${maven.home}</maven.home>
+          <redis.test.image-name>${redis.test.image-name}</redis.test.image-name>
+        </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/persistence/redis/integration-tests/src/main/resources/application.properties
+++ b/persistence/redis/integration-tests/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 # Overriding the default Redis image with Valkey
-quarkus.redis.devservices.image-name=valkey/valkey:latest
+quarkus.redis.devservices.image-name=${redis.test.image-name}

--- a/persistence/redis/pom.xml
+++ b/persistence/redis/pom.xml
@@ -7,9 +7,13 @@
         <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>quarkus-flow-redis-parent</artifactId>
-    <packaging>pom</packaging>
-    <name>Quarkus Flow :: Persistence :: Redis</name>
+  <artifactId>quarkus-flow-redis-parent</artifactId>
+  <packaging>pom</packaging>
+  <name>Quarkus Flow :: Persistence :: Redis</name>
+
+  <properties>
+    <redis.test.image-name>valkey/valkey:7.2-alpine</redis.test.image-name>
+  </properties>
 
     <modules>
         <module>runtime</module>


### PR DESCRIPTION
The pull request is related to this: https://github.com/quarkiverse/quarkus-flow/pull/533#issuecomment-4407820690

Adding testing and fixing the Docker image

### Test Plan

- [X] Unit tests added/updated
- [X] Integration tests added/updated (if applicable)
- [X] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [X] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [X] Code follows the project's code conventions
- [X] Tests have been added/updated to cover the changes
- [X] Documentation has been updated (if user-facing changes)
- [X] Commit messages are clear and follow conventional commits style
- [X] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [X] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)