### PR TITLE
Update base image to latest UBI 9 OpenJDK 17 runtime to address CVEs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,62 @@
 
 version: 2
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Core project - restrict Quarkus to patch updates only
+  - package-ecosystem: "maven"
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    # Allow only patch updates for Quarkus dependencies
+    ignore:
+      - dependency-name: "io.quarkus:*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "io.quarkus.platform:*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    # Group dependencies to reduce PR noise
+    groups:
+      quarkus:
+        patterns:
+          - "io.quarkus*"
+        update-types:
+          - "patch"
+      langchain4j:
+        patterns:
+          - "io.quarkiverse.langchain4j:*"
+          - "dev.langchain4j:*"
+      serverlessworkflow:
+        patterns:
+          - "io.serverlessworkflow:*"
+      test-dependencies:
+        patterns:
+          - "org.assertj:*"
+          - "org.awaitility:*"
+          - "org.junit*"
+          - "io.rest-assured:*"
+          - "org.wiremock:*"
+          - "org.mockito:*"
+
+  # Examples - allow all Quarkus updates (major/minor/patch)
+  - package-ecosystem: "maven"
+    directory: "/examples"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      quarkus:
+        patterns:
+          - "io.quarkus*"
+
+  - package-ecosystem: "docker"
+    directory: "/runner/app"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: "weekly"
+      day: "monday"

--- a/runner/app/Dockerfile
+++ b/runner/app/Dockerfile
@@ -30,7 +30,7 @@ ARG VARIANT=minimal
 # ============================================================================
 # Base Image - Red Hat UBI 9 with OpenJDK 17
 # ============================================================================
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.24
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.24-2.1782292635
 
 # Re-declare ARG after FROM to make it available in this stage
 ARG VARIANT=minimal


### PR DESCRIPTION
## Summary

Updates the runner base image to address CVEs found in the 0.12.0 release.

## Changes

- Base image: `registry.access.redhat.com/ubi9/openjdk-17-runtime:1.24` → `1.24-2.1782292635`
- Build date: 2026-06-24 (latest available)
- Includes updated base packages and security patches

## Issue

CVEs were discovered in the 0.12.0 release images:
https://quay.io/repository/quarkiverse/quarkus-flow-runner/manifest/sha256:40d1233096ab433c29e104928e728b597fa70f252a523c45d8a50cf47508d655?tab=vulnerabilities

## Next Steps

After merging:
1. Rebuild and republish runner images with the updated base
2. Consider patching 0.12.x with a 0.12.1 release

## Related

- Red Hat UBI 9 OpenJDK 17 Runtime: https://catalog.redhat.com/en/software/containers/ubi9/openjdk-17-runtime/61ee7d45384a3eb331996bee
- Dependabot will now track these updates automatically (#703)