### PR TITLE
Add best practices documentation for workflow development

### DIFF
--- a/docs/modules/ROOT/examples/org/acme/bestpractices/ApprovalService.java
+++ b/docs/modules/ROOT/examples/org/acme/bestpractices/ApprovalService.java
@@ -1,0 +1,30 @@
+package org.acme.bestpractices;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.serverlessworkflow.impl.WorkflowError;
+import io.serverlessworkflow.impl.WorkflowException;
+
+@ApplicationScoped
+public class ApprovalService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ApprovalService.class.getName());
+
+    public VacationRequest submit(VacationRequest vacationRequest) {
+        LOG.info("Submitting approval request");
+        return vacationRequest;
+    }
+
+    public VacationRequest requireApproval(VacationRequest vacationRequest) {
+        LOG.info("Approving request: {}", vacationRequest);
+        throw new WorkflowException(WorkflowError.error("APPROVAL_REJECTED", 422).build());
+    }
+
+    public Object notifyRejection(VacationRequest vacationRequest) {
+        LOG.info("Rejecting request");
+        return vacationRequest;
+    }
+}

--- a/docs/modules/ROOT/examples/org/acme/bestpractices/NotificationWorkflowBad.java
+++ b/docs/modules/ROOT/examples/org/acme/bestpractices/NotificationWorkflowBad.java
@@ -1,0 +1,25 @@
+package org.acme.bestpractices;
+
+import static io.quarkiverse.flow.dsl.FlowDSL.http;
+import static io.quarkiverse.flow.dsl.FlowWorkflowBuilder.workflow;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkiverse.flow.Flow;
+import io.serverlessworkflow.api.types.Workflow;
+
+@ApplicationScoped
+public class NotificationWorkflowBad extends Flow {
+
+    @Override
+    public Workflow descriptor() {
+        return workflow("notify")
+                .tasks(
+                        // NEVER hard-code tokens in the workflow definition
+                        http("callApi")
+                                .post()
+                                .endpoint("https://api.example.com/notify")
+                                .header("X-Api-Key", "my-api-key"))
+                .build();
+    }
+}

--- a/docs/modules/ROOT/examples/org/acme/bestpractices/NotificationWorkflowGood.java
+++ b/docs/modules/ROOT/examples/org/acme/bestpractices/NotificationWorkflowGood.java
@@ -1,0 +1,25 @@
+package org.acme.bestpractices;
+
+import static io.quarkiverse.flow.dsl.FlowDSL.http;
+import static io.quarkiverse.flow.dsl.FlowWorkflowBuilder.workflow;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkiverse.flow.Flow;
+import io.serverlessworkflow.api.types.Workflow;
+
+@ApplicationScoped
+public class NotificationWorkflowGood extends Flow {
+
+    @Override
+    public Workflow descriptor() {
+        return workflow("notify")
+                .use(u -> u.secrets("mySecrets"))
+                .tasks(
+                        http("callApi")
+                                .post()
+                                .endpoint("https://api.example.com/notify")
+                                .header("X-Api-Key", "${ $secret.mySecrets.apiKey }"))
+                .build();
+    }
+}

--- a/docs/modules/ROOT/examples/org/acme/bestpractices/Order.java
+++ b/docs/modules/ROOT/examples/org/acme/bestpractices/Order.java
@@ -1,0 +1,14 @@
+package org.acme.bestpractices;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+public class Order extends PanacheEntity {
+
+    public String product;
+    public int quantity;
+
+    public Order(String product, int quantity) {
+        this.product = product;
+        this.quantity = quantity;
+    }
+}

--- a/docs/modules/ROOT/examples/org/acme/bestpractices/OrderRequest.java
+++ b/docs/modules/ROOT/examples/org/acme/bestpractices/OrderRequest.java
@@ -1,0 +1,4 @@
+package org.acme.bestpractices;
+
+public record OrderRequest(String product, int quantity) {
+}

--- a/docs/modules/ROOT/examples/org/acme/bestpractices/OrderService.java
+++ b/docs/modules/ROOT/examples/org/acme/bestpractices/OrderService.java
@@ -1,0 +1,16 @@
+package org.acme.bestpractices;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+public class OrderService {
+
+    // tag::transactional-service[]
+    @Transactional
+    public Long placeOrder(Order order) {
+        order.persist();
+        return order.id;
+    }
+    // end::transactional-service[]
+}

