### PR TITLE
issue-707: Qflow generated JPA tables includes process instead of workflow in some of the generated DB objects

### DIFF
--- a/docs/modules/ROOT/examples/persistence/V1__create_tables_h2.sql
+++ b/docs/modules/ROOT/examples/persistence/V1__create_tables_h2.sql
@@ -15,7 +15,7 @@ CREATE TABLE cloud_event_entity
     PRIMARY KEY (id)
 );
 
-CREATE TABLE process_instance_entity
+CREATE TABLE workflow_instance_entity
 (
     application_id     VARCHAR(255)                NOT NULL,
     instance_id        VARCHAR(255)                NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE process_instance_entity
 CREATE TABLE task_info_entity
 (
     application_id      VARCHAR(255) NOT NULL,
-    process_instance_id VARCHAR(255) NOT NULL,
+    workflow_instance_id VARCHAR(255) NOT NULL,
     json_pointer        VARCHAR(255) NOT NULL,
     iteration           INTEGER      NOT NULL,
     task_type           INTEGER      NOT NULL CHECK (task_type IN (1, 2)),
@@ -41,10 +41,10 @@ CREATE TABLE task_info_entity
     next_position       VARCHAR(255),
     context             VARBINARY,
     model               VARBINARY,
-    PRIMARY KEY (iteration, application_id, json_pointer, process_instance_id),
+    PRIMARY KEY (iteration, application_id, json_pointer, workflow_instance_id),
     CHECK (task_type <> 1 OR (is_end_node IS NOT NULL)),
     CHECK (task_type <> 2 OR (retry_attempt IS NOT NULL)),
-    CONSTRAINT fk_task_process_instance
-        FOREIGN KEY (application_id, process_instance_id)
-            REFERENCES process_instance_entity (application_id, instance_id)
+    CONSTRAINT fk_task_workflow_instance
+        FOREIGN KEY (application_id, workflow_instance_id)
+            REFERENCES workflow_instance_entity (application_id, instance_id)
 );

--- a/docs/modules/ROOT/examples/persistence/V1__create_tables_mssql.sql
+++ b/docs/modules/ROOT/examples/persistence/V1__create_tables_mssql.sql
@@ -15,7 +15,7 @@ CREATE TABLE cloud_event_entity
     PRIMARY KEY (id)
     );
 
-CREATE TABLE process_instance_entity
+CREATE TABLE workflow_instance_entity
 (
     application_id     VARCHAR(255)      NOT NULL,
     instance_id        VARCHAR(255)      NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE process_instance_entity
 CREATE TABLE task_info_entity
 (
     application_id      VARCHAR(255) NOT NULL,
-    process_instance_id VARCHAR(255) NOT NULL,
+    workflow_instance_id VARCHAR(255) NOT NULL,
     json_pointer        VARCHAR(255) NOT NULL,
     iteration           INT          NOT NULL,
     task_type           INT          NOT NULL CHECK (task_type IN (1, 2)),
@@ -41,10 +41,10 @@ CREATE TABLE task_info_entity
     next_position       VARCHAR(255),
     context             VARBINARY(MAX),
     model               VARBINARY(MAX),
-    PRIMARY KEY (iteration, application_id, json_pointer, process_instance_id),
+    PRIMARY KEY (iteration, application_id, json_pointer, workflow_instance_id),
     CHECK (task_type <> 1 OR (is_end_node IS NOT NULL)),
     CHECK (task_type <> 2 OR (retry_attempt IS NOT NULL)),
-    CONSTRAINT fk_task_process_instance
-        FOREIGN KEY (application_id, process_instance_id)
-            REFERENCES process_instance_entity (application_id, instance_id)
+    CONSTRAINT fk_task_workflow_instance
+        FOREIGN KEY (application_id, workflow_instance_id)
+            REFERENCES workflow_instance_entity (application_id, instance_id)
 );

--- a/docs/modules/ROOT/examples/persistence/V1__create_tables_mysql.sql
+++ b/docs/modules/ROOT/examples/persistence/V1__create_tables_mysql.sql
@@ -15,7 +15,7 @@ CREATE TABLE cloud_event_entity
     PRIMARY KEY (id)
 );
 
