### PR TITLE
Add quarkus-arc to docs module

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -78,6 +78,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-messaging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
This pull request adds a new dependency to the project configuration in `docs/pom.xml`. Specifically, it introduces the `quarkus-arc` dependency, which is required for dependency injection and CDI (Contexts and Dependency Injection) support in Quarkus-based projects.

Dependency management:

* Added the `quarkus-arc` dependency to `docs/pom.xml` to enable CDI support in the documentation module.