--- a/docs/modules/ROOT/examples/org/acme/bestpractices/OrderWorkflowBad.java
+++ b/docs/modules/ROOT/examples/org/acme/bestpractices/OrderWorkflowBad.java
@@ -1,0 +1,40 @@
+package org.acme.bestpractices;
+
+// tag::bad[]
+import static io.quarkiverse.flow.dsl.FlowDSL.function;
+import static io.quarkiverse.flow.dsl.FlowDSL.listen;
+import static io.quarkiverse.flow.dsl.FlowDSL.toOne;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkiverse.flow.Flow;
+import io.quarkiverse.flow.dsl.FlowWorkflowBuilder;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.serverlessworkflow.api.types.Workflow;
+
+@ApplicationScoped
+public class OrderWorkflowBad extends Flow {
+
+    @Override
+    public Workflow descriptor() {
+        return FlowWorkflowBuilder.workflow("placeOrder")
+                .tasks(
+                        listen("waitOrder", toOne("order.submitted")),
+                        function("placeOrder", (OrderRequest request) -> {
+                            // WARNING: This will fail with "context not active" if the
+                            // workflow runs after the original HTTP request has completed.
+                            QuarkusTransaction.begin();
+                            try {
+                                Order order = new Order(request.product(), request.quantity());
+                                order.persist();
+                                QuarkusTransaction.commit();
+                                return order.id;
+                            } catch (Exception e) {
+                                QuarkusTransaction.rollback();
+                                throw e;
+                            }
+                        }, OrderRequest.class))
+                .build();
+    }
+}
+// end::bad[]

--- a/docs/modules/ROOT/examples/org/acme/bestpractices/OrderWorkflowGood.java
+++ b/docs/modules/ROOT/examples/org/acme/bestpractices/OrderWorkflowGood.java
@@ -1,0 +1,31 @@
+package org.acme.bestpractices;
+
+// tag::good[]
+import static io.quarkiverse.flow.dsl.FlowDSL.function;
+import static io.quarkiverse.flow.dsl.FlowDSL.listen;
+import static io.quarkiverse.flow.dsl.FlowDSL.toOne;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkiverse.flow.Flow;
+import io.quarkiverse.flow.dsl.FlowWorkflowBuilder;
+import io.serverlessworkflow.api.types.Workflow;
+
+@ApplicationScoped
+public class OrderWorkflowGood extends Flow {
+
+    @Inject
+    OrderService orderService;
+
+    @Override
+    public Workflow descriptor() {
+        return FlowWorkflowBuilder.workflow("placeOrder")
+                .tasks(
+                        listen("waitOrder", toOne("order.submitted")),
+                        function("placeOrder", orderService::placeOrder, Order.class)
+                                .outputAs((Long id) -> id))
+                .build();
+    }
+}
+// end::good[]

--- a/docs/modules/ROOT/examples/org/acme/bestpractices/VacationApproveWorkflow.java
+++ b/docs/modules/ROOT/examples/org/acme/bestpractices/VacationApproveWorkflow.java
@@ -1,0 +1,39 @@
+package org.acme.bestpractices;
+
+import static io.quarkiverse.flow.dsl.FlowDSL.function;
+import static io.quarkiverse.flow.dsl.FlowDSL.tasks;
+import static io.quarkiverse.flow.dsl.FlowDSL.tryCatch;
+import static io.quarkiverse.flow.dsl.FlowWorkflowBuilder.workflow;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkiverse.flow.Flow;
+import io.serverlessworkflow.api.types.Workflow;
+
+@ApplicationScoped
+public class VacationApproveWorkflow extends Flow {
+
+    @Inject
+    ApprovalService approvalService;
+
+    @Override
+    public Workflow descriptor() {
+        return workflow("vacation-approval")
+                .tasks(
+                        tryCatch(
+                                "tryApproval",
+                                t -> t.tryCatch(tasks(
+                                        function("submitRequest", approvalService::submit),
+                                        function("checkApproval", approvalService::requireApproval)))
+                                        .catchHandler(handler -> handler
+                                                .errorsWith(err -> err.type("APPROVAL_REJECTED"))
+                                                .retry(r -> r
+                                                        .limit(limit -> limit.attempt(a -> a.count(3)))
+                                                        .delay("PT1H"))
+                                                .doTasks(tasks(
+                                                        function("notifyRejection", approvalService::notifyRejection,
+                                                                VacationRequest.class))))))
+                .build();
+    }
+}

