### PR TITLE
Add bouncycastle dependency to durable kubernetes integration tests t…

### DIFF
--- a/durable-kubernetes/integration-tests/pom.xml
+++ b/durable-kubernetes/integration-tests/pom.xml
@@ -24,6 +24,12 @@
             <artifactId>quarkus-flow-durable-kubernetes</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Added after Fabric8 upgrade to 7.6.0+ that uses Netty self-signed certificate to warmup TLS on Kubernetes testing -->
+        <!-- Native image would fail if this dependency was not there -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit</artifactId>


### PR DESCRIPTION
…o fix native build problems on fabric8 7.6.x

## Description

- Fabric8 has removed the Bouncy Castle dependency on the 7.x branch release;
- Fabric8 has added a "warm up TLS" feature on 7.6.x, which makes [Netty fall back to Bouncy Castle to generate self-signed certificates](https://netty.io/4.1/api/io/netty/handler/ssl/util/SelfSignedCertificate.html). Since we don't have Bouncy Castle in the classpath any longer, it fails on native [1];
- Current Quarkus SNAPSHOT upgraded to Fabric8 from 7.5.2, which we currently depend on Quarkus 3.33.

[1] 
```logs
Caused by: com.oracle.graal.pointsto.constraints.UnresolvedElementException: Error loading a referenced type: java.lang.NoClassDefFoundError: org/bouncycastle/cert/X509v3CertificateBuilder
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.infrastructure.WrappedConstantPool.loadReferencedType(WrappedConstantPool.java:98)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.infrastructure.WrappedConstantPool.loadReferencedType(WrappedConstantPool.java:104)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SubstrateClassInitializationPlugin.loadReferencedType(SubstrateClassInitializationPlugin.java:58)
	at jdk.graal.compiler/jdk.graal.compiler.java.BytecodeParser.loadReferenceType(BytecodeParser.java:4831)
	at jdk.graal.compiler/jdk.graal.compiler.java.BytecodeParser.maybeEagerlyResolve(BytecodeParser.java:4813)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.maybeEagerlyResolve(SharedGraphBuilderPhase.java:620)
	at jdk.graal.compiler/jdk.graal.compiler.java.BytecodeParser.lookupMethod(BytecodeParser.java:4749)
	at jdk.graal.compiler/jdk.graal.compiler.java.BytecodeParser.genInvokeStatic(BytecodeParser.java:1871)
	... 52 more
Caused by: java.lang.NoClassDefFoundError: org/bouncycastle/cert/X509v3CertificateBuilder
	at jdk.internal.vm.ci/jdk.vm.ci.hotspot.CompilerToVM.resolveTypeInPool(Native Method)
	at jdk.internal.vm.ci/jdk.vm.ci.hotspot.CompilerToVM.resolveTypeInPool(CompilerToVM.java:573)
	at jdk.internal.vm.ci/jdk.vm.ci.hotspot.HotSpotConstantPool.loadReferencedType(HotSpotConstantPool.java:936)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.infrastructure.WrappedConstantPool.loadReferencedType(WrappedConstantPool.java:90)
	... 59 more
Caused by: java.lang.ClassNotFoundException: org.bouncycastle.cert.X509v3CertificateBuilder
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:580)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageClassLoader.loadClass(NativeImageClassLoader.java:637)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
	... 63 more
```

## Changes

<!-- List the main changes in this PR -->

- Added Bouncy Castle as a dependency on Durable Kubernetes `integration-tests`. We took the same approach as Quarkus Kubernetes Client ITs.

https://github.com/quarkusio/quarkus/blob/94816e3e9afb635ac6e7fd101fb2fe0f544a740d/integration-tests/kubernetes-client/pom.xml#L43-L46

## Testing

- Run full tests locally