-CREATE TABLE process_instance_entity
+CREATE TABLE workflow_instance_entity
 (
     application_id     VARCHAR(255) NOT NULL,
     instance_id        VARCHAR(255) NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE process_instance_entity
 CREATE TABLE task_info_entity
 (
     application_id      VARCHAR(255) NOT NULL,
-    process_instance_id VARCHAR(255) NOT NULL,
+    workflow_instance_id VARCHAR(255) NOT NULL,
     json_pointer        VARCHAR(255) NOT NULL,
     iteration           INTEGER      NOT NULL,
     task_type           INTEGER      NOT NULL CHECK (task_type IN (1, 2)),
@@ -41,10 +41,10 @@ CREATE TABLE task_info_entity
     next_position       VARCHAR(255),
     context             LONGBLOB,
     model               LONGBLOB,
-    PRIMARY KEY (iteration, application_id, json_pointer, process_instance_id),
+    PRIMARY KEY (iteration, application_id, json_pointer, workflow_instance_id),
     CHECK (task_type <> 1 OR (is_end_node IS NOT NULL)),
     CHECK (task_type <> 2 OR (retry_attempt IS NOT NULL)),
-    CONSTRAINT fk_task_process_instance
-        FOREIGN KEY (application_id, process_instance_id)
-            REFERENCES process_instance_entity (application_id, instance_id)
+    CONSTRAINT fk_task_workflow_instance
+        FOREIGN KEY (application_id, workflow_instance_id)
+            REFERENCES workflow_instance_entity (application_id, instance_id)
 );

--- a/docs/modules/ROOT/examples/persistence/V1__create_tables_oracle.sql
+++ b/docs/modules/ROOT/examples/persistence/V1__create_tables_oracle.sql
@@ -15,7 +15,7 @@ CREATE TABLE cloud_event_entity
     PRIMARY KEY (id)
 );
 
-CREATE TABLE process_instance_entity
+CREATE TABLE workflow_instance_entity
 (
     application_id     VARCHAR2(255)               NOT NULL,
     instance_id        VARCHAR2(255)               NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE process_instance_entity
 CREATE TABLE task_info_entity
 (
     application_id      VARCHAR2(255) NOT NULL,
-    process_instance_id VARCHAR2(255) NOT NULL,
+    workflow_instance_id VARCHAR2(255) NOT NULL,
     json_pointer        VARCHAR2(255) NOT NULL,
     iteration           NUMBER(10, 0) NOT NULL,
     task_type           NUMBER(10, 0) NOT NULL CHECK (task_type IN (1, 2)),
@@ -41,10 +41,10 @@ CREATE TABLE task_info_entity
     next_position       VARCHAR2(255),
     context             BLOB,
     model               BLOB,
-    PRIMARY KEY (iteration, application_id, json_pointer, process_instance_id),
+    PRIMARY KEY (iteration, application_id, json_pointer, workflow_instance_id),
     CHECK (task_type <> 1 OR (is_end_node IS NOT NULL)),
     CHECK (task_type <> 2 OR (retry_attempt IS NOT NULL)),
-    CONSTRAINT fk_task_process_instance
-        FOREIGN KEY (application_id, process_instance_id)
-            REFERENCES process_instance_entity (application_id, instance_id)
+    CONSTRAINT fk_task_workflow_instance
+        FOREIGN KEY (application_id, workflow_instance_id)
+            REFERENCES workflow_instance_entity (application_id, instance_id)
 );

--- a/docs/modules/ROOT/examples/persistence/V1__create_tables_pg.sql
+++ b/docs/modules/ROOT/examples/persistence/V1__create_tables_pg.sql
@@ -15,7 +15,7 @@ CREATE TABLE cloud_event_entity
     PRIMARY KEY (id)
 );
 
