### PR TITLE
Fix docs module: add missing deployment modules dependencies

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -16,6 +16,7 @@
 
     <dependencies>
         <!-- Make sure the doc is built after the other artifacts -->
+        <!-- Always bring the deployment modules, so we guarantee that the runtime also comes: required for the prepare-release reactor -->
         <dependency>
             <groupId>io.quarkiverse.flow</groupId>
             <artifactId>quarkus-flow-deployment</artifactId>
@@ -23,16 +24,17 @@
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.flow</groupId>
-            <artifactId>quarkus-flow-grpc</artifactId>
+            <artifactId>quarkus-flow-langchain4j-deployment</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-grpc</artifactId>
+            <groupId>io.quarkiverse.flow</groupId>
+            <artifactId>quarkus-flow-grpc-deployment</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.flow</groupId>
-            <artifactId>quarkus-flow-langchain4j</artifactId>
+            <artifactId>quarkus-flow-scheduler-deployment</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -74,11 +76,6 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.flow</groupId>
-            <artifactId>quarkus-flow-scheduler</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>


### PR DESCRIPTION
Error in the prepare-release pipeline:

```logs
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Quarkus Flow :: Parent 1.0.0-SNAPSHOT:
[INFO] 
[INFO] Quarkus Flow :: Parent ............................. SUCCESS [  7.021 s]
[INFO] Quarkus Flow :: Messaging :: Parent ................ SUCCESS [  0.019 s]
[INFO] Quarkus Flow :: Messaging :: Runtime ............... SUCCESS [ 11.784 s]
[INFO] Quarkus Flow :: Core :: Parent ..................... SUCCESS [  0.012 s]
[INFO] Quarkus Flow :: Core :: Runtime .................... SUCCESS [  9.466 s]
[INFO] Quarkus Flow :: Core :: Runtime Dev Mode Only ...... SUCCESS [  1.212 s]
[INFO] Quarkus Flow :: Messaging :: Deployment ............ SUCCESS [  0.569 s]
[INFO] Quarkus Flow :: Core :: Deployment ................. SUCCESS [  7.077 s]
[INFO] Quarkus Flow :: LangChain4j :: Parent .............. SUCCESS [  0.014 s]
[INFO] Quarkus Flow :: LangChain4j :: Runtime ............. FAILURE [  2.120 s]
[INFO] Quarkus Flow :: gRPC ............................... SKIPPED
[INFO] Quarkus Flow :: gRPC :: Runtime .................... SKIPPED
[INFO] Quarkus Flow :: Scheduler .......................... SKIPPED
[INFO] Quarkus Flow :: Scheduler:: InMemory ............... SKIPPED
[INFO] Quarkus Flow :: Scheduler :: InMemory:: Runtime .... SKIPPED
[INFO] Quarkus Flow :: Documentation ...................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:02 min
[INFO] Finished at: 2026-06-30T19:12:12Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal io.quarkus:quarkus-extension-maven-plugin:3.33.2.1:extension-descriptor (default) on project quarkus-flow-langchain4j: Deployment artifact io.quarkiverse.flow:quarkus-flow-langchain4j-deployment::jar:1.0.0-SNAPSHOT is missing the following dependencies from its configuration: io.quarkiverse.flow:quarkus-flow-langchain4j::jar, io.quarkus:quarkus-arc-deployment::jar, io.quarkus:quarkus-core-deployment::jar, io.quarkiverse.flow:quarkus-flow-deployment::jar, io.quarkus:quarkus-jackson-deployment::jar, io.quarkiverse.jackson-jq:quarkus-jackson-jq-deployment::jar, io.quarkus:quarkus-proxy-registry-deployment::jar, io.quarkus:quarkus-rest-client-jackson-deployment::jar, io.quarkus:quarkus-rest-jackson-common-deployment::jar, io.quarkus:quarkus-rest-common-deployment::jar, io.quarkus:quarkus-jsonp-deployment::jar, io.quarkus:quarkus-rest-client-deployment::jar, io.quarkus:quarkus-rest-client-jaxrs-deployment::jar, io.quarkus:quarkus-rest-client-config-deployment::jar, io.quarkus:quarkus-tls-registry-deployment::jar, io.quarkus:quarkus-smallrye-fault-tolerance-deployment::jar, io.quarkus:quarkus-mutiny-deployment::jar, io.quarkus:quarkus-smallrye-context-propagation-deployment::jar, io.quarkiverse.langchain4j:quarkus-langchain4j-agentic-deployment::jar, io.quarkiverse.langchain4j:quarkus-langchain4j-core-deployment::jar, io.quarkus:quarkus-qute-deployment::jar, io.quarkus:quarkus-vertx-deployment::jar, io.quarkus:quarkus-netty-deployment::jar, io.quarkus:quarkus-virtual-threads-deployment::jar -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error:  
Error:  After correcting the problems, you can resume the build with the command
Error:    mvn <args> -rf :quarkus-flow-langchain4j
Error: Process completed with exit code 1.
```