### PR TITLE
[QUARKUS-8371] pin cloudevents to 4.1.1 across all modules

### DIFF
--- a/examples/agentic-http/pom.xml
+++ b/examples/agentic-http/pom.xml
@@ -24,6 +24,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.quarkiverse.flow</groupId>
+                <artifactId>quarkus-flow-bom</artifactId>
+                <version>${quarkus.flow.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${quarkus.platform.version}</version>

--- a/examples/durable-workflows-k8s/pom.xml
+++ b/examples/durable-workflows-k8s/pom.xml
@@ -24,6 +24,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.quarkiverse.flow</groupId>
+                <artifactId>quarkus-flow-bom</artifactId>
+                <version>${quarkus.flow.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${quarkus.platform.version}</version>

--- a/examples/greeting-runner/pom.xml
+++ b/examples/greeting-runner/pom.xml
@@ -26,6 +26,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.quarkiverse.flow</groupId>
+                <artifactId>quarkus-flow-bom</artifactId>
+                <version>${quarkus.flow.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${quarkus.platform.version}</version>

--- a/examples/http-basic-auth/pom.xml
+++ b/examples/http-basic-auth/pom.xml
@@ -27,6 +27,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.quarkiverse.flow</groupId>
+                <artifactId>quarkus-flow-bom</artifactId>
+                <version>${quarkus.flow.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${quarkus.platform.version}</version>

--- a/examples/langchain4j-agentic-workflow/pom.xml
+++ b/examples/langchain4j-agentic-workflow/pom.xml
@@ -25,6 +25,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.quarkiverse.flow</groupId>
+                <artifactId>quarkus-flow-bom</artifactId>
+                <version>${quarkus.flow.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${quarkus.platform.version}</version>

--- a/examples/micrometer-prometheus/pom.xml
+++ b/examples/micrometer-prometheus/pom.xml
@@ -22,6 +22,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.quarkiverse.flow</groupId>
+                <artifactId>quarkus-flow-bom</artifactId>
+                <version>${quarkus.flow.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${quarkus.platform.version}</version>

--- a/examples/newsletter-drafter/pom.xml
+++ b/examples/newsletter-drafter/pom.xml
@@ -28,6 +28,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.quarkiverse.flow</groupId>
+                <artifactId>quarkus-flow-bom</artifactId>
+                <version>${quarkus.flow.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${quarkus.platform.version}</version>

--- a/examples/order-fulfillment-compensation/pom.xml
+++ b/examples/order-fulfillment-compensation/pom.xml
@@ -22,6 +22,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.quarkiverse.flow</groupId>
+                <artifactId>quarkus-flow-bom</artifactId>
+                <version>${quarkus.flow.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${quarkus.platform.version}</version>

--- a/examples/petstore-openapi/pom.xml
+++ b/examples/petstore-openapi/pom.xml
@@ -29,6 +29,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.quarkiverse.flow</groupId>
+                <artifactId>quarkus-flow-bom</artifactId>
+                <version>${quarkus.flow.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${quarkus.platform.version}</version>

--- a/examples/resilient-task-orchestrator/pom.xml
+++ b/examples/resilient-task-orchestrator/pom.xml
@@ -27,6 +27,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.quarkiverse.flow</groupId>
+                <artifactId>quarkus-flow-bom</artifactId>
+                <version>${quarkus.flow.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${quarkus.platform.version}</version>

--- a/examples/suspend-resume-abort/pom.xml
+++ b/examples/suspend-resume-abort/pom.xml
@@ -22,6 +22,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.quarkiverse.flow</groupId>
+                <artifactId>quarkus-flow-bom</artifactId>
+                <version>${quarkus.flow.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${quarkus.platform.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
             </dependency>
             <dependency>
                 <groupId>io.cloudevents</groupId>
+                <artifactId>cloudevents-core</artifactId>
+                <version>${io.cloudevents.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.cloudevents</groupId>
                 <artifactId>cloudevents-json-jackson</artifactId>
                 <version>${io.cloudevents.version}</version>
             </dependency>


### PR DESCRIPTION
## Description

JIRA ticket: https://redhat.atlassian.net/browse/QUARKUS-8371

pin cloudevents to 4.1.1 across all modules

## Changes

- add cloudevents-core and cloudevents-json-jackson version pins to bom/pom.xml
- add cloudevents-core pin to root pom.xml (for core/messaging modules)
- import quarkus-flow-bom in all example modules so BOM pins take effect

## Testing

maven build including tests

### Test Plan

N/A

### Manual Testing

N/A

## Checklist

Before submitting this PR, please ensure:

- [x] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] n/a Code follows the project's code conventions
- [ ] n/a Tests have been added/updated to cover the changes
- [ ] n/a Documentation has been updated (if user-facing changes)
- [x] Commit messages are clear and follow conventional commits style
- [x] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

n/a
