### PR TITLE
Register proto files to be included in native mode

### DIFF
--- a/docs/modules/ROOT/pages/grpc.adoc
+++ b/docs/modules/ROOT/pages/grpc.adoc
@@ -93,6 +93,25 @@ public class GrpcGreetingFlow extends Flow {
 
 The proto file at `src/main/resources/proto/greeter.proto` is resolved from the classpath automatically.
 
+[IMPORTANT]
+====
+**Native image**: proto files are read from the classpath at runtime, so Quarkus Flow does **not** bundle them
+into the native image automatically. If you build a native executable, don't forget to register your proto
+files as native resources, otherwise the workflow fails at startup with a missing-resource error:
+
+[source,properties]
+----
+quarkus.native.resources.includes=proto/greeter.proto
+----
+
+You can also use a pattern to include every proto under a directory:
+
+[source,properties]
+----
+quarkus.native.resources.includes=proto/*
+----
+====
+
 == Example project
 
 See the full runnable example at https://github.com/quarkiverse/quarkus-flow/tree/main/examples/grpc-client-routing[examples/grpc-client-routing].

--- a/grpc/integration-tests/src/main/resources/application.properties
+++ b/grpc/integration-tests/src/main/resources/application.properties
@@ -4,3 +4,5 @@ quarkus.grpc.server.plain-text=true
 quarkus.grpc.clients.flowGrpc.host=localhost
 quarkus.grpc.clients.flowGrpc.port=9000
 quarkus.grpc.clients.flowGrpc.plain-text=true
+
+quarkus.native.resources.includes=proto/*


### PR DESCRIPTION
# Context

This pull request try to fixes the current CI issue when running gRPC integration-tests on native mode.

## Pipeline

[![Native Compilation Nightly](https://github.com/quarkiverse/quarkus-flow/actions/workflows/native-nigthly-ci.yaml/badge.svg)](https://github.com/quarkiverse/quarkus-flow/actions/workflows/native-nigthly-ci.yaml)

