### PR TITLE
Update artifact naming for OCI archive

### DIFF
--- a/.github/workflows/publish-runner-images.yml
+++ b/.github/workflows/publish-runner-images.yml
@@ -138,13 +138,13 @@ jobs:
           docker build --build-arg VARIANT=${VARIANT} -f Dockerfile -t quay.io/quarkiverse/quarkus-flow-runner:${TAG}-${VARIANT} .
 
           # Save as OCI archive
-          skopeo copy docker-daemon:quay.io/quarkiverse/quarkus-flow-runner:${TAG}-${VARIANT} oci-archive:artifact.tar.gz
+          skopeo copy docker-daemon:quay.io/quarkiverse/quarkus-flow-runner:${TAG}-${VARIANT} oci-archive:artifact-${VARIANT}.tar.gz
 
       - name: Upload the Docker Image
         uses: actions/upload-artifact@v7
         with:
           name: artifact-${{ matrix.variant }}
-          path: runner/app/artifact.tar.gz
+          path: runner/app/artifact-${{ matrix.variant }}.tar.gz
           retention-days: 1
 
   publish:


### PR DESCRIPTION
Small fix to the publish image pipeline to reflect the artifact name correctly.