### PR TITLE
Make the async persistence executor run with the transaction context cleared

### DIFF
--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/JpaPersistenceExecutor.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/JpaPersistenceExecutor.java
@@ -3,14 +3,14 @@ package io.quarkiverse.flow.persistence.jpa;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
-import io.smallrye.context.api.ManagedExecutorConfig;
 import jakarta.enterprise.context.ApplicationScoped;
-
 import jakarta.inject.Inject;
+
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
 
 import io.serverlessworkflow.impl.persistence.AbstractAsyncPersistenceExecutor;
+import io.smallrye.context.api.ManagedExecutorConfig;
 
 @ApplicationScoped
 public class JpaPersistenceExecutor extends AbstractAsyncPersistenceExecutor {

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/JpaPersistenceExecutor.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/JpaPersistenceExecutor.java
@@ -16,7 +16,6 @@ import io.smallrye.context.api.ManagedExecutorConfig;
 public class JpaPersistenceExecutor extends AbstractAsyncPersistenceExecutor {
 
     @Inject
-    // See https://github.com/quarkiverse/quarkus-flow/issues/652
     @ManagedExecutorConfig(cleared = ThreadContext.TRANSACTION)
     ManagedExecutor service;
 

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/JpaPersistenceExecutor.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/JpaPersistenceExecutor.java
@@ -3,10 +3,12 @@ package io.quarkiverse.flow.persistence.jpa;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
+import io.smallrye.context.api.ManagedExecutorConfig;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
 
+import jakarta.inject.Inject;
 import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
 
 import io.serverlessworkflow.impl.persistence.AbstractAsyncPersistenceExecutor;
 
@@ -14,6 +16,8 @@ import io.serverlessworkflow.impl.persistence.AbstractAsyncPersistenceExecutor;
 public class JpaPersistenceExecutor extends AbstractAsyncPersistenceExecutor {
 
     @Inject
+    // See https://github.com/quarkiverse/quarkus-flow/issues/652
+    @ManagedExecutorConfig(cleared = ThreadContext.TRANSACTION)
     ManagedExecutor service;
 
     @Override


### PR DESCRIPTION
## Description

<!-- Provide a clear description of what this PR does -->

Fixes #652 

## Changes

<!-- List the main changes in this PR -->

- Make the async persistence executor run with the **transaction context cleared**, so workflow
execution never inherits the caller's transaction. Each checkpoint then opens its own transaction
via the existing `REQUIRES_NEW`.

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
