### PR TITLE
Add versionless gRPC channel resolution override

### DIFF
--- a/docs/modules/ROOT/pages/grpc.adoc
+++ b/docs/modules/ROOT/pages/grpc.adoc
@@ -20,13 +20,15 @@ It connects the Serverless Workflow gRPC executor to Quarkus gRPC channels, so y
 
 The module resolves the Quarkus gRPC named channel to use for each workflow task, following this order:
 
-1. **Task-level override**: `quarkus.flow.grpc.client.<workflowId>:<taskName>.name=<clientName>`
-2. **Workflow-level override**: `quarkus.flow.grpc.client.<workflowId>.name=<clientName>`
-3. **Default channel**: If a Quarkus gRPC client named `flowGrpc` exists, it is used for all workflows.
+1. **Task-level override**: `quarkus.flow.grpc.client."<workflowId>:<taskName>".name=<clientName>`
+2. **Workflow-level override**: `quarkus.flow.grpc.client."<workflowId>".name=<clientName>`
+3. **Versionless override**: `quarkus.flow.grpc.client."<namespace>:<name>".name=<clientName>` — applied to **all versions** of the workflow.
 4. **Workflow ID as client name**: If a Quarkus gRPC client matching the workflow ID exists, it is used.
-5. **SDK fallback**: If none of the above match, the SDK falls back to the host and port declared in the workflow itself.
+5. **Default channel**: If a Quarkus gRPC client named `flowGrpc` exists, it is used for all workflows.
+6. **SDK fallback**: If none of the above match, the SDK falls back to the host and port declared in the workflow itself.
 
 The workflow ID is `namespace:name:version` (e.g. `org.acme:grpcGreeting:0.0.1`).
+The versionless key is `namespace:name` (e.g. `org.acme:grpcGreeting`).
 
 == Configure a default channel
 
@@ -49,8 +51,22 @@ quarkus.grpc.clients.myService.host=my-grpc-server.example.com
 quarkus.grpc.clients.myService.port=443
 quarkus.grpc.clients.myService.plain-text=false
 
-quarkus.flow.grpc.client.org.acme:grpcGreeting:0.0.1.name=myService
+quarkus.flow.grpc.client."org.acme:grpcGreeting:0.0.1".name=myService
 ```
+
+== Configure a channel for all versions of a workflow
+
+To route every version of a workflow to the same gRPC server, use the versionless key `namespace:name` (omit the version):
+
+```properties
+quarkus.grpc.clients.myService.host=my-grpc-server.example.com
+quarkus.grpc.clients.myService.port=443
+quarkus.grpc.clients.myService.plain-text=false
+
+quarkus.flow.grpc.client."org.acme:grpcGreeting".name=myService
+```
+
+A version-specific override (`org.acme:grpcGreeting:0.0.1`) always takes precedence over the versionless one (`org.acme:grpcGreeting`).
 
 == Configure per-task channels
 
@@ -58,8 +74,8 @@ If a single workflow orchestrates multiple gRPC servers, use task-level override
 Each gRPC task in the workflow must have a unique name.
 
 ```properties
-quarkus.flow.grpc.client.org.acme:orderWorkflow:0.0.1.name=orderService
-quarkus.flow.grpc.client.org.acme:orderWorkflow:0.0.1:checkInventory.name=inventoryService
+quarkus.flow.grpc.client."org.acme:orderWorkflow:0.0.1".name=orderService
+quarkus.flow.grpc.client."org.acme:orderWorkflow:0.0.1:checkInventory".name=inventoryService
 ```
 
 [NOTE]

--- a/examples/grpc-client-routing/README.md
+++ b/examples/grpc-client-routing/README.md
@@ -6,8 +6,7 @@ This example shows how to call a gRPC service from a Quarkus Flow workflow using
 
 * A `GrpcGreetingFlow` workflow that uses the fluent `grpc()` DSL
 * A Quarkus gRPC service running in the same application
-* Routing the workflow through `quarkus.grpc.clients.greeter`
-* Selecting that client with `quarkus.flow.grpc.workflow.grpcGreeting.name=greeter`
+* Routing the workflow through the default `flowGrpc` Quarkus gRPC client
 
 ## Key configuration
 
@@ -15,12 +14,16 @@ This example shows how to call a gRPC service from a Quarkus Flow workflow using
 quarkus.grpc.server.port=9000
 quarkus.grpc.server.plain-text=true
 
-quarkus.grpc.clients.greeter.host=localhost
-quarkus.grpc.clients.greeter.port=9000
-quarkus.grpc.clients.greeter.plain-text=true
-
-quarkus.flow.grpc.workflow.grpcGreeting.name=greeter
+quarkus.grpc.clients.flowGrpc.host=localhost
+quarkus.grpc.clients.flowGrpc.port=9000
+quarkus.grpc.clients.flowGrpc.plain-text=true
 ```
