### PR TITLE
Downgrade Quarkus version (`quarkus.version`) to the latest LTS version 3.33.2

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/EventAdaptersUnremovableTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/EventAdaptersUnremovableTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.cloudevents.CloudEvent;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableInstance;
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 import io.serverlessworkflow.impl.events.AbstractTypeConsumer;
 import io.serverlessworkflow.impl.events.EventConsumer;
 import io.serverlessworkflow.impl.events.EventPublisher;
@@ -24,7 +24,7 @@ import io.serverlessworkflow.impl.events.EventPublisher;
 public class EventAdaptersUnremovableTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(CustomEventPublisher.class, CustomEventConsumer.class))
             .withConfigurationResource("application-test-random.properties");

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/FlowDefinitionInjectionTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/FlowDefinitionInjectionTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.Arc;
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.impl.WorkflowDefinition;
 import io.serverlessworkflow.impl.WorkflowModel;
@@ -22,7 +22,7 @@ import io.smallrye.common.annotation.Identifier;
 public class FlowDefinitionInjectionTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(HelloWorldWorkflow.class)
                     .addClass(GreetingsWorkflow.class))

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/WorkflowFromSpecWithDuplicationTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/WorkflowFromSpecWithDuplicationTest.java
@@ -4,12 +4,12 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 
 public class WorkflowFromSpecWithDuplicationTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .withConfigurationResource("application-flow-file.properties")
             .withApplicationRoot((jar) -> jar.addAsResource(new StringAsset("""
                     document:

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/http/HttpFlowClientConfigTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/http/HttpFlowClientConfigTest.java
@@ -23,7 +23,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 
 import io.quarkus.arc.Arc;
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 import io.serverlessworkflow.impl.WorkflowDefinition;
 import io.serverlessworkflow.impl.WorkflowInstance;
 import io.serverlessworkflow.impl.WorkflowModel;
@@ -53,7 +53,7 @@ public class HttpFlowClientConfigTest {
     }
 
     @RegisterExtension
-    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(HttpRestFlow.class))
             // Wire the endpoint used by HttpRestFlow

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/listeners/CustomListenerTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/listeners/CustomListenerTest.java
@@ -13,14 +13,14 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 import io.serverlessworkflow.impl.WorkflowApplication;
 import io.serverlessworkflow.impl.lifecycle.WorkflowExecutionCompletableListener;
 
 public class CustomListenerTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(CustomExecutionListener.class))
             .withConfigurationResource("application-test-random.properties");

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/SendMetricWhenDisabledTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/SendMetricWhenDisabledTest.java
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 
 public class SendMetricWhenDisabledTest {
 
     @RegisterExtension
-    static QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .withApplicationRoot(jar -> {
                 jar.addClass(SimpleFlow.class);
             })

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/SendMetricWhenEnabledTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/SendMetricWhenEnabledTest.java
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 
 public class SendMetricWhenEnabledTest {
 
     @RegisterExtension
-    static QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .withApplicationRoot(jar -> {
                 jar.addClass(SimpleFlow.class);
             })

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/SendMetricWithCustomizedPrefixTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/SendMetricWithCustomizedPrefixTest.java
@@ -11,12 +11,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 
 public class SendMetricWithCustomizedPrefixTest {
 
     @RegisterExtension
-    static QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .withApplicationRoot(jar -> jar.addClass(SimpleFlow.class))
             .withConfigurationResource("metrics-enabled-custom-prefix.properties");
 

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/ShouldNotSendHistogramWithDurationsDisabledTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/ShouldNotSendHistogramWithDurationsDisabledTest.java
@@ -15,12 +15,12 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 
 public class ShouldNotSendHistogramWithDurationsDisabledTest {
 
     @RegisterExtension
-    static QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .withApplicationRoot(jar -> {
                 jar.addClass(SimpleFlow.class);
             })

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/ShouldNotSendMetricsUsingPercentilesTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/ShouldNotSendMetricsUsingPercentilesTest.java
@@ -16,12 +16,12 @@ import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 
 public class ShouldNotSendMetricsUsingPercentilesTest {
 
     @RegisterExtension
-    static QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .withApplicationRoot(jar -> {
                 jar.addClass(SimpleFlow.class);
             })

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/ShouldSendMetricsUsingPercentilesTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/ShouldSendMetricsUsingPercentilesTest.java
@@ -16,12 +16,12 @@ import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 
 public class ShouldSendMetricsUsingPercentilesTest {
 
     @RegisterExtension
-    static QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .withApplicationRoot(jar -> {
                 jar.addClass(SimpleFlow.class);
             })

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/recorders/WorkflowApplicationIdTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/recorders/WorkflowApplicationIdTest.java
@@ -9,13 +9,13 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 import io.serverlessworkflow.impl.WorkflowApplication;
 
 public class WorkflowApplicationIdTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
             .withConfigurationResource("application-named.properties");
 

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/secrets/SecretMissingResolutionTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/secrets/SecretMissingResolutionTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkiverse.flow.Flow;
 import io.quarkus.arc.Arc;
 import io.quarkus.credentials.CredentialsProvider;
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.fluent.spec.WorkflowBuilder;
 import io.serverlessworkflow.impl.WorkflowDefinition;
@@ -29,7 +29,7 @@ import io.smallrye.common.annotation.Identifier;
 public class SecretMissingResolutionTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(MissingSecretFlow.class)
                     .addClass(EmptyCredentialsProvider.class))

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/secrets/SecretResolutionFromConfigFileTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/secrets/SecretResolutionFromConfigFileTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.Arc;
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 import io.serverlessworkflow.impl.WorkflowDefinition;
 import io.serverlessworkflow.impl.WorkflowModel;
 import io.serverlessworkflow.impl.config.ConfigManager;
@@ -26,7 +26,7 @@ public class SecretResolutionFromConfigFileTest {
     ConfigManager cm;
 
     @RegisterExtension
-    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(SecretEchoWorkflow.class)
                     .addAsResource(new StringAsset("""

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/secrets/SecretResolutionTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/secrets/SecretResolutionTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.Arc;
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 import io.serverlessworkflow.impl.WorkflowDefinition;
 import io.serverlessworkflow.impl.WorkflowModel;
 import io.smallrye.common.annotation.Identifier;
@@ -19,7 +19,7 @@ import io.smallrye.common.annotation.Identifier;
 public class SecretResolutionTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(SecretEchoWorkflow.class)
                     .addClass(DumbCredentialsProvider.class))

--- a/docs/modules/ROOT/pages/includes/quarkus-flow-messaging.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-messaging.adoc
@@ -63,8 +63,8 @@ When enabled, correlation metadata attributes are automatically added to emitted
 
 The default correlation metadata includes:
 
- * `flowinstanceid` the instance ID, see `WorkflowInstance++#++id()`
- * `flowtaskid` the task's position that where the request was made, see `io.serverlessworkflow.impl.TaskContext++#++position()`
+ - `flowinstanceid` the instance ID, see `WorkflowInstance++#++id()`
+ - `flowtaskid` the task's position that where the request was made, see `io.serverlessworkflow.impl.TaskContext++#++position()`
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-flow-messaging_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-messaging_quarkus.flow.adoc
@@ -63,8 +63,8 @@ When enabled, correlation metadata attributes are automatically added to emitted
 
 The default correlation metadata includes:
 
- * `flowinstanceid` the instance ID, see `WorkflowInstance++#++id()`
- * `flowtaskid` the task's position that where the request was made, see `io.serverlessworkflow.impl.TaskContext++#++position()`
+ - `flowinstanceid` the instance ID, see `WorkflowInstance++#++id()`
+ - `flowtaskid` the task's position that where the request was made, see `io.serverlessworkflow.impl.TaskContext++#++position()`
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow.adoc
@@ -44,8 +44,8 @@ Naming strategy to be used when generating `Identifier++#++value()` for `io.quar
 
 Given a workflow definition with namespace (`namespace: foo`) name (`name: bar`):
 
- * If the naming strategy is `class`, the generated identifier will be `foo.Bar`.
- * If the naming strategy is `spec`, the generated identifier will be `foo:bar`.
+ - If the naming strategy is `class`, the generated identifier will be `foo.Bar`.
+ - If the naming strategy is `spec`, the generated identifier will be `foo:bar`.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -72,16 +72,16 @@ Must be a valid Java package name.
 
 Example:
 
- * Workflow Document's name: `myWorkflow`
- * Workflow Document's namespace: `flow`
- * Configuration: `quarkus.flow.namespace.prefix=my.company`
+ - Workflow Document's name: `myWorkflow`
+ - Workflow Document's namespace: `flow`
+ - Configuration: `quarkus.flow.namespace.prefix=my.company`
 
 
 
 Generated identifiers are:
 
- * `@Identifier("my.company.flow.MyWorkflow")`
- * `@Identifier("flow:myWorkflow")`
+ - `@Identifier("my.company.flow.MyWorkflow")`
+ - `@Identifier("flow:myWorkflow")`
 
 
 
@@ -156,8 +156,8 @@ endif::add-copy-button-to-config-props[]
 --
 The type of storage to use for workflow instances in dev mode.
 
- * *in-memory*: Data is stored in memory and lost on restart
- * *mvstore*: Data is persisted to a file using H2 MVStore
+ - *in-memory*: Data is stored in memory and lost on restart
+ - *mvstore*: Data is persisted to a file using H2 MVStore
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -303,9 +303,9 @@ Events to capture and log.
 
 Supports glob patterns:
 
- * `workflow.++*++` - All workflow and task events
- * `workflow.instance.++*++` - Only workflow-level events
- * `workflow.task.faulted` - Only task failures
+ - `workflow.++*++` - All workflow and task events
+ - `workflow.instance.++*++` - Only workflow-level events
+ - `workflow.task.faulted` - Only task failures
 
 
 
@@ -511,11 +511,11 @@ Timestamp format for structured logging events.
 
 Controls the format of all timestamp fields (timestamp, startTime, endTime, lastUpdateTime).
 
- * `iso8601` - ISO 8601 with nanosecond precision (default, backward compatible)
- * `epoch-seconds` - Unix epoch as double with fractional seconds (PostgreSQL via FluentBit)
- * `epoch-millis` - Unix epoch milliseconds as long (Elasticsearch)
- * `epoch-nanos` - Unix epoch nanoseconds as long (high-precision time-series)
- * `custom` - Custom DateTimeFormatter pattern (requires timestamp-pattern)
+ - `iso8601` - ISO 8601 with nanosecond precision (default, backward compatible)
+ - `epoch-seconds` - Unix epoch as double with fractional seconds (PostgreSQL via FluentBit)
+ - `epoch-millis` - Unix epoch milliseconds as long (Elasticsearch)
+ - `epoch-nanos` - Unix epoch nanoseconds as long (high-precision time-series)
+ - `custom` - Custom DateTimeFormatter pattern (requires timestamp-pattern)
 
 
 
@@ -546,9 +546,9 @@ Only used when `timestamp-format()` is `CUSTOM`.
 
 Example patterns:
 
- * `yyyy-MM-dd'T'HH:mm:ss.SSSXXX` - ISO 8601 with millisecond precision
- * `yyyy-MM-dd HH:mm:ss` - Simple datetime without timezone
- * `EEE, dd MMM yyyy HH:mm:ss Z` - RFC 1123 format
+ - `yyyy-MM-dd'T'HH:mm:ss.SSSXXX` - ISO 8601 with millisecond precision
+ - `yyyy-MM-dd HH:mm:ss` - Simple datetime without timezone
+ - `EEE, dd MMM yyyy HH:mm:ss Z` - RFC 1123 format
 
 
 
@@ -577,9 +577,9 @@ The log handler mode to use for structured logging events.
 
 Determines where workflow and task execution events are written:
 
- * `file` - Writes to a dedicated file (`/var/log/quarkus-flow/events.log` in production, `target/quarkus-flow-events.log` in dev/test)
- * `container` - Writes to stdout for containerized deployments (Kubernetes, Docker, cloud-native environments)
- * `none` - Disables automatic handler creation; you must manually configure handlers via `quarkus.log.++*++` properties
+ - `file` - Writes to a dedicated file (`/var/log/quarkus-flow/events.log` in production, `target/quarkus-flow-events.log` in dev/test)
+ - `container` - Writes to stdout for containerized deployments (Kubernetes, Docker, cloud-native environments)
+ - `none` - Disables automatic handler creation; you must manually configure handlers via `quarkus.log.++*++` properties
 
 
 
@@ -1127,9 +1127,9 @@ Logging scope for the underlying REST client.
 
 Supported values (case-insensitive):
 
- * `request-response`
- * `all`
- * `none`
+ - `request-response`
+ - `all`
+ - `none`
 
 Default client:
 
@@ -1252,9 +1252,9 @@ quarkus.flow.http.client.named.<name>.proxy-configuration-name=proxy-cfg
 
 There are some rules for using proxy configuration:
 
- * If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
- * If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
- * If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
+ - If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
+ - If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
+ - If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
 
 
 
@@ -1605,9 +1605,9 @@ Defines the maximum number of retries for a task execution.
 
 The value must be greater than or equal to `-1`.
 
- * `-1`: retries indefinitely
- * `0`: no retries (the task is executed only once)
- * `N > 0`: the task is executed `N {plus} 1` times (1 initial execution plus `N` retries)
+ - `-1`: retries indefinitely
+ - `0`: no retries (the task is executed only once)
+ - `N > 0`: the task is executed `N {plus} 1` times (1 initial execution plus `N` retries)
 
 
 
@@ -2030,8 +2030,8 @@ Whether the HTTP Client should propagate through HTTP headers the correlation me
 
 The correlation metadata are:
 
- * `X-Flow-Instance-Id` the instance ID see `WorkflowInstance++#++id()`
- * `X-Flow-Task-Id` the task's position that where the request was made, see `TaskContext++#++position()`
+ - `X-Flow-Instance-Id` the instance ID see `WorkflowInstance++#++id()`
+ - `X-Flow-Task-Id` the task's position that where the request was made, see `TaskContext++#++position()`
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -2602,9 +2602,9 @@ Logging scope for the underlying REST client.
 
 Supported values (case-insensitive):
 
- * `request-response`
- * `all`
- * `none`
+ - `request-response`
+ - `all`
+ - `none`
 
 Default client:
 
@@ -2727,9 +2727,9 @@ quarkus.flow.http.client.named.<name>.proxy-configuration-name=proxy-cfg
 
 There are some rules for using proxy configuration:
 
- * If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
- * If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
- * If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
+ - If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
+ - If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
+ - If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
 
 
 
@@ -3080,9 +3080,9 @@ Defines the maximum number of retries for a task execution.
 
 The value must be greater than or equal to `-1`.
 
- * `-1`: retries indefinitely
- * `0`: no retries (the task is executed only once)
- * `N > 0`: the task is executed `N {plus} 1` times (1 initial execution plus `N` retries)
+ - `-1`: retries indefinitely
+ - `0`: no retries (the task is executed only once)
+ - `N > 0`: the task is executed `N {plus} 1` times (1 initial execution plus `N` retries)
 
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.flow.adoc
@@ -44,8 +44,8 @@ Naming strategy to be used when generating `Identifier++#++value()` for `io.quar
 
 Given a workflow definition with namespace (`namespace: foo`) name (`name: bar`):
 
- * If the naming strategy is `class`, the generated identifier will be `foo.Bar`.
- * If the naming strategy is `spec`, the generated identifier will be `foo:bar`.
+ - If the naming strategy is `class`, the generated identifier will be `foo.Bar`.
+ - If the naming strategy is `spec`, the generated identifier will be `foo:bar`.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -72,16 +72,16 @@ Must be a valid Java package name.
 
 Example:
 
- * Workflow Document's name: `myWorkflow`
- * Workflow Document's namespace: `flow`
- * Configuration: `quarkus.flow.namespace.prefix=my.company`
+ - Workflow Document's name: `myWorkflow`
+ - Workflow Document's namespace: `flow`
+ - Configuration: `quarkus.flow.namespace.prefix=my.company`
 
 
 
 Generated identifiers are:
 
- * `@Identifier("my.company.flow.MyWorkflow")`
- * `@Identifier("flow:myWorkflow")`
+ - `@Identifier("my.company.flow.MyWorkflow")`
+ - `@Identifier("flow:myWorkflow")`
 
 
 
@@ -156,8 +156,8 @@ endif::add-copy-button-to-config-props[]
 --
 The type of storage to use for workflow instances in dev mode.
 
- * *in-memory*: Data is stored in memory and lost on restart
- * *mvstore*: Data is persisted to a file using H2 MVStore
+ - *in-memory*: Data is stored in memory and lost on restart
+ - *mvstore*: Data is persisted to a file using H2 MVStore
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -303,9 +303,9 @@ Events to capture and log.
 
 Supports glob patterns:
 
- * `workflow.++*++` - All workflow and task events
- * `workflow.instance.++*++` - Only workflow-level events
- * `workflow.task.faulted` - Only task failures
+ - `workflow.++*++` - All workflow and task events
+ - `workflow.instance.++*++` - Only workflow-level events
+ - `workflow.task.faulted` - Only task failures
 
 
 
@@ -511,11 +511,11 @@ Timestamp format for structured logging events.
 
 Controls the format of all timestamp fields (timestamp, startTime, endTime, lastUpdateTime).
 
- * `iso8601` - ISO 8601 with nanosecond precision (default, backward compatible)
- * `epoch-seconds` - Unix epoch as double with fractional seconds (PostgreSQL via FluentBit)
- * `epoch-millis` - Unix epoch milliseconds as long (Elasticsearch)
- * `epoch-nanos` - Unix epoch nanoseconds as long (high-precision time-series)
- * `custom` - Custom DateTimeFormatter pattern (requires timestamp-pattern)
+ - `iso8601` - ISO 8601 with nanosecond precision (default, backward compatible)
+ - `epoch-seconds` - Unix epoch as double with fractional seconds (PostgreSQL via FluentBit)
+ - `epoch-millis` - Unix epoch milliseconds as long (Elasticsearch)
+ - `epoch-nanos` - Unix epoch nanoseconds as long (high-precision time-series)
+ - `custom` - Custom DateTimeFormatter pattern (requires timestamp-pattern)
 
 
 
@@ -546,9 +546,9 @@ Only used when `timestamp-format()` is `CUSTOM`.
 
 Example patterns:
 
- * `yyyy-MM-dd'T'HH:mm:ss.SSSXXX` - ISO 8601 with millisecond precision
- * `yyyy-MM-dd HH:mm:ss` - Simple datetime without timezone
- * `EEE, dd MMM yyyy HH:mm:ss Z` - RFC 1123 format
+ - `yyyy-MM-dd'T'HH:mm:ss.SSSXXX` - ISO 8601 with millisecond precision
+ - `yyyy-MM-dd HH:mm:ss` - Simple datetime without timezone
+ - `EEE, dd MMM yyyy HH:mm:ss Z` - RFC 1123 format
 
 
 
@@ -577,9 +577,9 @@ The log handler mode to use for structured logging events.
 
 Determines where workflow and task execution events are written:
 
- * `file` - Writes to a dedicated file (`/var/log/quarkus-flow/events.log` in production, `target/quarkus-flow-events.log` in dev/test)
- * `container` - Writes to stdout for containerized deployments (Kubernetes, Docker, cloud-native environments)
- * `none` - Disables automatic handler creation; you must manually configure handlers via `quarkus.log.++*++` properties
+ - `file` - Writes to a dedicated file (`/var/log/quarkus-flow/events.log` in production, `target/quarkus-flow-events.log` in dev/test)
+ - `container` - Writes to stdout for containerized deployments (Kubernetes, Docker, cloud-native environments)
+ - `none` - Disables automatic handler creation; you must manually configure handlers via `quarkus.log.++*++` properties
 
 
 
@@ -1127,9 +1127,9 @@ Logging scope for the underlying REST client.
 
 Supported values (case-insensitive):
 
- * `request-response`
- * `all`
- * `none`
+ - `request-response`
+ - `all`
+ - `none`
 
 Default client:
 
@@ -1252,9 +1252,9 @@ quarkus.flow.http.client.named.<name>.proxy-configuration-name=proxy-cfg
 
 There are some rules for using proxy configuration:
 
- * If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
- * If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
- * If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
+ - If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
+ - If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
+ - If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
 
 
 
@@ -1605,9 +1605,9 @@ Defines the maximum number of retries for a task execution.
 
 The value must be greater than or equal to `-1`.
 
- * `-1`: retries indefinitely
- * `0`: no retries (the task is executed only once)
- * `N > 0`: the task is executed `N {plus} 1` times (1 initial execution plus `N` retries)
+ - `-1`: retries indefinitely
+ - `0`: no retries (the task is executed only once)
+ - `N > 0`: the task is executed `N {plus} 1` times (1 initial execution plus `N` retries)
 
 
 
@@ -2030,8 +2030,8 @@ Whether the HTTP Client should propagate through HTTP headers the correlation me
 
 The correlation metadata are:
 
- * `X-Flow-Instance-Id` the instance ID see `WorkflowInstance++#++id()`
- * `X-Flow-Task-Id` the task's position that where the request was made, see `TaskContext++#++position()`
+ - `X-Flow-Instance-Id` the instance ID see `WorkflowInstance++#++id()`
+ - `X-Flow-Task-Id` the task's position that where the request was made, see `TaskContext++#++position()`
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -2602,9 +2602,9 @@ Logging scope for the underlying REST client.
 
 Supported values (case-insensitive):
 
- * `request-response`
- * `all`
- * `none`
+ - `request-response`
+ - `all`
+ - `none`
 
 Default client:
 
@@ -2727,9 +2727,9 @@ quarkus.flow.http.client.named.<name>.proxy-configuration-name=proxy-cfg
 
 There are some rules for using proxy configuration:
 
- * If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
- * If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
- * If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
+ - If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
+ - If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
+ - If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
 
 
 
@@ -3080,9 +3080,9 @@ Defines the maximum number of retries for a task execution.
 
 The value must be greater than or equal to `-1`.
 
- * `-1`: retries indefinitely
- * `0`: no retries (the task is executed only once)
- * `N > 0`: the task is executed `N {plus} 1` times (1 initial execution plus `N` retries)
+ - `-1`: retries indefinitely
+ - `0`: no retries (the task is executed only once)
+ - `N > 0`: the task is executed `N {plus} 1` times (1 initial execution plus `N` retries)
 
 
 

--- a/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/FlowLangChain4jProcessorIT.java
+++ b/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/FlowLangChain4jProcessorIT.java
@@ -12,7 +12,7 @@ import io.quarkiverse.flow.internal.WorkflowNameUtils;
 import io.quarkiverse.flow.langchain4j.Agents;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 import io.serverlessworkflow.impl.WorkflowApplication;
 import io.serverlessworkflow.impl.WorkflowDefinition;
 import io.serverlessworkflow.impl.WorkflowDefinitionId;
@@ -20,7 +20,7 @@ import io.serverlessworkflow.impl.WorkflowDefinitionId;
 public class FlowLangChain4jProcessorIT {
 
     @RegisterExtension
-    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(Agents.class)
                     .addAsResource(new StringAsset("quarkus.http.test-port=0"), "application.properties"));

--- a/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/FlowLangChain4jProcessorTest.java
+++ b/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/FlowLangChain4jProcessorTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkiverse.flow.internal.WorkflowNameUtils;
 import io.quarkiverse.flow.langchain4j.Agents;
 import io.quarkus.arc.Arc;
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.impl.WorkflowApplication;
 import io.serverlessworkflow.impl.WorkflowDefinition;
@@ -28,7 +28,7 @@ import io.serverlessworkflow.impl.WorkflowDefinitionId;
  */
 public class FlowLangChain4jProcessorTest {
     @RegisterExtension
-    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(Agents.class)
                     .addAsResource(new StringAsset("quarkus.http.test-port=0"), "application.properties"));

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.log.level>OFF</quarkus.log.level>
 
-        <quarkus.version>3.36.0</quarkus.version>
+        <quarkus.version>3.33.2</quarkus.version>
         <jandex.version>3.5.3</jandex.version>
         <io.serverlessworkflow.version>7.21.2.Final</io.serverlessworkflow.version>
         <io.cloudevents.version>4.0.2</io.cloudevents.version>


### PR DESCRIPTION
## Downgrade Quarkus to LTS version 3.33.2

Downgrades the Quarkus version to `3.33.2`, the current Long-Term Support (LTS) release.

### Changes

- **Documentation:** Regenerated docs produced by the Quarkus annotation processor to match the new version output
- **Extension tests:** Replaced usages of `QuarkusUnitTest`, which was deprecated in versions above `3.33.2`, with the appropriate alternative

Closes #568 