### PR TITLE
Add StructuredLoggingListener as bean again

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
@@ -38,6 +38,7 @@ import io.quarkiverse.flow.recorders.SDKRecorder;
 import io.quarkiverse.flow.recorders.WorkflowApplicationCreator;
 import io.quarkiverse.flow.recorders.WorkflowApplicationRecorder;
 import io.quarkiverse.flow.recorders.WorkflowDefinitionRecorder;
+import io.quarkiverse.flow.structuredlogging.StructuredLoggingListener;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
@@ -179,6 +180,7 @@ class FlowProcessor {
                 .addBeanClass(FaultToleranceProvider.class)
                 .addBeanClass(WorkflowApplicationCreator.class)
                 .addBeanClass(WorkflowApplicationInitializer.class)
+                .addBeanClass(StructuredLoggingListener.class)
                 .setUnremovable()
                 .build();
     }

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingHttpAsyncTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingHttpAsyncTest.java
@@ -4,6 +4,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -113,19 +114,23 @@ public class StructuredLoggingHttpAsyncTest {
 
         // Then: structured log file should contain workflow completion event with output
         Path logFile = Path.of("target/quarkus-flow-events.log");
-        assertThat(logFile).exists();
 
-        List<String> logLines = Files.readAllLines(logFile);
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertThat(logFile).exists();
 
-        // Find the workflow.completed event
-        boolean foundCompletionEventWithOutput = logLines.stream()
-                .filter(line -> line.contains("workflow.completed"))
-                .filter(line -> line.contains(instance.id()))
-                .anyMatch(line -> line.contains("\"output\"") && line.contains("Received: Async Test Data"));
+            List<String> logLines = Files.readAllLines(logFile);
 
-        assertThat(foundCompletionEventWithOutput)
-                .as("Structured log should contain workflow.completed event with output for instance " + instance.id())
-                .isTrue();
+            // Find the workflow.completed event
+            boolean foundCompletionEventWithOutput = logLines.stream()
+                    .filter(line -> line.contains("workflow.completed"))
+                    .filter(line -> line.contains(instance.id()))
+                    .anyMatch(line -> line.contains("\"output\"") && line.contains("Received: Async Test Data"));
+
+            assertThat(foundCompletionEventWithOutput)
+                    .as("Structured log should contain workflow.completed event with output for instance "
+                            + instance.id())
+                    .isTrue();
+        });
     }
 
     @Test

--- a/core/runtime/src/main/java/io/quarkiverse/flow/structuredlogging/StructuredLoggingListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/structuredlogging/StructuredLoggingListener.java
@@ -17,8 +17,10 @@ import static io.quarkiverse.flow.structuredlogging.StructuredLoggingEventTypes.
 
 import java.util.logging.Handler;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import jakarta.inject.Singleton;
 import org.jboss.logging.Logger;
 import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.formatters.PatternFormatter;
@@ -46,6 +48,7 @@ import io.serverlessworkflow.impl.lifecycle.WorkflowSuspendedEvent;
 /**
  * Workflow execution listener that emits structured JSON logs for all lifecycle events.
  */
+@Singleton
 @LookupIfProperty(name = "quarkus.flow.structured-logging.enabled", stringValue = "true")
 public class StructuredLoggingListener implements WorkflowExecutionListener {
 

--- a/core/runtime/src/main/java/io/quarkiverse/flow/structuredlogging/StructuredLoggingListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/structuredlogging/StructuredLoggingListener.java
@@ -17,10 +17,9 @@ import static io.quarkiverse.flow.structuredlogging.StructuredLoggingEventTypes.
 
 import java.util.logging.Handler;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-
 import jakarta.inject.Singleton;
+
 import org.jboss.logging.Logger;
 import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.formatters.PatternFormatter;


### PR DESCRIPTION
Add the `StructuredLoggingListener` as singleton bean again, due to a change on https://github.com/quarkiverse/quarkus-flow/pull/679 PR.