### PR TITLE
Fix NPE when agentic workflows are persisted by JPA

### DIFF
--- a/langchain4j/integration-tests/pom.xml
+++ b/langchain4j/integration-tests/pom.xml
@@ -51,6 +51,20 @@
             <artifactId>quarkus-flow-langchain4j-deployment</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.flow</groupId>
+            <artifactId>quarkus-flow-jpa</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.flow</groupId>
+            <artifactId>quarkus-flow-jpa-deployment</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/langchain4j/integration-tests/src/main/resources/application.properties
+++ b/langchain4j/integration-tests/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+# quarkus-flow-jpa is on the classpath for AgenticWorkflowWithJpaPersistenceIT.
+# Hibernate requires a datasource at build time; H2 in-memory is enough since the
+# round-trip test exercises the marshaller via the converter, not a table write.
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+quarkus.hibernate-orm.database.generation=drop-and-create

--- a/langchain4j/integration-tests/src/test/java/io/quarkiverse/flow/langchain4j/it/AgenticWorkflowWithJpaPersistenceIT.java
+++ b/langchain4j/integration-tests/src/test/java/io/quarkiverse/flow/langchain4j/it/AgenticWorkflowWithJpaPersistenceIT.java
@@ -1,0 +1,62 @@
+package io.quarkiverse.flow.langchain4j.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
+import io.quarkiverse.flow.langchain4j.spec.AgenticAwareModelFactory;
+import io.quarkiverse.flow.persistence.jpa.WorkflowModelConverter;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.serverlessworkflow.impl.WorkflowModel;
+
+/**
+ * Verifies that an agentic workflow model survives the exact serialization path the JPA persistence
+ * layer uses: {@link WorkflowModelConverter} marshals the model to bytes and back. This exercises
+ * {@code AgenticAwareWorkflowModelMarshaller}, which serializes the {@link AgenticScope} through the
+ * managed {@code ObjectMapper}. A round-trip keeps the assertion deterministic and free of the
+ * workflow-completion lifecycle (completed instances are not retained, so counting rows is meaningless).
+ */
+@QuarkusTest
+@QuarkusTestResource(FlowAgentOllamaMockResource.class)
+public class AgenticWorkflowWithJpaPersistenceIT {
+
+    @Inject
+    Agents.ExpertRouterAgent expertRouterAgent;
+
+    @Inject
+    WorkflowModelConverter converter;
+
+    @Test
+    @DisplayName("agentic_workflow_model_survives_jpa_persistence_round_trip")
+    void agentic_workflow_model_survives_jpa_persistence_round_trip() {
+        ResultWithAgenticScope<String> result = expertRouterAgent
+                .ask("I have severe chest pain and difficulty breathing, what medical treatment should I seek?");
+        AgenticScope scope = result.agenticScope();
+        assertThat(scope.readState("category"))
+                .as("sanity: the agentic scope carries the routed category before persistence")
+                .isEqualTo(Agents.RequestCategory.MEDICAL);
+
+        WorkflowModel model = new AgenticAwareModelFactory().fromOther(scope);
+
+        byte[] persisted = converter.convertToDatabaseColumn(model);
+        assertThat(persisted)
+                .as("the AgenticScope should marshal to bytes instead of failing silently")
+                .isNotEmpty();
+
+        WorkflowModel restored = converter.convertToEntityAttribute(persisted);
+
+        assertThat(restored.asMap())
+                .as("restored agentic model should expose its state")
+                .isPresent();
+        assertThat(restored.asMap().orElseThrow())
+                .as("restored agentic state should preserve the original scope state")
+                .containsKeys(scope.state().keySet().toArray(new String[0]))
+                .containsEntry("category", Agents.RequestCategory.MEDICAL);
+    }
+}

--- a/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/spec/AgenticAwareWorkflowModel.java
+++ b/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/spec/AgenticAwareWorkflowModel.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import dev.langchain4j.agentic.scope.AgenticScope;
 import io.serverlessworkflow.impl.AbstractWorkflowModel;
@@ -13,6 +15,8 @@ import io.serverlessworkflow.impl.WorkflowModel;
 import io.serverlessworkflow.impl.jackson.JsonUtils;
 import io.serverlessworkflow.impl.model.jackson.JacksonModel;
 