-CREATE TABLE process_instance_entity
+CREATE TABLE workflow_instance_entity
 (
     application_id     VARCHAR(255)                NOT NULL,
     instance_id        VARCHAR(255)                NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE process_instance_entity
 CREATE TABLE task_info_entity
 (
     application_id      VARCHAR(255) NOT NULL,
-    process_instance_id VARCHAR(255) NOT NULL,
+    workflow_instance_id VARCHAR(255) NOT NULL,
     json_pointer        VARCHAR(255) NOT NULL,
     iteration           INTEGER      NOT NULL,
     task_type           INTEGER      NOT NULL CHECK (task_type IN (1, 2)),
@@ -41,10 +41,10 @@ CREATE TABLE task_info_entity
     next_position       VARCHAR(255),
     context             BYTEA,
     model               BYTEA,
-    PRIMARY KEY (iteration, application_id, json_pointer, process_instance_id),
+    PRIMARY KEY (iteration, application_id, json_pointer, workflow_instance_id),
     CHECK (task_type <> 1 OR (is_end_node IS NOT NULL)),
     CHECK (task_type <> 2 OR (retry_attempt IS NOT NULL)),
-    CONSTRAINT fk_task_process_instance
-        FOREIGN KEY (application_id, process_instance_id)
-            REFERENCES process_instance_entity (application_id, instance_id)
+    CONSTRAINT fk_task_workflow_instance
+        FOREIGN KEY (application_id, workflow_instance_id)
+            REFERENCES workflow_instance_entity (application_id, instance_id)
 );

--- a/langchain4j/integration-tests/src/main/resources/db/migration/V1__create_tables.sql
+++ b/langchain4j/integration-tests/src/main/resources/db/migration/V1__create_tables.sql
@@ -15,7 +15,7 @@ CREATE TABLE cloud_event_entity
     PRIMARY KEY (id)
 );
 
-CREATE TABLE process_instance_entity
+CREATE TABLE workflow_instance_entity
 (
     application_id     VARCHAR(255)                NOT NULL,
     instance_id        VARCHAR(255)                NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE process_instance_entity
 CREATE TABLE task_info_entity
 (
     application_id      VARCHAR(255) NOT NULL,
-    process_instance_id VARCHAR(255) NOT NULL,
+    workflow_instance_id VARCHAR(255) NOT NULL,
     json_pointer        VARCHAR(255) NOT NULL,
     iteration           INTEGER      NOT NULL,
     task_type           INTEGER      NOT NULL CHECK (task_type IN (1, 2)),
@@ -41,10 +41,10 @@ CREATE TABLE task_info_entity
     next_position       VARCHAR(255),
     context             VARBINARY,
     model               VARBINARY,
-    PRIMARY KEY (iteration, application_id, json_pointer, process_instance_id),
+    PRIMARY KEY (iteration, application_id, json_pointer, workflow_instance_id),
     CHECK (task_type <> 1 OR (is_end_node IS NOT NULL)),
     CHECK (task_type <> 2 OR (retry_attempt IS NOT NULL)),
-    CONSTRAINT fk_task_process_instance
-        FOREIGN KEY (application_id, process_instance_id)
-            REFERENCES process_instance_entity (application_id, instance_id)
+    CONSTRAINT fk_task_workflow_instance
+        FOREIGN KEY (application_id, workflow_instance_id)
+            REFERENCES workflow_instance_entity (application_id, instance_id)
 );

--- a/langchain4j/integration-tests/src/main/resources/db/migration/h2/V1__create_tables.sql
+++ b/langchain4j/integration-tests/src/main/resources/db/migration/h2/V1__create_tables.sql
@@ -15,7 +15,7 @@ CREATE TABLE cloud_event_entity
     PRIMARY KEY (id)
 );
 
