### PR TITLE
Add quarkus-arc-deployment to quarkus-flow-docs

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,7 +23,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc-deployment</artifactId>
+            <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,6 +22,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-core</artifactId>
             <version>${io.quarkiverse.langchain4j.version}</version>


### PR DESCRIPTION
This pull request makes a small update to the project's Maven configuration by adding a new dependency. The change adds the `quarkus-arc-deployment` dependency to the `docs/pom.xml` file, which may be required for build-time dependency injection or related Quarkus features.