+
+When a client named `flowGrpc` exists, every workflow uses it automatically.
+
+To route a specific workflow or task to a different client, see the
+[Channel resolution](https://docs.quarkiverse.io/quarkus-flow/dev/grpc.html#_channel_resolution)
+docs for the full priority order and override keys.
 
 ## Run it
 

--- a/grpc/runtime/pom.xml
+++ b/grpc/runtime/pom.xml
@@ -29,6 +29,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/grpc/runtime/src/main/java/io/quarkiverse/flow/config/FlowGrpcConfig.java
+++ b/grpc/runtime/src/main/java/io/quarkiverse/flow/config/FlowGrpcConfig.java
@@ -18,18 +18,19 @@ public interface FlowGrpcConfig {
      * <p>
      * Keys can be:
      * <ul>
-     * <li>{@code <namespace>:<name>:<version>} — workflow-level override</li>
      * <li>{@code <namespace>:<name>:<version>:<taskName>} — task-level override</li>
+     * <li>{@code <namespace>:<name>:<version>} — workflow-level override</li>
+     * <li>{@code <namespace>:<name>} — versionless override, applied to all versions of the workflow</li>
      * </ul>
      *
      * @return the map of client overrides
      */
-    Map<String, ClientOverride> client();
+    Map<String, ClientOverrideConfig> client();
 
     /**
      * Override for the Quarkus gRPC client name.
      */
-    interface ClientOverride {
+    interface ClientOverrideConfig {
 
         /**
          * The Quarkus gRPC client name to use, configured under

--- a/grpc/runtime/src/main/java/io/quarkiverse/flow/providers/GrpcChannelProvider.java
+++ b/grpc/runtime/src/main/java/io/quarkiverse/flow/providers/GrpcChannelProvider.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.flow.providers;
 
+import java.util.Map;
+import java.util.function.Predicate;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -48,31 +51,54 @@ public class GrpcChannelProvider implements WorkflowApplicationBuilderCustomizer
     }
 
     private String resolveClientName(WorkflowDefinitionId workflowId, String taskName) {
+        return resolveClientName(config.client(), this::channelExists, workflowId, taskName);
+    }
+
+    static String resolveClientName(Map<String, FlowGrpcConfig.ClientOverrideConfig> overrides,
+            Predicate<String> channelExists, WorkflowDefinitionId workflowId, String taskName) {
         String workflowKey = workflowId.toString(KEY_SEPARATOR);
 
+        // 1. Task-level override: namespace:name:version:taskName
         if (taskName != null && !taskName.isBlank()) {
-            String taskKey = workflowKey + KEY_SEPARATOR + taskName;
-            FlowGrpcConfig.ClientOverride taskOverride = config.client().get(taskKey);
-            if (taskOverride != null && taskOverride.name().isPresent()) {
-                return taskOverride.name().get();
+            String taskOverride = overrideName(overrides, workflowKey + KEY_SEPARATOR + taskName);
+            if (taskOverride != null) {
+                return taskOverride;
             }
         }
 
-        FlowGrpcConfig.ClientOverride workflowOverride = config.client().get(workflowKey);
-        if (workflowOverride != null && workflowOverride.name().isPresent()) {
-            return workflowOverride.name().get();
+        // 2. Workflow-level override: namespace:name:version
+        String workflowOverride = overrideName(overrides, workflowKey);
+        if (workflowOverride != null) {
+            return workflowOverride;
         }
 
-        if (channelExists(workflowKey)) {
+        // 3. Versionless workflow override: namespace:name (applies to all versions)
+        String versionlessOverride = overrideName(overrides, workflowId.namespace() + KEY_SEPARATOR + workflowId.name());
+        if (versionlessOverride != null) {
+            return versionlessOverride;
+        }
+
+        // 4. Workflow ID as client name
+        if (channelExists.test(workflowKey)) {
             return workflowKey;
         }
 
-        if (channelExists(DEFAULT_CHANNEL_NAME)) {
+        // 5. Default channel
+        if (channelExists.test(DEFAULT_CHANNEL_NAME)) {
             return DEFAULT_CHANNEL_NAME;
         }
 
+        // 6. SDK fallback
         LOG.debug("No Quarkus gRPC client configured for workflow '{}'; SDK will use its default channel",
                 workflowKey);
+        return null;
+    }
+
+    private static String overrideName(Map<String, FlowGrpcConfig.ClientOverrideConfig> overrides, String key) {
+        FlowGrpcConfig.ClientOverrideConfig override = overrides.get(key);
+        if (override != null && override.name().isPresent()) {
+            return override.name().get();
+        }
         return null;
     }
 

--- a/grpc/runtime/src/test/java/io/quarkiverse/flow/providers/GrpcChannelProviderPriorityOrderTest.java
+++ b/grpc/runtime/src/test/java/io/quarkiverse/flow/providers/GrpcChannelProviderPriorityOrderTest.java
@@ -1,0 +1,143 @@
+package io.quarkiverse.flow.providers;
+
+import static io.quarkiverse.flow.providers.GrpcChannelProvider.DEFAULT_CHANNEL_NAME;
+import static io.quarkiverse.flow.providers.GrpcChannelProvider.resolveClientName;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.flow.config.FlowGrpcConfig;
+import io.serverlessworkflow.impl.WorkflowDefinitionId;
+
+class GrpcChannelProviderPriorityOrderTest {
+
+    private static final WorkflowDefinitionId WORKFLOW = new WorkflowDefinitionId("org.acme", "grpcGreeting", "0.0.1");
+
+    private static final String TASK_KEY = "org.acme:grpcGreeting:0.0.1:greet";
+    private static final String WORKFLOW_KEY = "org.acme:grpcGreeting:0.0.1";
+    private static final String VERSIONLESS_KEY = "org.acme:grpcGreeting";
+
+    private static FlowGrpcConfig.ClientOverrideConfig override(String name) {
+        return () -> Optional.ofNullable(name);
+    }
+
+    /** No Quarkus gRPC clients are registered. */
+    private static final Predicate<String> NO_CHANNELS = name -> false;
+
+    /** Treats the given names as registered Quarkus gRPC clients. */
+    private static Predicate<String> channels(String... names) {
+        return Set.of(names)::contains;
+    }
+
+    @Nested
+    @DisplayName("config overrides")
+    class ConfigOverrides {
+
+        @Test
+        @DisplayName("A task-level override takes precedence over workflow, versionless and channel-existence rules")
+        void task_override_wins_over_everything() {
+            Map<String, FlowGrpcConfig.ClientOverrideConfig> overrides = Map.of(
+                    TASK_KEY, override("taskClient"),
+                    WORKFLOW_KEY, override("workflowClient"),
+                    VERSIONLESS_KEY, override("versionlessClient"));
+
+            String resolved = resolveClientName(overrides, channels(WORKFLOW_KEY, DEFAULT_CHANNEL_NAME), WORKFLOW, "greet");
+
+            assertThat(resolved).isEqualTo("taskClient");
+        }
+
+        @Test
+        @DisplayName("A version-specific workflow override takes precedence over the versionless override")
+        void workflow_override_wins_over_versionless() {
+            Map<String, FlowGrpcConfig.ClientOverrideConfig> overrides = Map.of(
+                    WORKFLOW_KEY, override("workflowClient"),
+                    VERSIONLESS_KEY, override("versionlessClient"));
+
+            String resolved = resolveClientName(overrides, channels(WORKFLOW_KEY, DEFAULT_CHANNEL_NAME), WORKFLOW, "greet");
+
+            assertThat(resolved).isEqualTo("workflowClient");
+        }
+
+        @Test
+        @DisplayName("The versionless override is applied when no version-specific override exists")
+        void versionless_override_applies_when_no_version_specific_override() {
+            Map<String, FlowGrpcConfig.ClientOverrideConfig> overrides = Map.of(
+                    VERSIONLESS_KEY, override("versionlessClient"));
+
+            String resolved = resolveClientName(overrides, channels(WORKFLOW_KEY, DEFAULT_CHANNEL_NAME), WORKFLOW, "greet");
+
+            assertThat(resolved).isEqualTo("versionlessClient");
+        }
+
+        @Test
+        @DisplayName("An explicit versionless override wins over the workflow-id-named client and the default channel")
+        void versionless_override_wins_over_workflow_id_named_client_and_default() {
+            Map<String, FlowGrpcConfig.ClientOverrideConfig> overrides = Map.of(
+                    VERSIONLESS_KEY, override("versionlessClient"));
+
+            // Both the workflow-id-named client and the default channel exist, but the explicit override wins.
+            String resolved = resolveClientName(overrides, channels(WORKFLOW_KEY, DEFAULT_CHANNEL_NAME), WORKFLOW, "greet");
+
+            assertThat(resolved).isEqualTo("versionlessClient");
+        }
+
+        @Test
+        @DisplayName("An override whose client name is absent is ignored and resolution continues")
+        void override_with_empty_name_is_ignored() {
+            Map<String, FlowGrpcConfig.ClientOverrideConfig> overrides = Map.of(
+                    VERSIONLESS_KEY, override(null));
+
+            String resolved = resolveClientName(overrides, channels(DEFAULT_CHANNEL_NAME), WORKFLOW, "greet");
+
+            assertThat(resolved).isEqualTo(DEFAULT_CHANNEL_NAME);
+        }
+    }
+
+    @Nested
+    @DisplayName("channel existence fallbacks")
+    class ChannelExistenceFallbacks {
+
+        @Test
+        @DisplayName("A client named after the workflow id wins over the default channel")
+        void workflow_id_named_client_wins_over_default_channel() {
+            String resolved = resolveClientName(Map.of(), channels(WORKFLOW_KEY, DEFAULT_CHANNEL_NAME), WORKFLOW, "greet");
+
+            assertThat(resolved).isEqualTo(WORKFLOW_KEY);
+        }
+
+        @Test
+        @DisplayName("The default channel is used when no workflow-id-named client exists")
+        void default_channel_used_when_no_workflow_id_named_client() {
+            String resolved = resolveClientName(Map.of(), channels(DEFAULT_CHANNEL_NAME), WORKFLOW, "greet");
+
+            assertThat(resolved).isEqualTo(DEFAULT_CHANNEL_NAME);
+        }
+
+        @Test
+        @DisplayName("Resolution returns null (SDK fallback) when no override or channel matches")
+        void sdk_fallback_returns_null_when_nothing_matches() {
+            String resolved = resolveClientName(Map.of(), NO_CHANNELS, WORKFLOW, "greet");
+
+            assertThat(resolved).isNull();
+        }
+    }
+
+    @Test
+    @DisplayName("A null task name skips the task-level override lookup and falls through to the workflow override")
+    void null_task_name_skips_task_level_override() {
+        Map<String, FlowGrpcConfig.ClientOverrideConfig> overrides = Map.of(
+                TASK_KEY, override("taskClient"),
+                WORKFLOW_KEY, override("workflowClient"));
+
+        String resolved = resolveClientName(overrides, NO_CHANNELS, WORKFLOW, null);
+
+        assertThat(resolved).isEqualTo("workflowClient");
+    }
+}


### PR DESCRIPTION
## Description

This pull request aims to add a versionless gRPC channel resolution override: It allows to define a gRPC channel to be used by all version of a workflow.

Fixes #691 

## Changes

<!-- List the main changes in this PR -->

- Introduce a new entry in the gRPC channel resolution priority order so a single override can target all versions of a workflow.
- Align the gRPC README.md example with the code
- Change `ClientOverride` to `ClientOverrideConfig` to follow the current codebase standard
- Add tests to be sure about the resolution priority order

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
