### PR TITLE
Fix #629 - Do not query kubernetes locally on durable use cases

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-flow-durable-kubernetes.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-durable-kubernetes.adoc
@@ -91,24 +91,24 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++random+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-dev-dev-mode-strategy-enabled]] [.property-path]##link:#quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-dev-dev-mode-strategy-enabled[`+++quarkus.flow.durable.kube.dev.dev-mode-strategy-enabled+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-local-local-strategy-enabled]] [.property-path]##link:#quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-local-local-strategy-enabled[`+++quarkus.flow.durable.kube.local.local-strategy-enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.durable.kube.dev.dev-mode-strategy-enabled+++[]
+config_property_copy_button:+++quarkus.flow.durable.kube.local.local-strategy-enabled+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-If true, enables the dev-mode/test-mode strategy that avoids querying the K8s cluster when in dev mode or testing profiles. Defaults to true.
+If true, enables the dev-mode/test-mode/local-mode strategy that avoids querying the K8s cluster when in dev mode or testing profiles or executing in an environment without Kubernetes access. Defaults to true.
 
 Enable it ONLY if you can mock the Kubernetes objects required for the durable use case. In normal conditions, you will NEVER disable this property.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DURABLE_KUBE_DEV_DEV_MODE_STRATEGY_ENABLED+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DURABLE_KUBE_LOCAL_LOCAL_STRATEGY_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_DURABLE_KUBE_DEV_DEV_MODE_STRATEGY_ENABLED+++`
+Environment variable: `+++QUARKUS_FLOW_DURABLE_KUBE_LOCAL_LOCAL_STRATEGY_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/includes/quarkus-flow-durable-kubernetes_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-durable-kubernetes_quarkus.flow.adoc
@@ -91,24 +91,24 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++random+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-dev-dev-mode-strategy-enabled]] [.property-path]##link:#quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-dev-dev-mode-strategy-enabled[`+++quarkus.flow.durable.kube.dev.dev-mode-strategy-enabled+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-local-local-strategy-enabled]] [.property-path]##link:#quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-local-local-strategy-enabled[`+++quarkus.flow.durable.kube.local.local-strategy-enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.durable.kube.dev.dev-mode-strategy-enabled+++[]
+config_property_copy_button:+++quarkus.flow.durable.kube.local.local-strategy-enabled+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-If true, enables the dev-mode/test-mode strategy that avoids querying the K8s cluster when in dev mode or testing profiles. Defaults to true.
+If true, enables the dev-mode/test-mode/local-mode strategy that avoids querying the K8s cluster when in dev mode or testing profiles or executing in an environment without Kubernetes access. Defaults to true.
 
 Enable it ONLY if you can mock the Kubernetes objects required for the durable use case. In normal conditions, you will NEVER disable this property.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DURABLE_KUBE_DEV_DEV_MODE_STRATEGY_ENABLED+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DURABLE_KUBE_LOCAL_LOCAL_STRATEGY_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_DURABLE_KUBE_DEV_DEV_MODE_STRATEGY_ENABLED+++`
+Environment variable: `+++QUARKUS_FLOW_DURABLE_KUBE_LOCAL_LOCAL_STRATEGY_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/durable-kubernetes/deployment/src/main/java/io/quarkiverse/flow/durable/kube/deployment/FlowDurableKubernetesProcessor.java
+++ b/durable-kubernetes/deployment/src/main/java/io/quarkiverse/flow/durable/kube/deployment/FlowDurableKubernetesProcessor.java
@@ -1,16 +1,16 @@
 package io.quarkiverse.flow.durable.kube.deployment;
 
 import io.quarkiverse.flow.durable.kube.DeploymentPoolTopologyResolver;
