### PR TITLE
issue-587: Fix incorrect quarkus_version_pom_property setup

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -19,3 +19,4 @@ jobs:
     with:
       ecosystem_ci_repo_path: quarkiverse-flow
       java_version: 17
+      quarkus_version_pom_property: 'quarkus.version'


### PR DESCRIPTION
Rely on explicit value used by `quarkus-flow

https://github.com/quarkiverse/.github/blob/main/.github/workflows/quarkus-ecosystem-ci.yml#L28C7-L28C35

## Description

<!-- Provide a clear description of what this PR does -->

Fixes #587 
## Changes

Explicitly defines `quarkus_version_pom_property` in https://github.com/quarkiverse/quarkus-flow/blob/main/.github/workflows/quarkus-snapshot.yaml to match [pom.xml value](https://github.com/quarkiverse/quarkus-flow/blob/3e882b15d7ee5883eb6abd9fb6de667dc631e1d2/pom.xml#L41)

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [x] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [x] Code follows the project's code conventions
- [x] Tests have been added/updated to cover the changes
- [x] Documentation has been updated (if user-facing changes)
- [x] Commit messages are clear and follow conventional commits style
- [x] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