-CREATE TABLE process_instance_entity
+CREATE TABLE workflow_instance_entity
 (
     application_id     VARCHAR(255)                NOT NULL,
     instance_id        VARCHAR(255)                NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE process_instance_entity
 CREATE TABLE task_info_entity
 (
     application_id      VARCHAR(255) NOT NULL,
-    process_instance_id VARCHAR(255) NOT NULL,
+    workflow_instance_id VARCHAR(255) NOT NULL,
     json_pointer        VARCHAR(255) NOT NULL,
     iteration           INTEGER      NOT NULL,
     task_type           INTEGER      NOT NULL CHECK (task_type IN (1, 2)),
@@ -41,10 +41,10 @@ CREATE TABLE task_info_entity
     next_position       VARCHAR(255),
     context             VARBINARY,
     model               VARBINARY,
-    PRIMARY KEY (iteration, application_id, json_pointer, process_instance_id),
+    PRIMARY KEY (iteration, application_id, json_pointer, workflow_instance_id),
     CHECK (task_type <> 1 OR (is_end_node IS NOT NULL)),
     CHECK (task_type <> 2 OR (retry_attempt IS NOT NULL)),
-    CONSTRAINT fk_task_process_instance
-        FOREIGN KEY (application_id, process_instance_id)
-            REFERENCES process_instance_entity (application_id, instance_id)
+    CONSTRAINT fk_task_workflow_instance
+        FOREIGN KEY (application_id, workflow_instance_id)
+            REFERENCES workflow_instance_entity (application_id, instance_id)
 );

--- a/langchain4j/integration-tests/src/main/resources/db/migration/mysql/V1__create_tables.sql
+++ b/langchain4j/integration-tests/src/main/resources/db/migration/mysql/V1__create_tables.sql
@@ -15,7 +15,7 @@ CREATE TABLE cloud_event_entity
     PRIMARY KEY (id)
 );
 
-CREATE TABLE process_instance_entity
+CREATE TABLE workflow_instance_entity
 (
     application_id     VARCHAR(255) NOT NULL,
     instance_id        VARCHAR(255) NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE process_instance_entity
 CREATE TABLE task_info_entity
 (
     application_id      VARCHAR(255) NOT NULL,
-    process_instance_id VARCHAR(255) NOT NULL,
+    workflow_instance_id VARCHAR(255) NOT NULL,
     json_pointer        VARCHAR(255) NOT NULL,
     iteration           INTEGER      NOT NULL,
     task_type           INTEGER      NOT NULL CHECK (task_type IN (1, 2)),
@@ -41,10 +41,10 @@ CREATE TABLE task_info_entity
     next_position       VARCHAR(255),
     context             LONGBLOB,
     model               LONGBLOB,
-    PRIMARY KEY (iteration, application_id, json_pointer, process_instance_id),
+    PRIMARY KEY (iteration, application_id, json_pointer, workflow_instance_id),
     CHECK (task_type <> 1 OR (is_end_node IS NOT NULL)),
     CHECK (task_type <> 2 OR (retry_attempt IS NOT NULL)),
-    CONSTRAINT fk_task_process_instance
-        FOREIGN KEY (application_id, process_instance_id)
-            REFERENCES process_instance_entity (application_id, instance_id)
+    CONSTRAINT fk_task_workflow_instance
+        FOREIGN KEY (application_id, workflow_instance_id)
+            REFERENCES workflow_instance_entity (application_id, instance_id)
 );

--- a/langchain4j/integration-tests/src/main/resources/db/migration/oracle/V1__create_tables.sql
+++ b/langchain4j/integration-tests/src/main/resources/db/migration/oracle/V1__create_tables.sql
@@ -15,7 +15,7 @@ CREATE TABLE cloud_event_entity
     PRIMARY KEY (id)
 );
 
