### PR TITLE
docs: add experimental warning for proxy support

### DIFF
--- a/docs/modules/ROOT/pages/http-client.adoc
+++ b/docs/modules/ROOT/pages/http-client.adoc
@@ -124,6 +124,11 @@ quarkus.flow.http.client.alpn=true
 
 == 8. Proxy support
 
+[WARNING]
+====
+HTTP proxy support relies on `quarkus-proxy-registry`, which is currently *experimental*. This feature is not recommended for production environments as the API may change in future Quarkus versions.
+====
+
 Quarkus Flow integrates with the link:https://quarkus.io/guides/proxy-registry[Quarkus Proxy Registry].
 
 [source,properties]


### PR DESCRIPTION
## Summary

Adds warning that `quarkus-proxy-registry` is experimental and not recommended for production environments.

## Changes

- Added WARNING admonition to section 8 (Proxy support) in `http-client.adoc`
- Warning appears immediately when users read about proxy configuration

## Preview

```adoc
[WARNING]
====
HTTP proxy support relies on `quarkus-proxy-registry`, which is currently *experimental*. This feature is not recommended for production environments as the API may change in future Quarkus versions.
====
```

Fixes #725