### PR TITLE
Add separate RAG artifact for documentation search

### DIFF
--- a/core/deployment/src/main/resources/META-INF/quarkus-rag-artifact.properties
+++ b/core/deployment/src/main/resources/META-INF/quarkus-rag-artifact.properties
@@ -1,0 +1,2 @@
+groupId=io.quarkiverse.flow
+artifactId=quarkus-flow-docs-rag

--- a/docs-rag/pom.xml
+++ b/docs-rag/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.flow</groupId>
+        <artifactId>quarkus-flow-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-flow-docs-rag</artifactId>
+    <name>Quarkus Flow - Documentation RAG</name>
+    <description>RAG vector embeddings for Quarkus Flow documentation</description>
+
+    <properties>
+        <skipRagGeneration>true</skipRagGeneration>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-extension-descriptor</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-documentation-rag-maven-plugin</artifactId>
+                <version>0.0.5</version>
+                <executions>
+                    <execution>
+                        <id>generate-rag</id>
+                        <goals>
+                            <goal>generate-rag</goal>
+                        </goals>
+                        <configuration>
+                            <guidesDirectory>${project.basedir}/../docs/modules/ROOT/pages</guidesDirectory>
+                            <skip>${skipRagGeneration}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>rag</id>
+            <properties>
+                <skipRagGeneration>false</skipRagGeneration>
+            </properties>
+        </profile>
+        <profile>
+            <id>release</id>
+            <properties>
+                <skipRagGeneration>false</skipRagGeneration>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/docs-rag/pom.xml
+++ b/docs-rag/pom.xml
@@ -10,11 +10,12 @@
     </parent>
 
     <artifactId>quarkus-flow-docs-rag</artifactId>
-    <name>Quarkus Flow - Documentation RAG</name>
+    <name>Quarkus Flow :: Documentation RAG</name>
     <description>RAG vector embeddings for Quarkus Flow documentation</description>
 
     <properties>
         <skipRagGeneration>true</skipRagGeneration>
+        <version.quarkus.rag-maven-plugin>0.0.5</version.quarkus.rag-maven-plugin>
     </properties>
 
     <build>
@@ -32,7 +33,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-documentation-rag-maven-plugin</artifactId>
-                <version>0.0.5</version>
+                <version>${version.quarkus.rag-maven-plugin}</version>
                 <executions>
                     <execution>
                         <id>generate-rag</id>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <module>bom</module>
         <module>quarkus-platform-checks</module>
         <module>runner</module>
+        <module>docs-rag</module>
     </modules>
 
     <scm>


### PR DESCRIPTION
Ships RAG vector embeddings in a dedicated `docs-rag` module so AI assistants (quarkus-agent-mcp, chappie) can search all 39 documentation pages (470 chunks, 1.0M artifact).

- New `docs-rag` module runs the RAG plugin against all documentation pages (activated by `-Prag` or `-Prelease`)
- Pointer file `META-INF/quarkus-rag-artifact.properties` in core/deployment tells the loader where to find it
- No deployment JAR size impact (only gains a small pointer file)

Depends on quarkusio/quarkus-agent-mcp#215 and chappie-bot/chappie-server#43 for the loader-side pointer file support.