-CREATE TABLE process_instance_entity
+CREATE TABLE workflow_instance_entity
 (
     application_id     VARCHAR2(255)               NOT NULL,
     instance_id        VARCHAR2(255)               NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE process_instance_entity
 CREATE TABLE task_info_entity
 (
     application_id      VARCHAR2(255) NOT NULL,
-    process_instance_id VARCHAR2(255) NOT NULL,
+    workflow_instance_id VARCHAR2(255) NOT NULL,
     json_pointer        VARCHAR2(255) NOT NULL,
     iteration           NUMBER(10, 0) NOT NULL,
     task_type           NUMBER(10, 0) NOT NULL CHECK (task_type IN (1, 2)),
@@ -41,10 +41,10 @@ CREATE TABLE task_info_entity
     next_position       VARCHAR2(255),
     context             BLOB,
     model               BLOB,
-    PRIMARY KEY (iteration, application_id, json_pointer, process_instance_id),
+    PRIMARY KEY (iteration, application_id, json_pointer, workflow_instance_id),
     CHECK (task_type <> 1 OR (is_end_node IS NOT NULL)),
     CHECK (task_type <> 2 OR (retry_attempt IS NOT NULL)),
-    CONSTRAINT fk_task_process_instance
-        FOREIGN KEY (application_id, process_instance_id)
-            REFERENCES process_instance_entity (application_id, instance_id)
+    CONSTRAINT fk_task_workflow_instance
+        FOREIGN KEY (application_id, workflow_instance_id)
+            REFERENCES workflow_instance_entity (application_id, instance_id)
 );

--- a/langchain4j/integration-tests/src/main/resources/db/migration/postgresql/V1__create_tables.sql
+++ b/langchain4j/integration-tests/src/main/resources/db/migration/postgresql/V1__create_tables.sql
@@ -15,7 +15,7 @@ CREATE TABLE cloud_event_entity
     PRIMARY KEY (id)
 );
 
