### PR TITLE
Upgrade Quarkus version to 3.33.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.log.level>OFF</quarkus.log.level>
 
-        <quarkus.version>3.33.2</quarkus.version>
+        <quarkus.version>3.33.2.1</quarkus.version>
         <jandex.version>3.6.0</jandex.version>
         <io.serverlessworkflow.version>7.23.0.Final</io.serverlessworkflow.version>
         <io.cloudevents.version>4.1.1</io.cloudevents.version>


### PR DESCRIPTION
Upgrading Quarkus 3.33.x LTS to fix CVE issues reported in the latest 0.11.0 images release.