--- a/docs/modules/ROOT/examples/org/acme/bestpractices/VacationRequest.java
+++ b/docs/modules/ROOT/examples/org/acme/bestpractices/VacationRequest.java
@@ -1,0 +1,6 @@
+package org.acme.bestpractices;
+
+import java.time.LocalDate;
+
+public record VacationRequest(String employeeId, LocalDate from, LocalDate to) {
+}

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -37,6 +37,7 @@
 *** xref:custom-listeners.adoc[Listen to workflow events]
 ** Testing
 *** xref:test-debug.adoc[Test and debug workflows]
+** xref:best-practices.adoc[Best practices]
 
 * Architecture & Concepts
 ** xref:concepts-architecture.adoc[Engine Architecture]

--- a/docs/modules/ROOT/pages/best-practices.adoc
+++ b/docs/modules/ROOT/pages/best-practices.adoc
@@ -1,0 +1,175 @@
+= Best practices
+:page-role: howto
+include::includes/attributes.adoc[]
+
+This guide collects practical recommendations that help you avoid common pitfalls when building workflows with Quarkus Flow.
+
+== 1. Persist data with `@Transactional`
+
+Workflow tasks can execute **after the original HTTP request has completed**.
+When that happens, the request-scoped CDI context is no longer active, and any attempt to manage transactions manually with `QuarkusTransaction.begin()` will fail with a _context not active_ exception.
+
+The safe approach is to delegate persistence to a CDI bean whose method is annotated with `@Transactional`.
+The CDI proxy activates the transaction context automatically, regardless of when the workflow task runs.
+
+=== What to avoid
+
+[source,java]
+----
+include::{examples-dir}org/acme/bestpractices/OrderWorkflowBad.java[tag=bad]
+----
+
+=== Recommended approach
+
+Create a bean with a `@Transactional` method and call it from the workflow task:
+
+[source,java]
+----
+include::{examples-dir}org/acme/bestpractices/OrderService.java[tag=transactional-service]
+----
+
+[source,java]
+----
+include::{examples-dir}org/acme/bestpractices/OrderWorkflowGood.java[tag=good]
+----
+
+[TIP]
+====
+This pattern applies to any side-effect that depends on a CDI context scope: JPA operations, messaging producers, audit logging, and so on.
+If the operation touches the database, put it behind `@Transactional`.
+====
+
+== 2. Never hard-code secrets
+
+Workflow beans are **discovered and wired at build time**.
+Hard-coding credentials directly in a workflow definition means they are embedded in the compiled output and visible to anyone with access to the artifact.
+
+Always reference secrets by handle using `${ $secret.<handle>.<key> }` expressions.
+At runtime, Quarkus Flow resolves the handle through the `CredentialsProvider` SPI or, in dev/test, from `application.properties`.
+
+=== What to avoid
+
+[source,java]
+----
+include::{examples-dir}org/acme/bestpractices/NotificationWorkflowBad.java[]
+----
+
+=== Recommended approach
+
+Declare the secret handle and reference it via the authentication configurer or a `$secret` expression:
+
+[source,java]
+----
+include::{examples-dir}org/acme/bestpractices/NotificationWorkflowGood.java[]
+----
+
+In dev/test, provide the value in `application.properties`:
+
+[source,properties]
+----
+mySecrets.apiKey=my-api-key
+----
+
+In production, configure a `CredentialsProvider` (e.g., HashiCorp Vault, https://quarkus.io/guides/kubernetes-config[Kubernetes]) so that secret values are never stored in plain text.
+
+[TIP]
+====
+For a complete walkthrough of declaring, resolving, and testing secrets, see xref:secrets.adoc[Resolve secrets securely].
+====
+
+== 3. Name your tasks
+
+When a task does not have an explicit name,
+the Serverless Workflow SDK assigns a default task name automatically based in the type and the order of the task.
+
+That generated task name then appears in **every** observability signal: logs, metrics, and traces.
+
+Debugging a production incident becomes much harder when your dashboard shows `task="http-0"` instead of `task="fetchCustomerProfile"`.
+
+=== What to avoid
+
+[source,java]
+----
+return workflow("order-flow")
+        .tasks(
+                // No task names — the SDK generates
+                function(orderService::validate, OrderRequest.class),
+                function(paymentService::charge, PaymentRequest.class),
+                function(notificationService::send, NotificationRequest.class))
+        .build();
+----
+
+=== Recommended approach
+
+Always provide a descriptive, unique name for each task:
+
+[source,java]
+----
+return workflow("order-flow")
+        .tasks(
+                function("validateOrder", orderService::validate, OrderRequest.class),
+                function("chargePayment", paymentService::charge, PaymentRequest.class),
+                function("sendConfirmation", notificationService::send, NotificationRequest.class))
+        .build();
+----
+
+[NOTE]
+====
+The combination of workflow name and task name is used as metric label (e.g., `quarkus_flow_task_duration_seconds{workflow="order-flow",task="chargePayment"}`).
+Unique, descriptive names improve filtering, aggregation, and dashboard visualization.
+
+For the full list of metrics and how task names affect them, see xref:metrics-prometheus.adoc[Observability with Prometheus and Micrometer].
+====
+
+== 4. Separate business retries from infrastructure retries
+
+Quarkus Flow supports retries at two distinct levels. Mixing them up leads to workflows that either mask infrastructure failures or bury business logic in configuration files.
+
+=== Infrastructure retries (configuration)
+
+Network timeouts, HTTP 503 responses, and rate-limit errors are **infrastructure concerns**.
+Handle them with SmallRye Fault Tolerance configuration properties — the engine retries transparently, without changing your workflow logic:
+
+[source,properties]
+----
+quarkus.flow.http.client.resilience.retry.max-retries=3
+quarkus.flow.http.client.resilience.retry.delay=0
+quarkus.flow.http.client.resilience.retry.jitter=200ms
+----
+
+For details, see xref:fault-tolerance.adoc[Fault tolerance and resilience].
+
+=== Business retries (workflow DSL)
+
+A manager who has not yet approved a vacation request is a **business concern**, not a transient failure.
+Model this kind of retry as part of the workflow definition itself using the `tryCatch` construct with a `retry` policy:
+
+[source,java]
+----
+include::{examples-dir}org/acme/bestpractices/VacationApproveWorkflow.java[]
+----
+
+The `retry` policy on the catch handler tells the engine to re-execute the try block up to 3 times, with a 1-hour delay between attempts.
+This makes the business rule (re-submit if rejected) visible in the workflow definition, not hidden in configuration files.
+
+=== Rule of thumb
+
+[cols="1,1,1"]
+|===
+| Concern | Where it lives | Example
+
+| Transient network failures
+| `application.properties` (Fault Tolerance)
+| HTTP 503, connection timeout, rate limit
+
+| Business process conditions
+| Workflow DSL (`tryCatch` with `retry`)
+| Manager rejection, pending approval, missing document
+|===
+
+== See also
+* xref:secrets.adoc[Resolve secrets securely] — declaring and resolving secrets.
+* xref:metrics-prometheus.adoc[Observability with Prometheus and Micrometer] — how task names affect metrics.
+* xref:fault-tolerance.adoc[Fault tolerance and resilience] — infrastructure retries and circuit breakers.
+* xref:http-client.adoc[Configure the HTTP client] — per-client resilience tuning.
+* xref:dsl-cheatsheet.adoc[Java DSL cheatsheet] — complete list of task providers and naming patterns.

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -90,6 +90,14 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-messaging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-narayana-jta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
## Description

Covers four common pitfalls: using `@Transactional` for persistence instead of manual QuarkusTransaction, referencing secrets via handles instead of hard-coding credentials, naming tasks explicitly for observability, and separating business retries (tryCatch with retry) from infrastructure retries (Fault Tolerance config properties).

Fixes #723 

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
