### PR TITLE
Close MVStorePersistenceStore

### DIFF
--- a/persistence/mvstore/runtime/src/main/java/io/quarkiverse/flow/persistence/mvstore/MVStoreProducer.java
+++ b/persistence/mvstore/runtime/src/main/java/io/quarkiverse/flow/persistence/mvstore/MVStoreProducer.java
@@ -32,7 +32,7 @@ public class MVStoreProducer {
                 .withPersistenceExecutor(executor).build();
     }
 
-    void close(@Disposes MVStorePersistenceStore persistenceStore) {
+    public void close(@Disposes MVStorePersistenceStore persistenceStore) {
         try {
             persistenceStore.close();
         } catch (Exception e) {

--- a/persistence/mvstore/runtime/src/main/java/io/quarkiverse/flow/persistence/mvstore/MVStoreProducer.java
+++ b/persistence/mvstore/runtime/src/main/java/io/quarkiverse/flow/persistence/mvstore/MVStoreProducer.java
@@ -1,7 +1,11 @@
 package io.quarkiverse.flow.persistence.mvstore;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.serverlessworkflow.impl.marshaller.WorkflowBufferFactory;
 import io.serverlessworkflow.impl.persistence.DefaultPersistenceInstanceHandlers;
@@ -12,11 +16,27 @@ import io.serverlessworkflow.impl.persistence.mvstore.MVStorePersistenceStore;
 @ApplicationScoped
 public class MVStoreProducer {
 
+    static final Logger LOG = LoggerFactory.getLogger(MVStoreProducer.class);
+
     @Produces
     @ApplicationScoped
-    PersistenceInstanceHandlers mvStoreHandlers(MVStoreConfig config, WorkflowBufferFactory factory,
+    MVStorePersistenceStore persistenceStore(MVStoreConfig config, WorkflowBufferFactory factory) {
+        return new MVStorePersistenceStore(config.dbPath(), factory);
+    }
+
+    @Produces
+    @ApplicationScoped
+    PersistenceInstanceHandlers mvStoreHandlers(MVStorePersistenceStore store,
             PersistenceExecutor executor) {
-        return DefaultPersistenceInstanceHandlers.builder(new MVStorePersistenceStore(config.dbPath(), factory))
+        return DefaultPersistenceInstanceHandlers.builder(store)
                 .withPersistenceExecutor(executor).build();
+    }
+
+    void close(@Disposes MVStorePersistenceStore persistenceStore) {
+        try {
+            persistenceStore.close();
+        } catch (Exception e) {
+            LOG.warn("Error while closing MVStorePersistenceStore", e);
+        }
     }
 }

--- a/persistence/mvstore/runtime/src/test/java/io/quarkiverse/flow/persistence/mvstore/MVStoreProducerTest.java
+++ b/persistence/mvstore/runtime/src/test/java/io/quarkiverse/flow/persistence/mvstore/MVStoreProducerTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.flow.persistence.mvstore;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.h2.mvstore.MVStoreException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.serverlessworkflow.impl.marshaller.DefaultBufferFactory;
+import io.serverlessworkflow.impl.marshaller.WorkflowBufferFactory;
+import io.serverlessworkflow.impl.persistence.mvstore.MVStorePersistenceStore;
+
+public class MVStoreProducerTest {
+
+    @Test
+    void store_releases_file_lock_on_dispose() throws Exception {
+        Path db = Files.createTempDirectory("flow").resolve("persistent.db");
+        WorkflowBufferFactory factory = DefaultBufferFactory.factory();
+
+        MVStoreProducer producer = new MVStoreProducer();
+        MVStorePersistenceStore first = new MVStorePersistenceStore(db.toString(), factory);
+
+        producer.close(first); // exercise the @Disposes method
+
+        // Before the fix this throws: "The file is locked: persistent.db"
+        MVStorePersistenceStore second = new MVStorePersistenceStore(db.toString(), factory);
+        second.close();
+    }
+
+    @Test
+    void store_releases_file_lock_on_dispose_error() throws Exception {
+        Path db = Files.createTempDirectory("flow").resolve("persistent.db");
+        WorkflowBufferFactory factory = DefaultBufferFactory.factory();
+
+        MVStorePersistenceStore first = new MVStorePersistenceStore(db.toString(), factory);
+
+        // Before the fix this throws: "The file is locked: persistent.db"
+        String message = Assertions.assertThrows(MVStoreException.class, () -> {
+            new MVStorePersistenceStore(db.toString(), factory);
+        }).getMessage();
+
+        Assertions.assertTrue(message.contains("The file is locked"));
+    }
+}


### PR DESCRIPTION
## Description

<!-- Provide a clear description of what this PR does -->

Fixes #656
## Changes

<!-- List the main changes in this PR -->

- This pull request closes the `MVStorePersistenceStore` resources, it is very important when running a Quarkus Flow app with MVStore.

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
