### PR TITLE
docs: use a <path> placeholder for the workflow resource directory

### DIFF
--- a/docs/modules/ROOT/pages/workflow-definitions.adoc
+++ b/docs/modules/ROOT/pages/workflow-definitions.adoc
@@ -34,7 +34,7 @@ This definition:
 ====
 You can customize the discovery directory by setting the xref:configuration.adoc#quarkus-flow_quarkus-flow-definitions-dir[`quarkus.flow.definitions.dir`] property in your `application.properties`.
 
-The property accepts a classpath resource path (e.g., `flow`, `workflows`, or `custom/workflows`). Workflow files must be placed in `src/main/resources/{path}` to be available at runtime. All `*.yaml`, `*.yml`, and `*.json` files in the resource path are discovered automatically.
+The property accepts a classpath resource path (e.g., `flow`, `workflows`, or `custom/workflows`). Workflow files must be placed in `src/main/resources/<path>` to be available at runtime. All `*.yaml`, `*.yml`, and `*.json` files in the resource path are discovered automatically.
 ====
 
 [IMPORTANT]


### PR DESCRIPTION
## Summary

In `workflow-definitions.adoc`, the configurable classpath resource path is
written as `src/main/resources/{path}`. AsciiDoc treats `{path}` as an attribute
reference; with no `path` attribute defined, it renders literally as the broken
token `{path}`. This changes it to an angle-bracket `<path>` placeholder so it
reads as a user-supplied value, consistent with the escaped `{key}` placeholder
in `tracing.adoc`. Content-only — no behavior change.

## Files

- `docs/modules/ROOT/pages/workflow-definitions.adoc` (1 occurrence)