-import io.quarkiverse.flow.durable.kube.DevModeStrategy;
 import io.quarkiverse.flow.durable.kube.Fabric8KubeInfoStrategy;
 import io.quarkiverse.flow.durable.kube.InjectLeaseWorkflowApplicationBuilderCustomizer;
 import io.quarkiverse.flow.durable.kube.LeaseAcquisitionHealthCheck;
 import io.quarkiverse.flow.durable.kube.LeaseService;
+import io.quarkiverse.flow.durable.kube.LocalStrategy;
 import io.quarkiverse.flow.durable.kube.MemberLeaseCoordinator;
 import io.quarkiverse.flow.durable.kube.PoolLeaderController;
 import io.quarkiverse.flow.durable.kube.PoolMemberController;
-import io.quarkiverse.flow.durable.kube.config.DevModeConfig;
 import io.quarkiverse.flow.durable.kube.config.FlowDurableKubeConfig;
+import io.quarkiverse.flow.durable.kube.config.LocalConfig;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -34,12 +34,12 @@ class FlowDurableKubernetesProcessor {
      * @see <a href="https://quarkus.io/guides/all-builditems#scheduler">Build Items - Scheduler</a>
      */
     @BuildStep
-    void forceStartSchedulerBuildItem(LaunchModeBuildItem launchMode, DevModeConfig devModeConfig,
+    void forceStartSchedulerBuildItem(LaunchModeBuildItem launchMode, LocalConfig localConfig,
             BuildProducer<ForceStartSchedulerBuildItem> forceScheduler) {
         boolean isDevOrTest = launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ||
                 launchMode.getLaunchMode() == LaunchMode.TEST;
         // Skip our schedulers by default
-        boolean bypassActive = isDevOrTest && devModeConfig.devModeStrategyEnabled();
+        boolean bypassActive = isDevOrTest && localConfig.localStrategyEnabled();
         if (!bypassActive) {
             forceScheduler.produce(new ForceStartSchedulerBuildItem());
         }
@@ -58,7 +58,7 @@ class FlowDurableKubernetesProcessor {
                         InjectLeaseWorkflowApplicationBuilderCustomizer.class,
                         DeploymentPoolTopologyResolver.class,
                         LeaseAcquisitionHealthCheck.class,
-                        DevModeStrategy.class)
+                        LocalStrategy.class)
                 .setUnremovable()
                 .build();
     }

--- a/durable-kubernetes/integration-tests/src/main/resources/application.properties
+++ b/durable-kubernetes/integration-tests/src/main/resources/application.properties
@@ -18,4 +18,4 @@ quarkus.flow.durable.kube.lease.leader.duration=5
 quarkus.flow.durable.kube.lease.member.duration=10
 
 quarkus.log.category."io.quarkiverse.flow".level=INFO
-quarkus.flow.durable.kube.dev.dev-mode-strategy-enabled=false
+quarkus.flow.durable.kube.local.local-strategy-enabled=false

--- a/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/Fabric8KubeInfoStrategy.java
+++ b/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/Fabric8KubeInfoStrategy.java
@@ -1,7 +1,8 @@
 package io.quarkiverse.flow.durable.kube;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
+import static io.quarkiverse.flow.durable.kube.KubernetesAwareness.HOSTNAME_ENV_VAR;
+import static io.quarkiverse.flow.durable.kube.KubernetesAwareness.NAMESPACE_ENV_VAR;
+import static io.quarkiverse.flow.durable.kube.KubernetesAwareness.POD_NAME_ENV_VAR;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -13,31 +14,11 @@ import io.quarkus.arc.DefaultBean;
 @ApplicationScoped
 public class Fabric8KubeInfoStrategy implements KubeInfoStrategy {
 
-    private static final String POD_NAME_ENV_VAR = "POD_NAME";
-    private static final String NAMESPACE_ENV_VAR = "POD_NAMESPACE";
-    // Usually, tools add this env var to deployments - we can use it as an alternative in case users forgot to set POD_NAMESPACE
-    private static final String K8S_NAMESPACE_ENV_VAR = "KUBERNETES_NAMESPACE";
-    private static final String HOSTNAME_ENV_VAR = "HOSTNAME";
-
-    private static final Path SERVICE_ACCOUNT_NAMESPACE_PATH = Path
-            .of("/var/run/secrets/kubernetes.io/serviceaccount/namespace");
-
     @Inject
     KubernetesClient client;
 
     volatile String cachedNamespace;
     volatile String cachedPodName;
-
-    private static String readNamespaceFromServiceAccount() {
-        try {
-            if (Files.isRegularFile(SERVICE_ACCOUNT_NAMESPACE_PATH)) {
-                return Files.readString(SERVICE_ACCOUNT_NAMESPACE_PATH).trim();
-            }
-        } catch (Exception ignored) {
-            // best-effort fallback
-        }
-        return null;
-    }
 
     @Override
     public String namespace() {
@@ -61,7 +42,7 @@ public class Fabric8KubeInfoStrategy implements KubeInfoStrategy {
         if (p != null && !p.isBlank())
             return p;
 
-        p = resolvePodNameOrNull();
+        p = KubernetesAwareness.tryResolveCurrentPodNameOrNull();
         if (p == null) {
             throw new IllegalStateException("Impossible to get current pod name. Please set " + POD_NAME_ENV_VAR
                     + " on the current deployment via Downward API or check if " + HOSTNAME_ENV_VAR
@@ -71,34 +52,13 @@ public class Fabric8KubeInfoStrategy implements KubeInfoStrategy {
         return p;
     }
 
-    protected String resolveNamespaceOrNull() {
-        String namespace = System.getenv(NAMESPACE_ENV_VAR);
-        if (namespace != null && !namespace.isBlank())
-            return namespace;
-
-        namespace = System.getenv(K8S_NAMESPACE_ENV_VAR);
-        if (namespace != null && !namespace.isBlank())
-            return namespace;
-
-        namespace = readNamespaceFromServiceAccount();
-        if (namespace != null && !namespace.isBlank())
-            return namespace;
+    private String resolveNamespaceOrNull() {
+        String namespace = KubernetesAwareness.tryResolveCurrentNamespaceOrNull();
 
         namespace = client.getNamespace();
         if (namespace != null && !namespace.isBlank())
             return namespace;
 
         return null;
-    }
-
-    protected String resolvePodNameOrNull() {
-        String podName = System.getenv(POD_NAME_ENV_VAR);
-        if (podName == null || podName.isBlank()) {
-            podName = System.getenv(HOSTNAME_ENV_VAR);
-        }
-        if (podName == null || podName.isBlank()) {
-            return null;
-        }
-        return podName;
     }
 }

--- a/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/InjectLeaseWorkflowApplicationBuilderCustomizer.java
+++ b/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/InjectLeaseWorkflowApplicationBuilderCustomizer.java
@@ -25,7 +25,7 @@ public class InjectLeaseWorkflowApplicationBuilderCustomizer implements Workflow
     LeaseGroupConfig leaseConfig;
 
     @Inject
-    DevModeStrategy devModeStrategy;
+    LocalStrategy localStrategy;
 
     @Inject
     Event<LeaseStartupEvent> leaseStartupEvent;
@@ -41,8 +41,8 @@ public class InjectLeaseWorkflowApplicationBuilderCustomizer implements Workflow
             return;
         }
 
-        if (devModeStrategy.enabled()) {
-            LOG.info("Flow: Dev Mode detected. Bypassing Kubernetes Lease acquisition for instant startup.");
+        if (localStrategy.enabled()) {
+            LOG.info("Flow: Local Mode detected. Bypassing Kubernetes Lease acquisition for instant startup.");
             // Return early. The WorkflowApplication will fallback to a default/local UUID.
             return;
         }

--- a/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/KubernetesAwareness.java
+++ b/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/KubernetesAwareness.java
@@ -1,0 +1,81 @@
+package io.quarkiverse.flow.durable.kube;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class KubernetesAwareness {
+    private KubernetesAwareness() {
+    }
+
+    static final String POD_NAME_ENV_VAR = "POD_NAME";
+    static final String NAMESPACE_ENV_VAR = "POD_NAMESPACE";
+    // Usually, tools add this env var to deployments - we can use it as an alternative in case users forgot to set POD_NAMESPACE
+    static final String K8S_NAMESPACE_ENV_VAR = "KUBERNETES_NAMESPACE";
+    static final String HOSTNAME_ENV_VAR = "HOSTNAME";
+    private static final String KUBERNETES_SERVICE_HOST_ENV_VAR = "KUBERNETES_SERVICE_HOST";
+
+    private static final Path SERVICE_ACCOUNT_NAMESPACE_PATH = Path
+            .of("/var/run/secrets/kubernetes.io/serviceaccount/namespace");
+
+    private static final Path SERVICE_ACCOUNT_TOKEN_PATH = Path.of("/var/run/secrets/kubernetes.io/serviceaccount/token");
+
+    private static String readNamespaceFromServiceAccount() {
+        try {
+            if (Files.isRegularFile(SERVICE_ACCOUNT_NAMESPACE_PATH)) {
+                return Files.readString(SERVICE_ACCOUNT_NAMESPACE_PATH).trim();
+            }
+        } catch (Exception ignored) {
+            // best-effort fallback
+        }
+        return null;
+    }
+
+    /**
+     * Detects if the application is running inside a Kubernetes cluster.
+     * Checks for the presence of service account files (most reliable) and
+     * falls back to the KUBERNETES_SERVICE_HOST environment variable.
+     *
+     * @return true if running in Kubernetes, false otherwise
+     */
+    public static boolean isRunningInKubernetes() {
+        // Primary: Check for service account token (always mounted by default)
+        if (Files.isRegularFile(SERVICE_ACCOUNT_TOKEN_PATH)) {
+            return true;
+        }
+
+        // Secondary: Check for service account namespace file
+        if (Files.isRegularFile(SERVICE_ACCOUNT_NAMESPACE_PATH)) {
+            return true;
+        }
+
+        // Fallback: Check environment variable (can be disabled via enableServiceLinks: false)
+        return System.getenv(KUBERNETES_SERVICE_HOST_ENV_VAR) != null;
+    }
+
+    static String tryResolveCurrentNamespaceOrNull() {
+        String namespace = System.getenv(NAMESPACE_ENV_VAR);
+        if (namespace != null && !namespace.isBlank())
+            return namespace;
+
+        namespace = System.getenv(K8S_NAMESPACE_ENV_VAR);
+        if (namespace != null && !namespace.isBlank())
+            return namespace;
+
+        namespace = readNamespaceFromServiceAccount();
+        if (namespace != null && !namespace.isBlank())
+            return namespace;
+
+        return null;
+    }
+
+    static String tryResolveCurrentPodNameOrNull() {
+        String podName = System.getenv(POD_NAME_ENV_VAR);
+        if (podName == null || podName.isBlank()) {
+            podName = System.getenv(HOSTNAME_ENV_VAR);
+        }
+        if (podName == null || podName.isBlank()) {
+            return null;
+        }
+        return podName;
+    }
+}

--- a/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/LocalStrategy.java
+++ b/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/LocalStrategy.java
@@ -3,22 +3,21 @@ package io.quarkiverse.flow.durable.kube;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import io.quarkiverse.flow.durable.kube.config.DevModeConfig;
+import io.quarkiverse.flow.durable.kube.config.LocalConfig;
 import io.quarkus.runtime.LaunchMode;
 
 /**
- * Handles the strategy for dev mode or testing on user's space.
- * When enabled, means that the system will automatically skip querying the Kubernetes API in dev mode or testing.
+ * Handles the strategy for dev mode, testing or local execution on user's space.
+ * When enabled, means that the system will automatically skip querying the Kubernetes API.
  * <p/>
  * To override this behavior, user's can disable this strategy via configuration on
- * {@link DevModeConfig#devModeStrategyEnabled()}.
+ * {@link LocalConfig#localStrategyEnabled()}.
  */
 @ApplicationScoped
-public class DevModeStrategy {
+public class LocalStrategy {
 
     @Inject
-    DevModeConfig devConfig;
-
+    LocalConfig devConfig;
     @Inject
     LaunchMode launchMode;
 
@@ -26,7 +25,8 @@ public class DevModeStrategy {
      * @return Whether we are on dev mode or user forced configuration to query Kubernetes in dev.
      */
     boolean enabled() {
-        return launchMode.isDevOrTest() && devConfig.devModeStrategyEnabled();
+        return (launchMode.isDevOrTest() || !KubernetesAwareness.isRunningInKubernetes()) &&
+                devConfig.localStrategyEnabled();
     }
 
 }

--- a/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/PoolController.java
+++ b/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/PoolController.java
@@ -31,7 +31,7 @@ public abstract class PoolController implements Runnable {
     KubeInfoStrategy kubeInfo;
 
     @Inject
-    DevModeStrategy devModeStrategy;
+    LocalStrategy localStrategy;
 
     protected String computeSchedulerDelay() {
         String schedulerInitialDelay = schedulerConfig().initialDelay();
@@ -48,8 +48,8 @@ public abstract class PoolController implements Runnable {
             return;
         }
         String scheduledExecutorName = scheduledExecutorName();
-        if (devModeStrategy.enabled()) {
-            LOG.debug("Flow: pool controller '{}' disabled by dev mode strategy settings", scheduledExecutorName);
+        if (localStrategy.enabled()) {
+            LOG.debug("Flow: pool controller '{}' disabled by local mode strategy", scheduledExecutorName);
             return;
         }
         LOG.info("Flow: Initializing pool controller '{}' scheduler", scheduledExecutorName);
@@ -71,7 +71,7 @@ public abstract class PoolController implements Runnable {
 
     @PreDestroy
     public void release() {
-        if (devModeStrategy.enabled()) {
+        if (localStrategy.enabled()) {
             return;
         }
 

--- a/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/config/LocalConfig.java
+++ b/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/config/LocalConfig.java
@@ -6,17 +6,18 @@ import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-@ConfigMapping(prefix = "quarkus.flow.durable.kube.dev")
-public interface DevModeConfig {
+@ConfigMapping(prefix = "quarkus.flow.durable.kube.local")
+public interface LocalConfig {
 
     /**
-     * If true, enables the dev-mode/test-mode strategy that avoids querying the K8s cluster when in dev mode or testing
-     * profiles.
+     * If true, enables the dev-mode/test-mode/local-mode strategy that avoids querying the K8s cluster when in dev mode or
+     * testing
+     * profiles or executing in an environment without Kubernetes access.
      * Defaults to true.
      * <p/>
      * Enable it ONLY if you can mock the Kubernetes objects required for the durable use case.
      * In normal conditions, you will NEVER disable this property.
      */
     @WithDefault("true")
-    boolean devModeStrategyEnabled();
+    boolean localStrategyEnabled();
 }

--- a/durable-kubernetes/runtime/src/test/resources/application.properties
+++ b/durable-kubernetes/runtime/src/test/resources/application.properties
@@ -7,4 +7,4 @@ quarkus.flow.durable.kube.pool.name=mypool
 quarkus.flow.durable.kube.lease.member.enabled=false
 quarkus.flow.durable.kube.lease.leader.enabled=false
 
-quarkus.flow.durable.kube.dev.dev-mode-strategy-enabled=false
+quarkus.flow.durable.kube.local.local-strategy-enabled=false


### PR DESCRIPTION
## Description

Fixes #629

## Changes

- Added a check if the context is running on Kubernetes to skip lease configuration
- Refactor some classes to reuse a utility class
 