-CREATE TABLE process_instance_entity
+CREATE TABLE workflow_instance_entity
 (
     application_id     VARCHAR(255)                NOT NULL,
     instance_id        VARCHAR(255)                NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE process_instance_entity
 CREATE TABLE task_info_entity
 (
     application_id      VARCHAR(255) NOT NULL,
-    process_instance_id VARCHAR(255) NOT NULL,
+    workflow_instance_id VARCHAR(255) NOT NULL,
     json_pointer        VARCHAR(255) NOT NULL,
     iteration           INTEGER      NOT NULL,
     task_type           INTEGER      NOT NULL CHECK (task_type IN (1, 2)),
@@ -41,10 +41,10 @@ CREATE TABLE task_info_entity
     next_position       VARCHAR(255),
     context             BYTEA,
     model               BYTEA,
-    PRIMARY KEY (iteration, application_id, json_pointer, process_instance_id),
+    PRIMARY KEY (iteration, application_id, json_pointer, workflow_instance_id),
     CHECK (task_type <> 1 OR (is_end_node IS NOT NULL)),
     CHECK (task_type <> 2 OR (retry_attempt IS NOT NULL)),
-    CONSTRAINT fk_task_process_instance
-        FOREIGN KEY (application_id, process_instance_id)
-            REFERENCES process_instance_entity (application_id, instance_id)
+    CONSTRAINT fk_task_workflow_instance
+        FOREIGN KEY (application_id, workflow_instance_id)
+            REFERENCES workflow_instance_entity (application_id, instance_id)
 );

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/JpaInstanceOperations.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/JpaInstanceOperations.java
@@ -35,7 +35,7 @@ import io.serverlessworkflow.impl.persistence.RetriedTaskInfo;
 public class JpaInstanceOperations implements PersistenceInstanceOperations {
 
     @Inject
-    ProcessInstanceRepository repository;
+    WorkflowInstanceRepository repository;
 
     @Inject
     CloudEventRepository ceRepository;
@@ -49,7 +49,7 @@ public class JpaInstanceOperations implements PersistenceInstanceOperations {
     @Override
     public void writeInstanceData(WorkflowContextData workflowContext) {
         WorkflowInstanceData instance = workflowContext.instanceData();
-        repository.persist(new ProcessInstanceEntity(workflowContext.definition().application().id(),
+        repository.persist(new WorkflowInstanceEntity(workflowContext.definition().application().id(),
                 workflowContext.definition().id(), instance.id(), instance.startedAt(), instance.input()));
     }
 
@@ -124,12 +124,12 @@ public class JpaInstanceOperations implements PersistenceInstanceOperations {
         QuarkusTransaction.begin();
         WorkflowDefinitionId id = definition.id();
         return repository.stream(
-                "select x from ProcessInstanceEntity x where x.applicationId=?1 and x.workflowNamespace=?2 and x.workflowName=?3 and x.workflowVersion=?4",
+                "select x from WorkflowInstanceEntity x where x.applicationId=?1 and x.workflowNamespace=?2 and x.workflowName=?3 and x.workflowVersion=?4",
                 applicationId, id.namespace(), id.name(), id.version()).map(this::from)
                 .onClose(() -> QuarkusTransaction.commit());
     }
 
-    private PersistenceWorkflowInfo from(ProcessInstanceEntity x) {
+    private PersistenceWorkflowInfo from(WorkflowInstanceEntity x) {
         return new PersistenceWorkflowInfo(x.getInstanceId(), x.getStartedAt(), x.getInput(), x.getStatus(),
                 from(x.getTasks()));
     }
@@ -151,14 +151,14 @@ public class JpaInstanceOperations implements PersistenceInstanceOperations {
     @Override
     @Transactional
     public Optional<PersistenceWorkflowInfo> readWorkflowInfo(WorkflowDefinition definition, String instanceId) {
-        return repository.findByIdOptional(new ProcessInstanceKey(instanceId, definition.application().id())).map(this::from);
+        return repository.findByIdOptional(new WorkflowInstanceKey(instanceId, definition.application().id())).map(this::from);
     }
 
-    private ProcessInstanceEntity find(WorkflowContextData workflowContext) {
+    private WorkflowInstanceEntity find(WorkflowContextData workflowContext) {
         return repository.findById(toKey(workflowContext));
     }
 
-    private ProcessInstanceKey toKey(WorkflowContextData workflowContext) {
-        return new ProcessInstanceKey(workflowContext.instanceData().id(), workflowContext.definition().application().id());
+    private WorkflowInstanceKey toKey(WorkflowContextData workflowContext) {
+        return new WorkflowInstanceKey(workflowContext.instanceData().id(), workflowContext.definition().application().id());
     }
 }

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/TaskInfoEntity.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/TaskInfoEntity.java
@@ -21,8 +21,8 @@ public abstract class TaskInfoEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumns({
             @JoinColumn(name = "applicationId", referencedColumnName = "applicationId", insertable = false, updatable = false),
-            @JoinColumn(name = "processInstanceId", referencedColumnName = "instanceId", insertable = false, updatable = false) })
-    private ProcessInstanceEntity processInstance;
+            @JoinColumn(name = "workflowInstanceId", referencedColumnName = "instanceId", insertable = false, updatable = false) })
+    private WorkflowInstanceEntity workflowInstance;
 
     public TaskInfoEntity() {
     }

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/TaskInfoKey.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/TaskInfoKey.java
@@ -18,7 +18,7 @@ public class TaskInfoKey implements Serializable {
         TaskInfoKey key = new TaskInfoKey();
         key.jsonPointer = task.position().jsonPointer();
         key.applicationId = workflow.definition().application().id();
-        key.processInstanceId = workflow.instanceData().id();
+        key.workflowInstanceId = workflow.instanceData().id();
         key.iteration = task.iteration();
         return key;
     }
@@ -33,7 +33,7 @@ public class TaskInfoKey implements Serializable {
     private String applicationId;
 
     @Column
-    private String processInstanceId;
+    private String workflowInstanceId;
 
     public String getJsonPointer() {
         return jsonPointer;
@@ -51,12 +51,12 @@ public class TaskInfoKey implements Serializable {
         this.applicationId = applicationId;
     }
 
-    public String getProcessInstanceId() {
-        return processInstanceId;
+    public String getWorkflowInstanceId() {
+        return workflowInstanceId;
     }
 
-    public void setProcessInstanceId(String processInstanceId) {
-        this.processInstanceId = processInstanceId;
+    public void setWorkflowInstanceId(String workflowInstanceId) {
+        this.workflowInstanceId = workflowInstanceId;
     }
 
     public int getIteration() {
@@ -69,7 +69,7 @@ public class TaskInfoKey implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(applicationId, iteration, jsonPointer, processInstanceId);
+        return Objects.hash(applicationId, iteration, jsonPointer, workflowInstanceId);
     }
 
     @Override
@@ -83,6 +83,6 @@ public class TaskInfoKey implements Serializable {
         TaskInfoKey other = (TaskInfoKey) obj;
         return Objects.equals(applicationId, other.applicationId) && iteration == other.iteration
                 && Objects.equals(jsonPointer, other.jsonPointer)
-                && Objects.equals(processInstanceId, other.processInstanceId);
+                && Objects.equals(workflowInstanceId, other.workflowInstanceId);
     }
 }

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/WorkflowInstanceEntity.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/WorkflowInstanceEntity.java
@@ -20,8 +20,8 @@ import io.serverlessworkflow.impl.WorkflowStatus;
 
 @Entity
 @DynamicUpdate
-@IdClass(ProcessInstanceKey.class)
-public class ProcessInstanceEntity {
+@IdClass(WorkflowInstanceKey.class)
+public class WorkflowInstanceEntity {
 
     @Id
     private String instanceId;
@@ -47,13 +47,13 @@ public class ProcessInstanceEntity {
     @Basic(fetch = FetchType.LAZY)
     private WorkflowModel input;
 
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "processInstance")
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "workflowInstance")
     private Collection<TaskInfoEntity> tasks;
 
-    public ProcessInstanceEntity() {
+    public WorkflowInstanceEntity() {
     }
 
-    public ProcessInstanceEntity(String applicationId, WorkflowDefinitionId definitionId, String instanceId, Instant startedAt,
+    public WorkflowInstanceEntity(String applicationId, WorkflowDefinitionId definitionId, String instanceId, Instant startedAt,
             WorkflowModel input) {
         this.applicationId = applicationId;
         this.workflowNamespace = definitionId.namespace();

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/WorkflowInstanceKey.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/WorkflowInstanceKey.java
@@ -3,7 +3,7 @@ package io.quarkiverse.flow.persistence.jpa;
 import java.io.Serializable;
 import java.util.Objects;
 
-public class ProcessInstanceKey implements Serializable {
+public class WorkflowInstanceKey implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -11,10 +11,10 @@ public class ProcessInstanceKey implements Serializable {
 
     private String applicationId;
 
-    public ProcessInstanceKey() {
+    public WorkflowInstanceKey() {
     }
 
-    public ProcessInstanceKey(String instanceId, String applicationId) {
+    public WorkflowInstanceKey(String instanceId, String applicationId) {
         super();
         this.instanceId = instanceId;
         this.applicationId = applicationId;
@@ -33,7 +33,7 @@ public class ProcessInstanceKey implements Serializable {
             return false;
         if (getClass() != obj.getClass())
             return false;
-        ProcessInstanceKey other = (ProcessInstanceKey) obj;
+        WorkflowInstanceKey other = (WorkflowInstanceKey) obj;
         return Objects.equals(applicationId, other.applicationId) && Objects.equals(instanceId, other.instanceId);
     }
 }

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/WorkflowInstanceRepository.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/WorkflowInstanceRepository.java
@@ -5,6 +5,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 
 @ApplicationScoped
-public class ProcessInstanceRepository implements PanacheRepositoryBase<ProcessInstanceEntity, ProcessInstanceKey> {
+public class WorkflowInstanceRepository implements PanacheRepositoryBase<WorkflowInstanceEntity, WorkflowInstanceKey> {
 
 }


### PR DESCRIPTION
## Description

<!-- Provide a clear description of what this PR does -->

Fixes #707 

## Changes

Elimination of the "process" prefix in the JPA persistencer
- 
- 
- 

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
