### PR TITLE
Allow to inject versioned workflow loaded by Yaml DSL

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -58,7 +58,6 @@
         <dependency>
             <groupId>com.github.zafarkhaja</groupId>
             <artifactId>java-semver</artifactId>
-            <version>${com.github.zafarkhaja.version}</version>
         </dependency>
         <dependency>
             <groupId>io.serverlessworkflow</groupId>

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -56,6 +56,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>com.github.zafarkhaja</groupId>
+            <artifactId>java-semver</artifactId>
+            <version>${com.github.zafarkhaja.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.serverlessworkflow</groupId>
             <artifactId>serverlessworkflow-fluent-spec</artifactId>
             <scope>test</scope>

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/DiscoveredWorkflowBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/DiscoveredWorkflowBuildItem.java
@@ -38,7 +38,8 @@ public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
         this.workflowDefinitionId = WorkflowDefinitionId.of(workflow);
         this.specIdentifier = WorkflowNameUtils.yamlDescriptorIdentifier(
                 workflowDefinitionId.namespace(),
-                workflowDefinitionId.name());
+                workflowDefinitionId.name(),
+                workflowDefinitionId.version());
         this.content = content;
         this.from = From.SPEC;
     }
@@ -88,6 +89,10 @@ public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
 
     public String name() {
         return workflowDefinitionId.name();
+    }
+
+    public String version() {
+        return workflowDefinitionId.version();
     }
 
     public String specIdentifier() {

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowIdentifierBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowIdentifierBuildItem.java
@@ -1,9 +1,9 @@
 package io.quarkiverse.flow.deployment;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
@@ -24,9 +24,7 @@ public final class FlowIdentifierBuildItem extends MultiBuildItem {
     public FlowIdentifierBuildItem(Set<String> identifiers) {
         this.identifiers = Objects.requireNonNull(identifiers, "'identifiers' must not be null");
         // default: display label == CDI qualifier
-        Map<String, String> map = new LinkedHashMap<>();
-        identifiers.forEach(id -> map.put(id, id));
-        this.displayIdentifiers = Map.copyOf(map);
+        this.displayIdentifiers = identifiers.stream().collect(Collectors.toMap(id -> id, id -> id));
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowIdentifierBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowIdentifierBuildItem.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.flow.deployment;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -7,16 +9,47 @@ import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  * Build item representing a set of flow identifiers.
+ * <p>
+ * Each item carries the CDI qualifier string ({@link #identifiers()}) and an optional
+ * human-readable display label ({@link #displayIdentifiers()}) used only for log output.
+ * For most beans the two are identical; for versionless beans the display label includes
+ * the resolved version so that the startup log is self-explanatory.
  */
 public final class FlowIdentifierBuildItem extends MultiBuildItem {
 
     private final Set<String> identifiers;
+    /** identifier → display label (may equal the identifier when no extra annotation is needed). */
+    private final Map<String, String> displayIdentifiers;
 
     public FlowIdentifierBuildItem(Set<String> identifiers) {
         this.identifiers = Objects.requireNonNull(identifiers, "'identifiers' must not be null");
+        // default: display label == CDI qualifier
+        Map<String, String> map = new LinkedHashMap<>();
+        identifiers.forEach(id -> map.put(id, id));
+        this.displayIdentifiers = Map.copyOf(map);
     }
 
+    /**
+     * Creates a build item where the versionless identifier carries an annotated display label.
+     *
+     * @param identifiers the CDI qualifier strings
+     * @param displayIdentifiers map of {@code identifier → display label}
+     */
+    public FlowIdentifierBuildItem(Set<String> identifiers, Map<String, String> displayIdentifiers) {
+        this.identifiers = Objects.requireNonNull(identifiers, "'identifiers' must not be null");
+        this.displayIdentifiers = Objects.requireNonNull(displayIdentifiers, "'displayIdentifiers' must not be null");
+    }
+
+    /** Returns the CDI qualifier strings for these beans. */
     public Set<String> identifiers() {
         return identifiers;
+    }
+
+    /**
+     * Returns a map of {@code identifier → display label} used only for log output.
+     * For versionless beans the label includes the resolved version.
+     */
+    public Map<String, String> displayIdentifiers() {
+        return displayIdentifiers;
     }
 }

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
@@ -1,7 +1,8 @@
 package io.quarkiverse.flow.deployment;
 
 import static io.quarkiverse.flow.deployment.FlowLoggingUtils.logWorkflowList;
-import static io.quarkiverse.flow.deployment.WorkflowNamingConverter.*;
+import static io.quarkiverse.flow.deployment.WorkflowNamingConverter.generateFlowClassIdentifier;
+import static io.quarkiverse.flow.deployment.WorkflowNamingConverter.namespaceToPackage;
 import static io.quarkus.arc.processor.DotNames.SINGLETON;
 
 import java.util.List;

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
@@ -1,9 +1,11 @@
 package io.quarkiverse.flow.deployment;
 
 import static io.quarkiverse.flow.deployment.FlowLoggingUtils.logWorkflowList;
+import static io.quarkiverse.flow.deployment.WorkflowNamingConverter.*;
 import static io.quarkus.arc.processor.DotNames.SINGLETON;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -18,10 +20,14 @@ import org.jboss.jandex.DotName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.zafarkhaja.semver.ParseException;
+import com.github.zafarkhaja.semver.Version;
+
 import io.quarkiverse.flow.config.FlowDefinitionsConfig;
 import io.quarkiverse.flow.config.FlowMetricsConfig;
 import io.quarkiverse.flow.config.FlowStructuredLoggingConfig;
 import io.quarkiverse.flow.config.FlowTracingConfig;
+import io.quarkiverse.flow.internal.WorkflowNameUtils;
 import io.quarkiverse.flow.internal.WorkflowRegistry;
 import io.quarkiverse.flow.metrics.MicrometerExecutionListener;
 import io.quarkiverse.flow.providers.CredentialsProviderSecretManager;
@@ -160,8 +166,20 @@ class FlowProcessor {
         List<DiscoveredWorkflowBuildItem> fromSpec = discoveredWorkflows.stream()
                 .filter(DiscoveredWorkflowBuildItem::fromSpec)
                 .toList();
+
         for (DiscoveredWorkflowBuildItem d : fromSpec) {
-            produceWorkflowDefinitionBeanFromSpec(recorder, beans, identifiers, d);
+            produceVersionedWorkflowDefinitionBean(recorder, beans, identifiers, d);
+        }
+
+        if (this.flowDefinitionsConfig.namingStrategy() == FlowDefinitionsConfig.NamingStrategy.SPEC) {
+            selectLatestVersionPerWorkflow(fromSpec)
+                    .forEach((versionlessId, representative) -> {
+                        String displayLabel = versionlessId + "  →  " + representative.specIdentifier() + " (latest)";
+                        beans.produce(produceVersionlessSyntheticBean(versionlessId, recorder, representative));
+                        identifiers.produce(new FlowIdentifierBuildItem(
+                                Set.of(versionlessId),
+                                Map.of(versionlessId, displayLabel)));
+                    });
         }
     }
 
@@ -181,34 +199,77 @@ class FlowProcessor {
         identifiers.produce(new FlowIdentifierBuildItem(Set.of(it.className())));
     }
 
-    private void produceWorkflowDefinitionBeanFromSpec(WorkflowDefinitionRecorder recorder,
+    private void produceVersionedWorkflowDefinitionBean(WorkflowDefinitionRecorder recorder,
             BuildProducer<SyntheticBeanBuildItem> beans, BuildProducer<FlowIdentifierBuildItem> identifiers,
             DiscoveredWorkflowBuildItem workflow) {
-        String flowSubclassIdentifier = WorkflowNamingConverter.generateFlowClassIdentifier(
-                workflow.namespace(), workflow.name(), this.flowDefinitionsConfig.namespace().prefix());
+
+        String flowSubclassIdentifier = this.flowDefinitionsConfig.namespace().prefix()
+                .map(fromConfig -> generateFlowClassIdentifier(workflow.workflowDefinitionId(), namespaceToPackage(fromConfig)))
+                .orElse(generateFlowClassIdentifier(workflow.workflowDefinitionId(),
+                        namespaceToPackage(workflow.workflowDefinitionId().namespace())));
 
         String identifier = this.flowDefinitionsConfig.namingStrategy() == FlowDefinitionsConfig.NamingStrategy.SPEC
                 ? workflow.specIdentifier()
                 : flowSubclassIdentifier;
 
         beans.produce(produceSyntheticWorkflowDefinitionBean(identifier, recorder, workflow));
+        identifiers.produce(new FlowIdentifierBuildItem(Set.of(identifier)));
+    }
 
-        identifiers.produce(new FlowIdentifierBuildItem(
-                Set.of(identifier)));
+    /**
+     * Groups workflows by their versionless identifier (namespace:name) and selects
+     * the workflow with the highest semantic version for each group.
+     *
+     * @param workflows List of discovered workflows from spec files
+     * @return Map of versionless identifiers to their highest-version representative workflow
+     */
+    private static Map<String, DiscoveredWorkflowBuildItem> selectLatestVersionPerWorkflow(
+            List<DiscoveredWorkflowBuildItem> workflows) {
+        return workflows.stream()
+                .collect(Collectors.toMap(
+                        d -> WorkflowNameUtils.versionlessIdentifier(d.namespace(), d.name()),
+                        d -> d,
+                        (a, b) -> {
+                            return tryParseSemver(a.version(), a).compareTo(tryParseSemver(b.version(), b)) >= 0 ? a : b;
+                        }));
+    }
+
+    public static Version tryParseSemver(String semver, DiscoveredWorkflowBuildItem discoveredWorkflow) {
+        try {
+            return Version.parse(semver);
+        } catch (IllegalArgumentException | ParseException e) {
+            throw new IllegalArgumentException(
+                    String.format("Invalid semantic version '%s' in workflow '%s:%s' (file: %s). " +
+                            "Expected format: MAJOR.MINOR.PATCH (e.g., '1.0.0')",
+                            discoveredWorkflow.version(), discoveredWorkflow.namespace(), discoveredWorkflow.name(),
+                            discoveredWorkflow.absolutePath()),
+                    e);
+        }
     }
 
     @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
     void produceGeneratedFlows(List<DiscoveredWorkflowBuildItem> workflows,
-            BuildProducer<GeneratedBeanBuildItem> classes) {
+            BuildProducer<GeneratedBeanBuildItem> classes,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
+            WorkflowDefinitionRecorder recorder) {
 
         List<DiscoveredWorkflowBuildItem> fromSpec = workflows.stream().filter(DiscoveredWorkflowBuildItem::fromSpec)
                 .toList();
 
         GeneratedBeanGizmoAdaptor gizmo = new GeneratedBeanGizmoAdaptor(classes);
+
         for (DiscoveredWorkflowBuildItem workflow : fromSpec) {
-            produceFlowGizmoBean(workflow, gizmo);
+            produceVersionedFlowGizmoBean(workflow, gizmo);
         }
 
+        // 2. ONE versionless Flow subclass per unique namespace:name.
+        if (flowDefinitionsConfig.namingStrategy() == FlowDefinitionsConfig.NamingStrategy.SPEC) {
+
+            selectLatestVersionPerWorkflow(fromSpec)
+                    .forEach((versionlessId, representative) -> produceVersionlessFlowGizmoBean(versionlessId, representative,
+                            gizmo));
+        }
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)
@@ -238,15 +299,15 @@ class FlowProcessor {
     @Produce(SyntheticBeanBuildItem.class)
     void logRegisteredWorkflows(
             List<FlowIdentifierBuildItem> registeredIdentifiers) {
-        List<String> allIdentifiers = registeredIdentifiers.stream().map(FlowIdentifierBuildItem::identifiers)
-                .map(set -> String.join(", ", set))
+        List<String> allDisplayLabels = registeredIdentifiers.stream()
+                .flatMap(item -> item.displayIdentifiers().values().stream())
                 .distinct()
                 .collect(Collectors.toList());
         logWorkflowList(LOG,
-                allIdentifiers,
+                allDisplayLabels,
                 "Flow: No WorkflowDefinition beans were registered.",
                 "Flow: Registered WorkflowDefinition beans",
-                "Workflow class (Qualifier)");
+                "Workflow identifier");
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)
@@ -395,38 +456,36 @@ class FlowProcessor {
     }
 
     /**
-     * Generates a CDI-managed subclass of {@code Flow} using Gizmo.
-     *
+     * Produces a versionless {@code @Identifier("namespace:name")} synthetic bean that delegates
+     * to the highest-semver versioned {@link WorkflowDefinition} bean.
      * <p>
-     * The generated class has this effective structure:
-     *
-     * <pre>
-     * {@code
-     * &#64;Unremovable
-     * &#64;ApplicationScoped
-     * &#64;Identifier(identifier)
-     * class {className} extends Flow {
-     *
-     *     &#64;Inject
-     *     &#64;Identifier(identifier)
-     *     public WorkflowDefinition workflowDefinition;
-     *
-     *     public Workflow descriptor() {
-     *         return this.workflowDefinition.workflow();
-     *     }
-     * }
-     * }
-     * </pre>
-     * <p>
-     * When {@code specIdentifier} is {@code false}, the CDI bean identifier is prefixed with
-     * {@code Normal}, but the injected {@code workflowDefinition} field still uses {@code className}
-     * as its {@code @Identifier} value.
+     * An explicit injection point on the versioned bean is declared so CDI creates — and
+     * registers into {@code WorkflowApplication} — the versioned bean before this one,
+     * preventing any ordering / lookup-before-registration issues at startup.
      */
-    private void produceFlowGizmoBean(DiscoveredWorkflowBuildItem workflow,
+    private static SyntheticBeanBuildItem produceVersionlessSyntheticBean(String versionlessIdentifier,
+            WorkflowDefinitionRecorder recorder, DiscoveredWorkflowBuildItem representative) {
+        String versionedIdentifier = representative.specIdentifier();
+        return SyntheticBeanBuildItem.configure(WorkflowDefinition.class)
+                .scope(ApplicationScoped.class)
+                .unremovable()
+                .setRuntimeInit()
+                .addQualifier().annotation(DotNames.IDENTIFIER)
+                .addValue("value", versionlessIdentifier).done()
+                .addInjectionPoint(
+                        ClassType.create(DotName.createSimple(WorkflowDefinition.class)),
+                        AnnotationInstance.builder(DotNames.IDENTIFIER).value(versionedIdentifier).build())
+                .createWith(recorder.workflowDefinitionVersionlessDelegateCreator(versionedIdentifier))
+                .done();
+    }
+
+    private void produceVersionedFlowGizmoBean(DiscoveredWorkflowBuildItem workflow,
             GeneratedBeanGizmoAdaptor gizmo) {
 
-        String flowSubclassIdentifier = WorkflowNamingConverter.generateFlowClassIdentifier(
-                workflow.namespace(), workflow.name(), this.flowDefinitionsConfig.namespace().prefix());
+        String flowSubclassIdentifier = this.flowDefinitionsConfig.namespace().prefix()
+                .map(fromConfig -> generateFlowClassIdentifier(workflow.workflowDefinitionId(), namespaceToPackage(fromConfig)))
+                .orElse(generateFlowClassIdentifier(workflow.workflowDefinitionId(),
+                        namespaceToPackage(workflow.workflowDefinitionId().namespace())));
 
         String identifier = flowDefinitionsConfig.namingStrategy() == FlowDefinitionsConfig.NamingStrategy.SPEC
                 ? workflow.specIdentifier()
@@ -442,13 +501,42 @@ class FlowProcessor {
             creator.addAnnotation(ApplicationScoped.class);
             creator.addAnnotation(Identifier.class).add("value", identifier);
 
-            // @Inject @Identifier(identifier) public WorkflowDefinition workflowDefinition;
             FieldCreator fieldCreator = GizmoFlowHelper.addWorkflowDefinitionField(creator, identifier);
-
-            // public String identifier() { return identifier; }
             GizmoFlowHelper.addIdentifierMethod(creator, identifier);
+            GizmoFlowHelper.addDescriptorMethod(creator, fieldCreator);
+        }
+    }
 
-            // public Workflow descriptor() method
+    /**
+     * Generates a single versionless {@code Flow} subclass qualified with
+     * {@code @Identifier("namespace:name")}. Only called once per unique namespace:name pair,
+     * so no duplicate class/bean is produced when multiple versions of the same workflow exist.
+     */
+    private void produceVersionlessFlowGizmoBean(String versionlessId,
+            DiscoveredWorkflowBuildItem representative,
+            GeneratedBeanGizmoAdaptor gizmo) {
+
+        // Use versionlessId (namespace:name) to generate class name, not the representative's version
+        // This ensures the class name remains stable regardless of which version is "latest"
+        String namespace = representative.namespace();
+        String name = representative.name();
+
+        String versionlessClassName = this.flowDefinitionsConfig.namespace().prefix()
+                .map(prefix -> generateFlowClassIdentifier(namespace, name, prefix))
+                .orElse(generateFlowClassIdentifier(namespace, name));
+
+        try (ClassCreator creator = ClassCreator.builder()
+                .className(versionlessClassName)
+                .superClass(DotNames.FLOW.toString())
+                .classOutput(gizmo)
+                .build()) {
+
+            creator.addAnnotation(Unremovable.class);
+            creator.addAnnotation(ApplicationScoped.class);
+            creator.addAnnotation(Identifier.class).add("value", versionlessId);
+
+            FieldCreator fieldCreator = GizmoFlowHelper.addWorkflowDefinitionField(creator, versionlessId);
+            GizmoFlowHelper.addIdentifierMethod(creator, versionlessId);
             GizmoFlowHelper.addDescriptorMethod(creator, fieldCreator);
         }
     }

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
@@ -265,7 +265,6 @@ class FlowProcessor {
 
         // 2. ONE versionless Flow subclass per unique namespace:name.
         if (flowDefinitionsConfig.namingStrategy() == FlowDefinitionsConfig.NamingStrategy.SPEC) {
-
             selectLatestVersionPerWorkflow(fromSpec)
                     .forEach((versionlessId, representative) -> produceVersionlessFlowGizmoBean(versionlessId, representative,
                             gizmo));

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/WorkflowNamingConverter.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/WorkflowNamingConverter.java
@@ -1,7 +1,8 @@
 package io.quarkiverse.flow.deployment;
 
 import java.util.Objects;
-import java.util.Optional;
+
+import io.serverlessworkflow.impl.WorkflowDefinitionId;
 
 public interface WorkflowNamingConverter {
 
@@ -58,16 +59,71 @@ public interface WorkflowNamingConverter {
     }
 
     /**
+     * Converts a <a href="https://semver.org/">Semantic Versioning</a> string to a valid Java package name segment.
+     * <p>
+     * Rules applied:
+     * <ul>
+     * <li>Build metadata (everything after {@code +}) is stripped.</li>
+     * <li>Dots ({@code .}) and hyphens ({@code -}) are replaced with underscores ({@code _}).</li>
+     * <li>A {@code v} prefix is prepended so the result never starts with a digit.</li>
+     * </ul>
+     * <p>
+     * Examples:
+     *
+     * <pre>
+     *   "0.1.0"         → "v0_1_0"
+     *   "1.2.3-alpha.1" → "v1_2_3_alpha_1"
+     *   "1.0.0+build.1" → "v1_0_0"
+     * </pre>
+     *
+     * @param version a semantic version string (e.g. {@code "1.2.3"})
+     * @return a valid, lowercase Java package name segment representing the version
+     * @throws NullPointerException if {@code version} is {@code null}
+     * @throws IllegalArgumentException if {@code version} is blank
+     */
+    static String versionToPackage(String version) {
+        Objects.requireNonNull(version, "'version' must not be null");
+        if (version.isBlank()) {
+            throw new IllegalArgumentException("'version' must not be blank");
+        }
+
+        // Strip build metadata (SemVer §10: everything after '+')
+        int buildMetaIndex = version.indexOf('+');
+        String withoutBuildMeta = buildMetaIndex >= 0 ? version.substring(0, buildMetaIndex) : version;
+
+        // Replace dots and hyphens with underscores and lowercase the result
+        String sanitized = withoutBuildMeta.replace('.', '_').replace('-', '_').toLowerCase();
+
+        // Prefix with 'v' so the segment is a valid Java identifier (cannot start with a digit)
+        return "v" + sanitized;
+    }
+
+    /**
      * Generates a class identifier for {@link io.quarkiverse.flow.Flow} subclasses.
+     *
+     * @param namespace Document's namespace from specification
+     * @param name Document's name from specification
+     * @return the generated class identifier
+     */
+    static String generateFlowClassIdentifier(String namespace, String name) {
+        return namespaceToPackage(namespace) + "." + nameToClassName(name);
+    }
+
+    /**
+     * Generates a class identifier for {@link io.quarkiverse.flow.Flow} subclasses with a custom base namespace.
      *
      * @param namespace Document's namespace from specification
      * @param name Document's name from specification
      * @param namespaceFromConfig Base namespace for generating class identifiers
      * @return the generated class identifier
      */
-    static String generateFlowClassIdentifier(String namespace, String name, Optional<String> namespaceFromConfig) {
-        return namespaceFromConfig.map(s -> String.format("%s.%s.%s", s, namespaceToPackage(namespace), nameToClassName(name)))
-                .orElseGet(() -> namespaceToPackage(namespace) + "." + nameToClassName(name));
+    static String generateFlowClassIdentifier(String namespace, String name, String namespaceFromConfig) {
+        return String.format("%s.%s.%s", namespaceFromConfig, namespaceToPackage(namespace), nameToClassName(name));
     }
 
+    static String generateFlowClassIdentifier(WorkflowDefinitionId workflowDefinitionId, String namespace) {
+        return String.format("%s.%s.%s", namespace,
+                versionToPackage(workflowDefinitionId.version()),
+                nameToClassName(workflowDefinitionId.name()));
+    }
 }

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/FlowWorkflowFromFileDevModeTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/FlowWorkflowFromFileDevModeTest.java
@@ -37,7 +37,7 @@ public class FlowWorkflowFromFileDevModeTest {
     @Test
     void should_reload_workflow_def_identifier() {
 
-        String oldIdentifier = "default:wait-duration-inline";
+        String oldIdentifier = "default:wait-duration-inline:0.1.0";
         String path = "/identifier/workflow-def";
 
         identifierMustMatch(path, oldIdentifier);
@@ -46,7 +46,7 @@ public class FlowWorkflowFromFileDevModeTest {
                 // replace namespace: default
                 content -> content.replace("default", "quarkiverse"));
 
-        identifierMustMatch(path, "quarkiverse:wait-duration-inline");
+        identifierMustMatch(path, "quarkiverse:wait-duration-inline:0.1.0");
 
         // Old identifier should no longer be available
         shouldNoLongerBeAvailable(path, oldIdentifier);
@@ -55,7 +55,7 @@ public class FlowWorkflowFromFileDevModeTest {
     @Test
     void should_reload_flow_identifier() {
 
-        String oldIdentifier = "default:wait-duration-inline";
+        String oldIdentifier = "default:wait-duration-inline:0.1.0";
         String path = "/identifier/flow";
 
         identifierMustMatch(path, oldIdentifier);
@@ -64,7 +64,7 @@ public class FlowWorkflowFromFileDevModeTest {
                 // replace name wait-duration-inline to wait-please
                 content -> content.replace("wait-duration-inline", "wait-please"));
 
-        identifierMustMatch(path, "default:wait-please");
+        identifierMustMatch(path, "default:wait-please:0.1.0");
 
         // Old identifier should no longer be available
         shouldNoLongerBeAvailable(path, oldIdentifier);

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/FlowWorkflowFromFileProdTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/FlowWorkflowFromFileProdTest.java
@@ -42,7 +42,7 @@ public class FlowWorkflowFromFileProdTest {
     @Test
     void should_have_a_bean_recorded_when_running_prod_mode() {
         RestAssured.given()
-                .queryParam("identifier", "default:call-http")
+                .queryParam("identifier", "default:call-http:1.0.0")
                 .get("/identifier/workflow-def")
                 .then()
                 .statusCode(200);

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/IdentifierResource.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/IdentifierResource.java
@@ -25,7 +25,7 @@ public class IdentifierResource {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
         var document = handle.get().workflow().getDocument();
-        return Response.ok(document.getNamespace() + ":" + document.getName()).build();
+        return Response.ok(document.getNamespace() + ":" + document.getName() + ":" + document.getVersion()).build();
     }
 
     @GET

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/WorkflowNamingConverterTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/WorkflowNamingConverterTest.java
@@ -1,8 +1,7 @@
 package io.quarkiverse.flow.deployment.test;
 
-import java.util.Optional;
-
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import io.quarkiverse.flow.deployment.WorkflowNamingConverter;
@@ -44,14 +43,63 @@ class WorkflowNamingConverterTest {
     @Test
     void generateFlowClassIdentifier_should_generate_correctly() {
         String fqcn = WorkflowNamingConverter.generateFlowClassIdentifier(
-                "my-company", "myWorkflow", Optional.empty());
+                "my-company", "myWorkflow");
         Assertions.assertEquals("my.company.MyWorkflow", fqcn);
     }
 
     @Test
     void generateFlowClassIdentifier_should_use_config_namespace_if_present() {
         String fqcn = WorkflowNamingConverter.generateFlowClassIdentifier(
-                "my-company", "myWorkflow", Optional.of("custom.namespace"));
+                "my-company", "myWorkflow", "custom.namespace");
         Assertions.assertEquals("custom.namespace.my.company.MyWorkflow", fqcn);
+    }
+
+    @Test
+    @DisplayName("versionToPackage_should_convert_basic_semver")
+    void versionToPackage_should_convert_basic_semver() {
+        String result = WorkflowNamingConverter.versionToPackage("0.1.0");
+        Assertions.assertEquals("v0_1_0", result);
+    }
+
+    @Test
+    @DisplayName("versionToPackage_should_convert_pre_release")
+    void versionToPackage_should_convert_pre_release() {
+        String result = WorkflowNamingConverter.versionToPackage("1.2.3-alpha.1");
+        Assertions.assertEquals("v1_2_3_alpha_1", result);
+    }
+
+    @Test
+    @DisplayName("versionToPackage_should_strip_build_metadata")
+    void versionToPackage_should_strip_build_metadata() {
+        String result = WorkflowNamingConverter.versionToPackage("1.0.0+build.1");
+        Assertions.assertEquals("v1_0_0", result);
+    }
+
+    @Test
+    @DisplayName("versionToPackage_should_strip_build_metadata_and_pre_release")
+    void versionToPackage_should_strip_build_metadata_and_pre_release() {
+        String result = WorkflowNamingConverter.versionToPackage("1.0.0-beta.2+exp.sha.5114f85");
+        Assertions.assertEquals("v1_0_0_beta_2", result);
+    }
+
+    @Test
+    @DisplayName("versionToPackage_should_lowercase_pre_release_identifiers")
+    void versionToPackage_should_lowercase_pre_release_identifiers() {
+        String result = WorkflowNamingConverter.versionToPackage("2.0.0-RC.1");
+        Assertions.assertEquals("v2_0_0_rc_1", result);
+    }
+
+    @Test
+    @DisplayName("versionToPackage_should_throw_on_null")
+    void versionToPackage_should_throw_on_null() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> WorkflowNamingConverter.versionToPackage(null));
+    }
+
+    @Test
+    @DisplayName("versionToPackage_should_throw_on_blank")
+    void versionToPackage_should_throw_on_blank() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> WorkflowNamingConverter.versionToPackage("   "));
     }
 }

--- a/core/integration-tests/src/main/flow/echo-name-v2.yaml
+++ b/core/integration-tests/src/main/flow/echo-name-v2.yaml
@@ -1,0 +1,9 @@
+document:
+  dsl: '1.0.0'
+  namespace: flow
+  name: echo-name
+  version: '0.2.0'
+do:
+  - setEcho:
+      set:
+        message: '${ "Echo (v0.2.0): " + .name }'

--- a/core/integration-tests/src/main/java/io/quarkiverse/flow/it/EchoResource.java
+++ b/core/integration-tests/src/main/java/io/quarkiverse/flow/it/EchoResource.java
@@ -17,12 +17,28 @@ import io.smallrye.common.annotation.Identifier;
 public class EchoResource {
 
     @Inject
-    @Identifier("flow:echo-name")
+    @Identifier("flow:echo-name:0.1.0")
     Flow flow;
 
     @Inject
-    @Identifier("flow:echo-name")
+    @Identifier("flow:echo-name:0.1.0")
     WorkflowDefinition workflowDefinition;
+
+    @Inject
+    @Identifier("flow:echo-name:0.2.0")
+    Flow flowV2;
+
+    @Inject
+    @Identifier("flow:echo-name:0.2.0")
+    WorkflowDefinition workflowDefinitionV2;
+
+    @Inject
+    @Identifier("flow:echo-name")
+    WorkflowDefinition versionlessWorkflowDefinition;
+
+    @Inject
+    @Identifier("flow:echo-name")
+    Flow versionlessFlow;
 
     @GET
     @Path("/from-workflow-def")
@@ -38,6 +54,42 @@ public class EchoResource {
     public CompletableFuture<String> echoFromFlow(@QueryParam("name") String name) {
         final String finalName = Objects.requireNonNullElse(name, "(Duke)");
         return flow.instance(Map.of("name", finalName))
+                .start()
+                .thenApply(model -> model.asText().orElseThrow());
+    }
+
+    @GET
+    @Path("/v2/from-workflow-def")
+    public CompletableFuture<String> echoFromWorkflowDefV2(@QueryParam("name") String name) {
+        final String finalName = Objects.requireNonNullElse(name, "(Duke)");
+        return workflowDefinitionV2.instance(Map.of("name", finalName))
+                .start()
+                .thenApply(model -> model.asText().orElseThrow());
+    }
+
+    @GET
+    @Path("/v2/from-flow")
+    public CompletableFuture<String> echoFromFlowV2(@QueryParam("name") String name) {
+        final String finalName = Objects.requireNonNullElse(name, "(Duke)");
+        return flowV2.instance(Map.of("name", finalName))
+                .start()
+                .thenApply(model -> model.asText().orElseThrow());
+    }
+
+    @GET
+    @Path("/from-versionless-workflow-def")
+    public CompletableFuture<String> echoFromVersionlessWorkflowDef(@QueryParam("name") String name) {
+        final String finalName = Objects.requireNonNullElse(name, "(Duke)");
+        return versionlessWorkflowDefinition.instance(Map.of("name", finalName))
+                .start()
+                .thenApply(model -> model.asText().orElseThrow());
+    }
+
+    @GET
+    @Path("/from-versionless-flow")
+    public CompletableFuture<String> echoFromVersionlessFlow(@QueryParam("name") String name) {
+        final String finalName = Objects.requireNonNullElse(name, "(Duke)");
+        return versionlessFlow.instance(Map.of("name", finalName))
                 .start()
                 .thenApply(model -> model.asText().orElseThrow());
     }

--- a/core/integration-tests/src/main/java/io/quarkiverse/flow/it/HelloResource.java
+++ b/core/integration-tests/src/main/java/io/quarkiverse/flow/it/HelloResource.java
@@ -38,11 +38,11 @@ import io.smallrye.mutiny.Uni;
 public class HelloResource {
 
     @Inject
-    @Identifier("flow:echo-name")
+    @Identifier("flow:echo-name:0.1.0")
     WorkflowDefinition workflowDefEcho;
 
     @Inject
-    @Identifier("flow:echo-name")
+    @Identifier("flow:echo-name:0.1.0")
     Flow flowEcho;
 
     @Inject

--- a/core/integration-tests/src/test/flow/echo-name-v2.yaml
+++ b/core/integration-tests/src/test/flow/echo-name-v2.yaml
@@ -1,0 +1,9 @@
+document:
+  dsl: '1.0.0'
+  namespace: flow
+  name: echo-name
+  version: '0.2.0'
+do:
+  - setEcho:
+      set:
+        message: '${ "Echo (v0.2.0): " + .name }'

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/EchoResourceTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/EchoResourceTest.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.flow.it;
 
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -27,6 +28,48 @@ public class EchoResourceTest {
                 .then()
                 .statusCode(200)
                 .body(Matchers.containsString("Echo from test: Anakin Skywalker"));
+    }
+
+    @Test
+    void inject_from_file_should_execute_using_Flow_v2() {
+        RestAssured.given()
+                .queryParam("name", "Anakin Skywalker")
+                .get("/echo/v2/from-flow")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("Echo (v0.2.0): Anakin Skywalker"));
+    }
+
+    @Test
+    void inject_from_file_should_execute_using_WorkflowDefinition_v2() {
+        RestAssured.given()
+                .queryParam("name", "Anakin Skywalker")
+                .get("/echo/v2/from-workflow-def")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("Echo (v0.2.0): Anakin Skywalker"));
+    }
+
+    @Test
+    @DisplayName("Versionless identifier should resolve WorkflowDefinition without version")
+    void versionless_identifier_should_resolve_WorkflowDefinition_without_version() {
+        RestAssured.given()
+                .queryParam("name", "Anakin Skywalker")
+                .get("/echo/from-versionless-workflow-def")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("Echo (v0.2.0): Anakin Skywalker"));
+    }
+
+    @Test
+    @DisplayName("Versionless identifier should resolve Flow without version")
+    void versionless_identifier_should_resolve_Flow_without_version() {
+        RestAssured.given()
+                .queryParam("name", "Anakin Skywalker")
+                .get("/echo/from-versionless-flow")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("Echo (v0.2.0): Anakin Skywalker"));
     }
 
 }

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/HttpAsyncCompletionTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/HttpAsyncCompletionTest.java
@@ -43,7 +43,7 @@ public class HttpAsyncCompletionTest {
             """;
 
     @Inject
-    @Identifier("flow:http-async-completion")
+    @Identifier("flow:http-async-completion:0.1.0")
     Flow httpAsyncCompletionFlow;
 
     @BeforeEach

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/NamedHttpMetadataPropagationTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/NamedHttpMetadataPropagationTest.java
@@ -46,7 +46,7 @@ public class NamedHttpMetadataPropagationTest {
             """;
 
     @Inject
-    @Identifier("flow:quarkus-flow")
+    @Identifier("flow:quarkus-flow:0.1.0")
     Flow quarkusFlowFlow;
 
     @Inject

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingHttpAsyncTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingHttpAsyncTest.java
@@ -58,7 +58,7 @@ public class StructuredLoggingHttpAsyncTest {
             """;
 
     @Inject
-    @Identifier("flow:http-async-completion")
+    @Identifier("flow:http-async-completion:0.1.0")
     Flow httpAsyncCompletionFlow;
 
     @BeforeEach

--- a/core/runtime/src/main/java/io/quarkiverse/flow/internal/WorkflowNameUtils.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/internal/WorkflowNameUtils.java
@@ -15,12 +15,17 @@ public final class WorkflowNameUtils {
                 WorkflowDefinitionId.DEFAULT_VERSION);
     }
 
-    public static String yamlDescriptorIdentifier(String namespace, String name) {
-        return String.format("%s:%s", namespace, name);
+    public static String yamlDescriptorIdentifier(String namespace, String name, String version) {
+        return String.format("%s:%s:%s", namespace, name, version);
     }
 
-    public static String yamlDescriptorIdentifier(WorkflowDefinitionId workflowDefinitionId) {
-        return String.format("%s:%s", workflowDefinitionId.namespace(), workflowDefinitionId.name());
+    /**
+     * Returns the versionless identifier for a workflow, i.e. {@code "namespace:name"}.
+     * This is used to inject a workflow without specifying a version; the runtime will
+     * resolve either the only available version or the latest one using semver ordering.
+     */
+    public static String versionlessIdentifier(String namespace, String name) {
+        return String.format("%s:%s", namespace, name);
     }
 
     public static String safeNameFromClass(Class<?> clazz, String defaultValue) {

--- a/core/runtime/src/main/java/io/quarkiverse/flow/metrics/MicrometerExecutionListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/metrics/MicrometerExecutionListener.java
@@ -49,10 +49,10 @@ public class MicrometerExecutionListener implements WorkflowExecutionListener {
 
     @Override
     public void onWorkflowStarted(WorkflowStartedEvent event) {
-        String workflowName = workflowName(event);
         Counter.builder(FlowMetrics.WORKFLOW_STARTED_TOTAL.prefixedWith(prefix))
                 .description("Workflow Started Total")
-                .tag("workflow", workflowName)
+                .tag("workflow", workflowName(event))
+                .tag("workflowVersion", workflowVersion(event))
                 .register(meterRegistry)
                 .increment();
     }
@@ -65,6 +65,7 @@ public class MicrometerExecutionListener implements WorkflowExecutionListener {
         Counter.builder(FlowMetrics.WORKFLOW_COMPLETED_TOTAL.prefixedWith(prefix))
                 .description("Workflow Completed Total: The workflow/task ran to completion.")
                 .tag("workflow", workflowName)
+                .tag("workflowVersion", workflowVersion(event))
                 .register(meterRegistry)
                 .increment();
 
@@ -72,6 +73,7 @@ public class MicrometerExecutionListener implements WorkflowExecutionListener {
         Duration totalDurationInSeconds = identifyTotalDurationInSeconds(event);
         Timer.Builder builder = Timer.builder(FlowMetrics.WORKFLOW_DURATION.prefixedWith(prefix))
                 .description("Workflow Duration Total In Seconds")
+                .tag("workflowVersion", workflowVersion(event))
                 .tag("workflow", workflowName);
 
         configurePercentiles(builder);
@@ -87,6 +89,7 @@ public class MicrometerExecutionListener implements WorkflowExecutionListener {
         Counter.builder(FlowMetrics.WORKFLOW_FAULTED_TOTAL.prefixedWith(prefix))
                 .description("Workflow Faulted Total: The workflow/task execution has encountered an error.")
                 .tag("workflow", workflowName)
+                .tag("workflowVersion", workflowVersion(event))
                 .tag("errorType", event.workflowContext().instanceData().status().name())
                 .register(meterRegistry)
                 .increment();
@@ -98,6 +101,7 @@ public class MicrometerExecutionListener implements WorkflowExecutionListener {
         Counter.builder(FlowMetrics.WORKFLOW_CANCELLED_TOTAL.prefixedWith(prefix))
                 .description("Workflow Cancelled Total: The workflow/task execution has been terminated before completion.")
                 .tag("workflow", workflowName)
+                .tag("workflowVersion", workflowVersion(event))
                 .register(meterRegistry)
                 .increment();
     }
@@ -121,6 +125,7 @@ public class MicrometerExecutionListener implements WorkflowExecutionListener {
                 .description("Task Started Total")
                 .tag("task", event.taskContext().taskName())
                 .tag("workflow", workflowName)
+                .tag("workflowVersion", workflowVersion(event))
                 .register(meterRegistry)
                 .increment();
     }
@@ -135,6 +140,7 @@ public class MicrometerExecutionListener implements WorkflowExecutionListener {
                 .description("Task Execution Total")
                 .tag("workflow", workflowName)
                 .tag("task", event.taskContext().taskName())
+                .tag("workflowVersion", workflowVersion(event))
                 .register(meterRegistry)
                 .increment();
 
@@ -144,7 +150,8 @@ public class MicrometerExecutionListener implements WorkflowExecutionListener {
         Timer.Builder builder = Timer.builder(FlowMetrics.TASK_DURATION.prefixedWith(prefix))
                 .description("Task Duration In Seconds")
                 .tag("workflow", workflowName)
-                .tag("task", event.taskContext().taskName());
+                .tag("task", event.taskContext().taskName())
+                .tag("workflowVersion", workflowVersion(event));
 
         configurePercentiles(builder);
 
@@ -160,6 +167,7 @@ public class MicrometerExecutionListener implements WorkflowExecutionListener {
                 .description("Task Failed Total")
                 .tag("workflow", workflowName)
                 .tag("task", event.taskContext().taskName())
+                .tag("workflowVersion", workflowVersion(event))
                 .register(meterRegistry)
                 .increment();
     }
@@ -171,6 +179,7 @@ public class MicrometerExecutionListener implements WorkflowExecutionListener {
                 .description("Task Retries Total")
                 .tag("workflow", workflowName)
                 .tag("task", event.taskContext().taskName())
+                .tag("workflowVersion", workflowVersion(event))
                 .register(meterRegistry)
                 .increment();
     }
@@ -199,6 +208,10 @@ public class MicrometerExecutionListener implements WorkflowExecutionListener {
         return new WorkflowMetadata(namespace, name, version);
     }
 
+    private String workflowVersion(WorkflowEvent event) {
+        return event.workflowContext().definition().workflow().getDocument().getVersion();
+    }
+
     private String workflowName(WorkflowEvent event) {
         return event.workflowContext().definition().workflow().getDocument().getName();
     }
@@ -222,19 +235,22 @@ public class MicrometerExecutionListener implements WorkflowExecutionListener {
             Gauge.builder(FlowMetrics.INSTANCES_RUNNING.prefixedWith(prefix), counters.running, AtomicLong::get)
                     .description("Workflow Instances Currently Running: The workflow/task is currently in progress.")
                     .tag("workflow", workflowMetadata.name())
+                    .tag("workflowVersion", workflowMetadata.version())
                     .register(meterRegistry);
 
             Gauge.builder(FlowMetrics.INSTANCES_WAITING.prefixedWith(prefix), counters.waiting, AtomicLong::get)
                     .description("Workflow Instances Currently Waiting: The workflow/task execution is temporarily paused, " +
                             "awaiting either inbound event(s) or a specified time interval as defined by a wait task.")
                     .tag("workflow", workflowMetadata.name())
+                    .tag("workflowVersion", workflowMetadata.version())
                     .register(meterRegistry);
 
             Gauge.builder(FlowMetrics.INSTANCES_SUSPENDED.prefixedWith(prefix), counters.suspended, AtomicLong::get)
                     .description(
                             "Workflow Instances Currently Suspended: The workflow/task execution has been manually paused " +
                                     "by a user and will remain halted until explicitly resumed.")
-                    .tag("workflow", workflowName.name())
+                    .tag("workflow", workflowMetadata.name())
+                    .tag("workflowVersion", workflowMetadata.version())
                     .register(meterRegistry);
 
             return counters;

--- a/core/runtime/src/main/java/io/quarkiverse/flow/recorders/WorkflowDefinitionRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/recorders/WorkflowDefinitionRecorder.java
@@ -14,6 +14,7 @@ import io.serverlessworkflow.api.WorkflowFormat;
 import io.serverlessworkflow.api.WorkflowReader;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.impl.WorkflowDefinition;
+import io.smallrye.common.annotation.Identifier;
 
 /**
  * Registries all Workflow definitions found in the classpath built via the Java DSL.
@@ -50,4 +51,9 @@ public class WorkflowDefinitionRecorder {
         };
     }
 
+    public Function<SyntheticCreationalContext<WorkflowDefinition>, WorkflowDefinition> workflowDefinitionVersionlessDelegateCreator(
+            String versionedIdentifier) {
+        return context -> context.getInjectedReference(WorkflowDefinition.class,
+                Identifier.Literal.of(versionedIdentifier));
+    }
 }

--- a/core/runtime/src/main/resources/META-INF/grafana/grafana-dashboard-quarkus-flow.json
+++ b/core/runtime/src/main/resources/META-INF/grafana/grafana-dashboard-quarkus-flow.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 5,
+  "id": 1,
   "links": [],
   "panels": [
     {
@@ -90,11 +90,11 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.0",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "editorMode": "builder",
-          "expr": "quarkus_flow_workflow_started_total{workflow=\"$workflow\"}",
+          "expr": "quarkus_flow_workflow_started_total{workflow=\"$workflow\", workflowVersion=\"$version\"}",
           "legendFormat": "started",
           "range": true,
           "refId": "A"
@@ -105,8 +105,7 @@
             "uid": "prometheus"
           },
           "editorMode": "builder",
-          "expr": "quarkus_flow_workflow_completed_total{workflow=\"$workflow\"}",
-          "hide": false,
+          "expr": "quarkus_flow_workflow_completed_total{workflow=\"$workflow\", workflowVersion=\"$version\"}",
           "instant": false,
           "legendFormat": "completed",
           "range": true,
@@ -120,7 +119,6 @@
           "editorMode": "builder",
           "exemplar": false,
           "expr": "quarkus_flow_workflow_faulted_total{workflow=\"$workflow\"}",
-          "hide": false,
           "instant": false,
           "interval": "",
           "legendFormat": "faulted",
@@ -179,12 +177,12 @@
         "textMode": "value_and_name",
         "wideLayout": false
       },
-      "pluginVersion": "12.3.0",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "quarkus_flow_task_started_total{workflow=\"$workflow\"}",
+          "expr": "quarkus_flow_task_started_total{workflow=\"$workflow\", workflowVersion=\"$version\"}",
           "format": "time_series",
           "instant": false,
           "legendFormat": "{{task}}",
@@ -284,12 +282,12 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.0",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "rate(quarkus_flow_workflow_duration_seconds_sum{workflow=\"$workflow\"}[$__interval]) \n/ \nrate(quarkus_flow_workflow_duration_seconds_count{workflow=\"$workflow\"}[$__interval])",
+          "expr": "rate(quarkus_flow_workflow_duration_seconds_sum{workflow=\"$workflow\",workflowVersion=\"$version\"}[$__interval]) \n/ \nrate(quarkus_flow_workflow_duration_seconds_count{workflow=\"$workflow\",workflowVersion=\"$version\"}[$__interval])",
           "instant": false,
           "legendFormat": "{{quantile}}",
           "range": true,
@@ -355,13 +353,13 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.0",
+      "pluginVersion": "12.4.2",
       "repeat": "workflow",
       "repeatDirection": "h",
       "targets": [
         {
           "editorMode": "builder",
-          "expr": "quarkus_flow_task_started_total{workflow=\"$workflow\"}",
+          "expr": "quarkus_flow_task_started_total{workflow=\"$workflow\", workflowVersion=\"$version\"}",
           "legendFormat": "{{task}}",
           "range": true,
           "refId": "A"
@@ -426,13 +424,13 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.0",
+      "pluginVersion": "12.4.2",
       "repeat": "workflow",
       "repeatDirection": "h",
       "targets": [
         {
           "editorMode": "builder",
-          "expr": "quarkus_flow_task_completed_total{workflow=\"$workflow\"}",
+          "expr": "quarkus_flow_task_completed_total{workflow=\"$workflow\", workflowVersion=\"$version\"}",
           "legendFormat": "{{task}}",
           "range": true,
           "refId": "A"
@@ -497,13 +495,13 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.0",
+      "pluginVersion": "12.4.2",
       "repeat": "workflow",
       "repeatDirection": "h",
       "targets": [
         {
           "editorMode": "builder",
-          "expr": "quarkus_flow_task_failed_total{workflow=\"$workflow\"}",
+          "expr": "quarkus_flow_task_failed_total{workflow=\"$workflow\", workflowVersion=\"$version\"}",
           "legendFormat": "{{task}}",
           "range": true,
           "refId": "A"
@@ -513,7 +511,7 @@
       "type": "piechart"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -521,184 +519,183 @@
         "y": 41
       },
       "id": 12,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 8,
-            "x": 0,
-            "y": 42
-          },
-          "id": 13,
-          "options": {
-            "minVizHeight": 75,
-            "minVizWidth": 75,
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
-            "sizing": "auto"
-          },
-          "pluginVersion": "12.3.0",
-          "targets": [
-            {
-              "editorMode": "builder",
-              "expr": "quarkus_flow_instance_running",
-              "legendFormat": "{{workflow}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Running Workflow Instances",
-          "type": "gauge"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 8,
-            "x": 8,
-            "y": 42
-          },
-          "id": 14,
-          "options": {
-            "minVizHeight": 75,
-            "minVizWidth": 75,
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
-            "sizing": "auto"
-          },
-          "pluginVersion": "12.3.0",
-          "targets": [
-            {
-              "editorMode": "builder",
-              "expr": "quarkus_flow_instance_suspended",
-              "legendFormat": "{{workflow}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Suspended Workflow Instances",
-          "type": "gauge"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 8,
-            "x": 16,
-            "y": 42
-          },
-          "id": 19,
-          "options": {
-            "minVizHeight": 75,
-            "minVizWidth": 75,
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
-            "sizing": "auto"
-          },
-          "pluginVersion": "12.3.0",
-          "targets": [
-            {
-              "editorMode": "builder",
-              "expr": "quarkus_flow_instance_waiting",
-              "legendFormat": "{{workflow}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Waiting Workflow Instances",
-          "type": "gauge"
-        }
-      ],
+      "panels": [],
       "title": "General",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 42
+      },
+      "id": 13,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "editorMode": "builder",
+          "expr": "quarkus_flow_instance_running",
+          "legendFormat": "{{workflow}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Running Workflow Instances",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 42
+      },
+      "id": 14,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "editorMode": "builder",
+          "expr": "quarkus_flow_instance_suspended",
+          "legendFormat": "{{workflow}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Suspended Workflow Instances",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 42
+      },
+      "id": 19,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "editorMode": "builder",
+          "expr": "quarkus_flow_instance_waiting",
+          "legendFormat": "{{workflow}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Waiting Workflow Instances",
+      "type": "gauge"
     },
     {
       "collapsed": true,
@@ -706,7 +703,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 51
       },
       "id": 11,
       "panels": [
@@ -801,7 +798,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 43
+            "y": 52
           },
           "id": 8,
           "options": {
@@ -898,7 +895,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 43
+            "y": 52
           },
           "id": 10,
           "options": {
@@ -1020,7 +1017,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 43
+            "y": 52
           },
           "id": 9,
           "options": {
@@ -1061,7 +1058,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 52
       },
       "id": 4,
       "panels": [
@@ -1090,7 +1087,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 44
+            "y": 53
           },
           "id": 2,
           "options": {
@@ -1158,7 +1155,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 44
+            "y": 53
           },
           "id": 21,
           "options": {
@@ -1226,7 +1223,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 44
+            "y": 53
           },
           "id": 3,
           "options": {
@@ -1279,7 +1276,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 53
       },
       "id": 6,
       "panels": [
@@ -1308,7 +1305,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 45
+            "y": 54
           },
           "id": 15,
           "options": {
@@ -1370,7 +1367,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 45
+            "y": 54
           },
           "id": 5,
           "options": {
@@ -1432,7 +1429,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 45
+            "y": 54
           },
           "id": 16,
           "options": {
@@ -1494,7 +1491,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 53
+            "y": 62
           },
           "id": 18,
           "options": {
@@ -1550,8 +1547,8 @@
       {
         "allowCustomValue": false,
         "current": {
-          "text": "wait-event",
-          "value": "wait-event"
+          "text": "simple-workflow",
+          "value": "simple-workflow"
         },
         "definition": "label_values(quarkus_flow_instance_running,workflow)",
         "description": "Workflow's name",
@@ -1565,6 +1562,31 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "0.0.1",
+          "value": "0.0.1"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(quarkus_flow_instance_running{workflow=\"$workflow\"},workflowVersion)",
+        "description": "Workflow's version",
+        "label": "version",
+        "name": "version",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(quarkus_flow_instance_running{workflow=\"$workflow\"},workflowVersion)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       }
     ]
@@ -1577,5 +1599,6 @@
   "timezone": "browser",
   "title": "Quarkus Flow",
   "uid": "qflow",
-  "version": 1
+  "version": 9,
+  "weekStart": ""
 }

--- a/core/runtime/src/test/java/io/quarkiverse/flow/internal/WorkflowNameUtilsTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/flow/internal/WorkflowNameUtilsTest.java
@@ -112,4 +112,10 @@ public class WorkflowNameUtilsTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    @DisplayName("Versionless identifier should produce namespace colon name")
+    void versionlessIdentifier_should_produce_namespace_colon_name() {
+        assertThat(WorkflowNameUtils.versionlessIdentifier("flow", "echo-name"))
+                .isEqualTo("flow:echo-name");
+    }
 }

--- a/docs/modules/ROOT/examples/flow/echo-name-v2.yaml
+++ b/docs/modules/ROOT/examples/flow/echo-name-v2.yaml
@@ -1,0 +1,9 @@
+document:
+  dsl: '1.0.0'
+  namespace: flow
+  name: echo-name
+  version: '0.2.0'
+do:
+  - setEcho:
+      set:
+        message: '${ "Echo (v0.2.0): " + .name }'

--- a/docs/modules/ROOT/pages/metrics-prometheus.adoc
+++ b/docs/modules/ROOT/pages/metrics-prometheus.adoc
@@ -52,50 +52,50 @@ Below is the complete list of counter metrics emitted by Quarkus Flow to track w
 | `quarkus_flow_workflow_started_total`
 | Total number of workflows started
 | Counter
-| `workflow`
-| `quarkus_flow_workflow_started_total{workflow="simple-workflow"} 3`
+| `workflow`, `workflowVersion`
+| `quarkus_flow_workflow_started_total{workflow="simple-workflow",workflowVersion="1.0.0"} 3`
 
 | `quarkus_flow_workflow_completed_total`
 | Total number of workflows completed
 | Counter
-| `workflow`
-| `quarkus_flow_workflow_completed_total{workflow="simple-workflow"} 3`
+| `workflow`, `workflowVersion`
+| `quarkus_flow_workflow_completed_total{workflow="simple-workflow",workflowVersion="1.0.0"} 3`
 
 | `quarkus_flow_workflow_faulted_total`
 | Total number of workflows faulted
 | Counter
-| `workflow`, `errorType`
-| `quarkus_flow_workflow_faulted_total{workflow="faulted-workflow",errorType="FAULTED"} 4`
+| `workflow`, `workflowVersion`, `errorType`
+| `quarkus_flow_workflow_faulted_total{workflow="faulted-workflow",workflowVersion="1.0.0",errorType="FAULTED"} 4`
 
 | `quarkus_flow_workflow_cancelled_total`
 | Total number of workflows cancelled
 | Counter
-| `workflow`
-| `quarkus_flow_workflow_cancelled_total{workflow="simple-workflow"} 1`
+| `workflow`, `workflowVersion`
+| `quarkus_flow_workflow_cancelled_total{workflow="simple-workflow",workflowVersion="1.0.0"} 1`
 
 | `quarkus_flow_task_started_total`
 | Total number of tasks started
 | Counter
-| `workflow`, `task`
-| `quarkus_flow_task_started_total{workflow="simple-workflow",task="getPet"} 6`
+| `workflow`, `task`, `workflowVersion`
+| `quarkus_flow_task_started_total{workflow="simple-workflow",task="getPet",workflowVersion="1.0.0"} 6`
 
 | `quarkus_flow_task_completed_total`
 | Total number of tasks completed
 | Counter
-| `workflow`, `task`
-| `quarkus_flow_task_completed_total{workflow="simple-workflow",task="getPet"} 6`
+| `workflow`, `task`, `workflowVersion`
+| `quarkus_flow_task_completed_total{workflow="simple-workflow",task="getPet",workflowVersion="1.0.0"} 6`
 
 | `quarkus_flow_task_retries_total`
 | Total number of task retries
 | Counter
-| `workflow`, `task`
-| `quarkus_flow_task_retries_total{workflow="retryable-example",task="getPet"} 3`
+| `workflow`, `task`, `workflowVersion`
+| `quarkus_flow_task_retries_total{workflow="retryable-example",task="getPet",workflowVersion="1.0.0"} 3`
 
 | `quarkus_flow_task_failed_total`
 | Total number of tasks failed
 | Counter
-| `workflow`, `task`
-| `quarkus_flow_task_failed_total{workflow="retryable-example",task="tryGetPet"} 1`
+| `workflow`, `task`, `workflowVersion`
+| `quarkus_flow_task_failed_total{workflow="retryable-example",task="tryGetPet",workflowVersion="1.0.0"} 1`
 |===
 
 == What is happening now?
@@ -116,25 +116,40 @@ Below is the list of gauge metrics emitted by Quarkus Flow.
 | `quarkus_flow_instance_running`
 | Number of workflow instances currently running
 | Gauge
-| `workflow`
-| `quarkus_flow_instance_running{workflow="retryable-example"} 1`
+| `workflow`, `workflowVersion`
+| `quarkus_flow_instance_running{workflow="retryable-example",workflowVersion="1.0.0"} 1`
 
 | `quarkus_flow_instance_waiting`
 | Number of workflow instances currently waiting
 | Gauge
-| `workflow`
-| `quarkus_flow_instance_waiting{workflow="retryable-example"} 0`
+| `workflow`, `workflowVersion`
+| `quarkus_flow_instance_waiting{workflow="retryable-example",workflowVersion="1.0.0"} 0`
 
 | `quarkus_flow_instance_suspended`
 | Number of workflow instances currently suspended
 | Gauge
-| `workflow`
-| `quarkus_flow_instance_suspended{workflow="retryable-example"} 0`
+| `workflow`, `workflowVersion`
+| `quarkus_flow_instance_suspended{workflow="retryable-example",workflowVersion="1.0.0"} 0`
 |===
 
 == How long did a workflow or task take to complete?
 
 Workflow and task durations are exported using Micrometer *Timers*.
+
+[options="header"]
+|===
+| Metric name | Description | Type | Tags
+
+| `quarkus_flow_workflow_duration`
+| Duration of workflow executions
+| Timer
+| `workflow`, `workflowVersion`
+
+| `quarkus_flow_task_duration`
+| Duration of task executions
+| Timer
+| `workflow`, `task`, `workflowVersion`
+|===
 
 Example configuration in `application.properties`:
 
@@ -155,14 +170,25 @@ Example output from `/q/metrics`:
 ----
 # TYPE quarkus_flow_workflow_duration_seconds histogram
 
-# Client-side percentiles
-quarkus_flow_workflow_duration_seconds{workflow="wait-event",quantile="0.5"} 14.49
-quarkus_flow_workflow_duration_seconds{workflow="wait-event",quantile="0.95"} 14.49
-quarkus_flow_workflow_duration_seconds{workflow="wait-event",quantile="0.99"} 14.49
+# Client-side percentiles (workflow)
+quarkus_flow_workflow_duration_seconds{workflow="wait-event",workflowVersion="1.0.0",quantile="0.5"} 14.49
+quarkus_flow_workflow_duration_seconds{workflow="wait-event",workflowVersion="1.0.0",quantile="0.95"} 14.49
+quarkus_flow_workflow_duration_seconds{workflow="wait-event",workflowVersion="1.0.0",quantile="0.99"} 14.49
 
-# Histogram buckets
-quarkus_flow_workflow_duration_seconds_bucket{workflow="wait-event",le="0.001"} 0
-quarkus_flow_workflow_duration_seconds_bucket{workflow="wait-event",le="0.002"} 0
+# Histogram buckets (workflow)
+quarkus_flow_workflow_duration_seconds_bucket{workflow="wait-event",workflowVersion="1.0.0",le="0.001"} 0
+quarkus_flow_workflow_duration_seconds_bucket{workflow="wait-event",workflowVersion="1.0.0",le="0.002"} 0
+
+# TYPE quarkus_flow_task_duration_seconds histogram
+
+# Client-side percentiles (task)
+quarkus_flow_task_duration_seconds{workflow="simple-workflow",task="getPet",workflowVersion="1.0.0",quantile="0.5"} 0.12
+quarkus_flow_task_duration_seconds{workflow="simple-workflow",task="getPet",workflowVersion="1.0.0",quantile="0.95"} 0.15
+quarkus_flow_task_duration_seconds{workflow="simple-workflow",task="getPet",workflowVersion="1.0.0",quantile="0.99"} 0.18
+
+# Histogram buckets (task)
+quarkus_flow_task_duration_seconds_bucket{workflow="simple-workflow",task="getPet",workflowVersion="1.0.0",le="0.001"} 0
+quarkus_flow_task_duration_seconds_bucket{workflow="simple-workflow",task="getPet",workflowVersion="1.0.0",le="0.002"} 0
 ----
 
 [[fault-tolerance-metrics]]

--- a/docs/modules/ROOT/pages/workflow-definitions.adoc
+++ b/docs/modules/ROOT/pages/workflow-definitions.adoc
@@ -57,7 +57,26 @@ During the Quarkus build, the engine parses your YAML files and generates `Workf
 
 Quarkus Flow uses the `document.namespace` and `document.name` fields from your YAML file to create a unique identifier for the bean.
 
-=== 2.1. Naming Strategy
+=== 2.1. Workflow Versioning
+
+When you have multiple versions of the same workflow (same `namespace:name` but different `version`), Quarkus Flow automatically creates a **versionless bean** that points to the workflow with the highest semantic version.
+
+For example, if you have two versions of a workflow, you can inject the latest version using the versionless identifier `namespace:name` (without the version):
+
+[source,java]
+----
+@Inject
+@Identifier("company:echo-name")  // <1>
+Flow flow;
+----
+<1> Automatically points to the highest semantic version available
+
+[TIP]
+====
+If you later add a new version with a higher semantic version number, the versionless bean will automatically point to it without requiring any code changes.
+====
+
+=== 2.2. Naming Strategy
 
 You can choose between two identifier formats using the xref:configuration.adoc#quarkus-flow_quarkus-flow-definitions-naming-strategy[`quarkus.flow.definitions.naming-strategy`] property:
 
@@ -65,16 +84,19 @@ You can choose between two identifier formats using the xref:configuration.adoc#
 |===
 |Strategy |Format |Example
 
-|`regular` (default)
-|`namespace:name`
-|Given `namespace: company` and `name: echo-name`, the identifier is `company:echo-name`
+|`spec` (default)
+|`namespace:name:version` (versioned) +
+`namespace:name` (versionless)
+|Given `namespace: company`, `name: echo-name`, `version: 1.0.0`: +
+Versioned: `company:echo-name:1.0.0` +
+Versionless: `company:echo-name`
 
 |`class`
 |`namespace.ClassName`
 |Given `namespace: company` and `name: echo-name`, the identifier is `company.EchoName` (name is converted to PascalCase)
 |===
 
-The `spec` strategy preserves the exact workflow name as defined in your YAML, while the `class` strategy converts the name to PascalCase for a Java class-like identifier.
+The `spec` strategy (recommended) includes the version in the identifier and creates a versionless bean for convenience. The `class` strategy converts the name to PascalCase for a Java class-like identifier.
 
 To use the `class` strategy, add this to your `application.properties`:
 
@@ -83,7 +105,7 @@ To use the `class` strategy, add this to your `application.properties`:
 quarkus.flow.definitions.naming-strategy=class
 ----
 
-=== 2.2. Inject and Execute the Workflow
+=== 2.3. Inject and Execute the Workflow
 
 Create a JAX-RS resource that injects and runs the workflow using the generated identifier:
 
@@ -95,7 +117,7 @@ include::{examples-dir}org/acme/EchoResource.java[]
 
 [IMPORTANT]
 ====
-The `@Identifier` value must exactly match the metadata generated from your YAML specification. If you change either `document.namespace` or `document.name` in the YAML, you must update the `@Identifier` in every Java class that injects this workflow.
+The `@Identifier` value must exactly match the metadata generated from your YAML specification. If you change `document.namespace`, `document.name`, or `document.version` in the YAML, you must update the `@Identifier` in every Java class that injects this workflow.
 ====
 
 [TIP]
@@ -103,7 +125,7 @@ The `@Identifier` value must exactly match the metadata generated from your YAML
 You can define a global namespace prefix for the identifiers using the xref:configuration.adoc#quarkus-flow_quarkus-flow-definitions-namespace-prefix[`quarkus.flow.definitions.namespace.prefix`] property in your `application.properties`.
 ====
 
-=== 2.1 Reactive Execution and Error Handling
+=== 2.4. Reactive Execution and Error Handling
 
 The `EchoResource` example uses the **recommended non-blocking style** for Quarkus REST endpoints (returning a `Uni<String>`).
 

--- a/examples/micrometer-prometheus/src/main/java/org/acme/TryWorkflowsResource.java
+++ b/examples/micrometer-prometheus/src/main/java/org/acme/TryWorkflowsResource.java
@@ -32,11 +32,11 @@ public class TryWorkflowsResource {
     EventWorkflow eventWorkflow;
 
     @Inject
-    @Identifier("test:retryable-example")
+    @Identifier("test:retryable-example:0.1.0")
     Flow retryable;
 
     @Inject
-    @Identifier("test:emit-event")
+    @Identifier("test:emit-event:0.1.0")
     Flow emitWorkflow;
 
     @Inject

--- a/examples/suspend-resume-abort/src/main/java/org/acme/flow/FlowAPIResource.java
+++ b/examples/suspend-resume-abort/src/main/java/org/acme/flow/FlowAPIResource.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
 public class FlowAPIResource {
 
     @Inject
-    @Identifier("example:SwitchLoopWait")
+    @Identifier("example:SwitchLoopWait:0.1.0")
     WorkflowDefinition flow;
 
     /**

--- a/langchain4j/runtime/pom.xml
+++ b/langchain4j/runtime/pom.xml
@@ -76,6 +76,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.zafarkhaja</groupId>
+            <artifactId>java-semver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.flow</groupId>
             <artifactId>quarkus-flow-dev</artifactId>
             <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
         <io.cloudevents.version>4.0.2</io.cloudevents.version>
 
         <io.quarkiverse.jackson-jq.version>2.5.1</io.quarkiverse.jackson-jq.version>
+        <com.github.zafarkhaja.version>0.10.2</com.github.zafarkhaja.version>
         <io.quarkiverse.langchain4j.version>1.10.0</io.quarkiverse.langchain4j.version>
-
         <!-- Tests and Docs -->
         <org.assertj.version>3.27.7</org.assertj.version>
         <quarkus-antora.version>3.25.0</quarkus-antora.version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
                 <version>${io.cloudevents.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.github.zafarkhaja</groupId>
+                <artifactId>java-semver</artifactId>
+                <version>${com.github.zafarkhaja.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${org.assertj.version}</version>

--- a/scheduler/integration-tests/src/test/java/io/quarkiverse/flow/scheduler/test/FlowSchedulerTest.java
+++ b/scheduler/integration-tests/src/test/java/io/quarkiverse/flow/scheduler/test/FlowSchedulerTest.java
@@ -18,15 +18,15 @@ import io.smallrye.common.annotation.Identifier;
 @QuarkusTest
 public class FlowSchedulerTest {
     @Inject
-    @Identifier("test:after-driven-schedule")
+    @Identifier("test:after-driven-schedule:0.1.0")
     WorkflowDefinition afterStartDefinition;
 
     @Inject
-    @Identifier("test:cron-driven-schedule")
+    @Identifier("test:cron-driven-schedule:0.1.0")
     WorkflowDefinition cronDefinition;
 
     @Inject
-    @Identifier("test:every-driven-schedule")
+    @Identifier("test:every-driven-schedule:0.1.0")
     WorkflowDefinition everyDefinition;
 
     @Test


### PR DESCRIPTION
# Changes

1. With the this pull request when the user creates a workflow from YAML DSL the application should show the following table with all identifiers that can be used.

```shell
Flow: Registered WorkflowDefinition beans
+------------------------------------------------------------------+
| Workflow identifier                                              |
+------------------------------------------------------------------+
| example:SwitchLoopWait  →  example:SwitchLoopWait:0.1.0 (latest) |
| example:SwitchLoopWait:0.1.0                                     |
+------------------------------------------------------------------+
```

2. Now, the user can have multiple workflows with the same `namespace` and `name` but with different versions. See the `core/integration-tests/src/test/java/io/quarkiverse/flow/it/EchoResourceTest.java`.
3. We are now adding the tag `workflowVersion` when sending metrics.
4. The Grafana dashboard can now be filtered by workflow and additionally by version:

<img width="1418" height="704" alt="Screenshot 2026-05-11 at 17 09 17" src="https://github.com/user-attachments/assets/a07ecd5e-027d-445d-b605-d0439adc6fba" />


Closes #496