### PR TITLE
Fix quarkus-flow-jpa-deployment dependency on examples/pom.xml

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -74,7 +74,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.flow</groupId>
-            <artifactId>quarkus-flow-persistence-jpa-deployment</artifactId>
+            <artifactId>quarkus-flow-jpa-deployment</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Fix a small inconsistency of a non-existent dependency in the examples/pom.xml file.