### PR TITLE
Use `quarkus-junit*` instead of relocated `quarkus-junit5*`  artifacts

### DIFF
--- a/core/integration-tests/pom.xml
+++ b/core/integration-tests/pom.xml
@@ -56,7 +56,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-component</artifactId>
+            <artifactId>quarkus-junit-component</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/durable-kubernetes/runtime/pom.xml
+++ b/durable-kubernetes/runtime/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-component</artifactId>
+            <artifactId>quarkus-junit-component</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/langchain4j/runtime/pom.xml
+++ b/langchain4j/runtime/pom.xml
@@ -45,7 +45,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-component</artifactId>
+            <artifactId>quarkus-junit-component</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/persistence/test-common/pom.xml
+++ b/persistence/test-common/pom.xml
@@ -18,11 +18,11 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-junit5-component</artifactId>
+                <artifactId>quarkus-junit-component</artifactId>
                 <version>${quarkus.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/scheduler/integration-tests/pom.xml
+++ b/scheduler/integration-tests/pom.xml
@@ -21,7 +21,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-component</artifactId>
+            <artifactId>quarkus-junit-component</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Investigating why the ecosystem CI is failing in here. Cleaning up relocations first