### PR TITLE
Moving CloudEvent serialization to core module

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/flow/customizer/ObjectMapperCloudEventCustomizer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/customizer/ObjectMapperCloudEventCustomizer.java
@@ -1,13 +1,15 @@
-package io.quarkiverse.flow.messaging;
+package io.quarkiverse.flow.customizer;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.cloudevents.jackson.JsonFormat;
+import io.quarkus.arc.Unremovable;
 import io.quarkus.jackson.ObjectMapperCustomizer;
 
 @ApplicationScoped
+@Unremovable
 public class ObjectMapperCloudEventCustomizer implements ObjectMapperCustomizer {
 
     @Override

--- a/messaging/deployment/src/main/java/io/quarkiverse/flow/messaging/deployment/FlowMessagingProcessor.java
+++ b/messaging/deployment/src/main/java/io/quarkiverse/flow/messaging/deployment/FlowMessagingProcessor.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 import io.quarkiverse.flow.messaging.FlowDomainEventsPublisher;
 import io.quarkiverse.flow.messaging.FlowLifecycleEventsPublisher;
 import io.quarkiverse.flow.messaging.FlowMessagingConsumer;
-import io.quarkiverse.flow.messaging.ObjectMapperCloudEventCustomizer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -44,10 +43,4 @@ public class FlowMessagingProcessor {
 
         beans.produce(builder.setUnremovable().build());
     }
-
-    @BuildStep
-    AdditionalBeanBuildItem additionalBean() {
-        return AdditionalBeanBuildItem.unremovableOf(ObjectMapperCloudEventCustomizer.class);
-    }
-
 }


### PR DESCRIPTION
CloudEvent serialization is a core part of the spec and the object mapper needs to be configured accordingly.

Therefore, the current customizer is moved from messaging to core

