### PR TITLE
Fixing missing dependency

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -67,6 +67,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
+         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkiverse.jackson-jq</groupId>
             <artifactId>quarkus-jackson-jq</artifactId>


### PR DESCRIPTION
The absent of quarkus-jackson on runtime was causing failures with latest quarkus-jackson-deployment module