### PR TITLE
issue-557: fix durable-workflows-k8s readme instructions

### DIFF
--- a/examples/durable-workflows-k8s/README.md
+++ b/examples/durable-workflows-k8s/README.md
@@ -57,7 +57,7 @@ Navigate to the example directory and deploy the Redis manifests before deployin
 
 ```bash
 cd examples/durable-workflows-k8s
-kubectl apply -f manifests/redis.yaml
+kubectl apply -f manifests/valkey.yaml
 ```
 
 Wait a moment for the Redis pod to be ready:
@@ -73,7 +73,7 @@ From the **repository root**, build (and deploy) only this module plus its depen
 
 ```bash
 cd ../.. # back to repo root
-./mvnw -pl examples/durable-workflows-k8s -am -Pkind clean package
+mvn -pl examples/durable-workflows-k8s -am -Pkind clean package
 ```
 
 What this does:
@@ -88,6 +88,11 @@ kubectl -n default get deploy durable-flow-demo
 kubectl -n default get pods -l app=durable-flow-demo -o wide
 ```
 
+If the deployment is not `READY` make sure to load the image:
+```bash
+kind load docker-image local/durable-flow-demo --name quarkus-flow
+```
+
 ---
 
 ## 4) The Interactive Control Center
@@ -96,7 +101,7 @@ This demo includes a real-time UI dashboard to visualize durable workflow execut
 
 1. Port-forward the application to access the UI locally:
    ```bash
-   kubectl -n default port-forward svc/durable-flow-demo 8080:8080
+   kubectl -n default port-forward svc/durable-flow-demo 8080:80
    ```
 2. Open your browser and navigate to: `http://localhost:8080/index.html`
 3. **Demo the Durability:**


### PR DESCRIPTION
## Description

Fixes `/examples/durable-workflows-k8s/README.md`

Fixes #557 

## Changes

-  Add note with the need to the load the built image to the KIND cluster, in case the deployment is not getting READY
- Port-forwarding command was not correct, `8080:8080` -> `8080:80`
- Deployment of state persistence references non-existing file `redis` -> `valkey`
- No `mvnw` in the root of the repo -> use `mvn`

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] Tested manually (describe below if applicable)

### Manual Testing
I executed the `README` instructions step by step.

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [x] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [x] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