+@JsonSerialize(using = AgenticAwareWorkflowModelSerializer.class)
+@JsonDeserialize(using = AgenticAwareWorkflowModelDeserializer.class)
 public class AgenticAwareWorkflowModel extends AbstractWorkflowModel {
 
     private final AgenticScope agenticScope;

--- a/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/spec/AgenticAwareWorkflowModelDeserializer.java
+++ b/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/spec/AgenticAwareWorkflowModelDeserializer.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.flow.langchain4j.spec;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import dev.langchain4j.agentic.scope.AgenticScopeSerializer;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+
+public class AgenticAwareWorkflowModelDeserializer extends StdDeserializer<AgenticAwareWorkflowModel> {
+
+    private final AgenticAwareModelFactory factory;
+
+    public AgenticAwareWorkflowModelDeserializer() {
+        super(AgenticAwareWorkflowModel.class);
+        this.factory = new AgenticAwareModelFactory();
+    }
+
+    @Override
+    public AgenticAwareWorkflowModel deserialize(JsonParser parser, DeserializationContext ctxt) throws IOException {
+        DefaultAgenticScope scope = AgenticScopeSerializer.fromJson(parser.getValueAsString());
+        return (AgenticAwareWorkflowModel) factory.fromOther(scope);
+    }
+}

--- a/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/spec/AgenticAwareWorkflowModelMarshaller.java
+++ b/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/spec/AgenticAwareWorkflowModelMarshaller.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.flow.langchain4j.spec;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import io.serverlessworkflow.impl.jackson.JsonUtils;
+import io.serverlessworkflow.impl.marshaller.CustomObjectMarshaller;
+import io.serverlessworkflow.impl.marshaller.WorkflowInputBuffer;
+import io.serverlessworkflow.impl.marshaller.WorkflowOutputBuffer;
+
+public class AgenticAwareWorkflowModelMarshaller implements CustomObjectMarshaller<AgenticAwareWorkflowModel> {
+
+    @Override
+    public void write(WorkflowOutputBuffer buffer, AgenticAwareWorkflowModel value) {
+        try {
+            buffer.writeBytes(JsonUtils.mapper().writeValueAsBytes(value));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to marshal agentic workflow model", e);
+        }
+    }
+
+    @Override
+    public AgenticAwareWorkflowModel read(WorkflowInputBuffer buffer, Class<? extends AgenticAwareWorkflowModel> clazz) {
+        try {
+            return JsonUtils.mapper().readValue(buffer.readBytes(), clazz);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to unmarshal agentic workflow model", e);
+        }
+    }
+
+    @Override
+    public Class<AgenticAwareWorkflowModel> getObjectClass() {
+        return AgenticAwareWorkflowModel.class;
+    }
+}

--- a/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/spec/AgenticAwareWorkflowModelSerializer.java
+++ b/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/spec/AgenticAwareWorkflowModelSerializer.java
@@ -1,0 +1,23 @@
+package io.quarkiverse.flow.langchain4j.spec;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import dev.langchain4j.agentic.scope.AgenticScopeSerializer;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+
+public class AgenticAwareWorkflowModelSerializer extends StdSerializer<AgenticAwareWorkflowModel> {
+
+    public AgenticAwareWorkflowModelSerializer() {
+        super(AgenticAwareWorkflowModel.class);
+    }
+
+    @Override
+    public void serialize(AgenticAwareWorkflowModel value, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
+        gen.writeString(AgenticScopeSerializer.toJson(value.as(DefaultAgenticScope.class).orElseThrow()));
+    }
+}

--- a/langchain4j/runtime/src/main/resources/META-INF/services/io.serverlessworkflow.impl.marshaller.CustomObjectMarshaller
+++ b/langchain4j/runtime/src/main/resources/META-INF/services/io.serverlessworkflow.impl.marshaller.CustomObjectMarshaller
@@ -1,0 +1,1 @@
+io.quarkiverse.flow.langchain4j.spec.AgenticAwareWorkflowModelMarshaller


### PR DESCRIPTION
## Description

When both `quarkus-flow-jpa` and `quarkus-flow-langchain4j` are present, agentic workflows fail to persist their state. The agentic model (`AgenticAwareWorkflowModel`) carries a LangChain4j `AgenticScope`, and the serverlessworkflow buffer has no marshaller for it, so serialization throws. The JTA `beforeCompletion` swallows the exception, so the workflow appears to complete while nothing is persisted (silent data loss).

This PR adds a `CustomObjectMarshaller` for the agentic model that serializes the `AgenticScope` with LangChain4j's own `AgenticScopeSerializer`, so the state is actually persisted.

Fixes #613

## Changes

- Add `AgenticAwareWorkflowModelMarshaller` in `langchain4j/runtime`, implementing `CustomObjectMarshaller<AgenticAwareWorkflowModel>`. It serializes the `AgenticScope` via `AgenticScopeSerializer.toJson/fromJson`.
- Register it via `META-INF/services/io.serverlessworkflow.impl.marshaller.CustomObjectMarshaller` (same ServiceLoader pattern as `AgenticAwareModelFactory`).
- Add `AgenticWorkflowWithJpaPersistenceIT`: a round-trip test that takes a live `AgenticScope` from an agent invocation, runs it through `WorkflowModelConverter`, and asserts the state survives.

## Testing

- [x] Integration test added (round-trip through the JPA `WorkflowModelConverter`).

> [!NOTE]
> Verified on PostgreSQL, where `WorkflowModel` columns are `bytea` and the agentic state persists end to end. The #613 reproducer uses H2, where it now gets past the NPE but hits a separate, pre-existing limitation unrelated to this fix: `byte[]` columns map to `VARBINARY(255)`, so any sufficiently large model is truncated. H2 is not a production datastore; the column sizing could be tracked separately.
