### PR TITLE
Including Jackson Holder initializer for native compilation

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowNativeProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowNativeProcessor.java
@@ -8,6 +8,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.LambdaCapturingTypeBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.serverlessworkflow.impl.WorkflowModelFactory;
 import io.serverlessworkflow.impl.additional.NamedWorkflowAdditionalObject;
@@ -39,6 +40,12 @@ final class FlowNativeProcessor {
         sp.produce(ServiceProviderBuildItem.allProvidersFromClassPath(CallableTaskBuilder.class.getName()));
         sp.produce(ServiceProviderBuildItem.allProvidersFromClassPath(NamedWorkflowAdditionalObject.class.getName()));
         sp.produce(ServiceProviderBuildItem.allProvidersFromClassPath(CloudEventPredicateFactory.class.getName()));
+    }
+
+    @BuildStep
+    void runtimeInitialization(BuildProducer<RuntimeInitializedClassBuildItem> rt) {
+        rt.produce(new RuntimeInitializedClassBuildItem(
+                "io.serverlessworkflow.impl.executors.openapi.jackson.JacksonUnifiedOpenAPIReaderFactory$JacksonUnifiedOpenAPIReaderHolder"));
     }
 
     @BuildStep


### PR DESCRIPTION
This is a temptative fix for this failure on CI native build

`2026-05-13T05:51:58.3757527Z 2026-05-13 05:51:58,359 ERROR [io.quarkus.vertx.http.runtime.QuarkusErrorHandler] (vert.x-eventloop-thread-2) HTTP Request to /hello/problem-details failed, error id: c6dee263-7412-4853-a083-2e4de4a5d02e-1: java.lang.IllegalStateException: Missing UnifiedOpenAPIReader, please make sure dependency serverlessworkflow-impl-openapi is included`

Temptative because in local I cannot reproduce the issue