### PR TITLE
Fix Dependabot: Remove /examples config to enforce LTS-only updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,18 +41,6 @@ updates:
           - "org.wiremock:*"
           - "org.mockito:*"
 
-  # Examples - allow all Quarkus updates (major/minor/patch)
-  - package-ecosystem: "maven"
-    directory: "/examples"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 3
-    groups:
-      quarkus:
-        patterns:
-          - "io.quarkus*"
-
   - package-ecosystem: "docker"
     directory: "/runner/app"
     schedule:


### PR DESCRIPTION
## Problem

PR #709 showed that Dependabot bypassed the LTS restrictions (3.33.x only) by updating to Quarkus 3.37.1 via the `/examples` configuration.

The issue: The `/examples` Maven config had **no ignore rules**, allowing it to update the root `pom.xml`'s `<quarkus.version>` property to any version, effectively bypassing the root config's LTS-only restriction.

## Solution

Remove the separate `/examples` Maven configuration. Since all examples inherit from the root pom via `<parent>`, they automatically follow the root's LTS policy without needing separate configuration.

## Result

- ✅ All Maven updates (root + examples) now respect the 3.33.x-only restriction
- ✅ Dependabot PR limit reduced from 8 to 5 (no separate examples config)
- ✅ Simpler configuration, less confusion

## Fixes

Prevents issues like #709 where Dependabot suggested updating to 3.37.1 despite the intended LTS-only policy.