### PR TITLE
Quarkus Ecosystem CI: Disable DevServices

### DIFF
--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -6,4 +6,4 @@ mvn -nsu --settings .github/quarkus-ecosystem-maven-settings.xml -B versions:set
 mvn -nsu --settings .github/quarkus-ecosystem-maven-settings.xml -B versions:set-property -Dproperty=version.io.quarkus -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false -ntp
 
 # run the tests
-mvn -nsu --settings .github/quarkus-ecosystem-maven-settings.xml -B clean install -Dnative -Dquarkus.native.container-build -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-25 -DskipITs=true --fail-at-end -e -ntp
+mvn -nsu --settings .github/quarkus-ecosystem-maven-settings.xml -B clean install -Dnative -Dquarkus.native.container-build -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-25 -DskipITs=true -Dquarkus.langchain4j.ollama.devservices.enabled=false --fail-at-end -e -ntp

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -22,6 +22,7 @@ jobs:
       java_version: 17
       quarkus_version_pom_property: 'quarkus.version'
   lts:
+    name: "Build against Quarkus LTS ${{ matrix.version }}"
     uses: quarkiverse/.github/.github/workflows/quarkus-ecosystem-ci.yml@main
     secrets: inherit
     with:
@@ -31,5 +32,4 @@ jobs:
     strategy:
       matrix:
         version: ['3.33']
-    name: "Build ${{ matrix.version }} against Quarkus latest ${{ matrix.version }}"
       


### PR DESCRIPTION
There is no reason to have Ollama LLM running during Quarkus Ecosystem CI, due to `-DskipITs=true`. 

This pull request disables Ollama DevServices on Quarkus Ecosystem CI.