### PR TITLE
Fix #728 add ParallelMapperAgent, SupervisorAgent, PlannerAgent, McpClientAgent support

### DIFF
--- a/langchain4j/deployment/src/main/java/io/quarkiverse/flow/langchain4j/deployment/GizmoAgentFlowsHelper.java
+++ b/langchain4j/deployment/src/main/java/io/quarkiverse/flow/langchain4j/deployment/GizmoAgentFlowsHelper.java
@@ -124,7 +124,9 @@ final class GizmoAgentFlowsHelper {
 
         throw new IllegalStateException(
                 "No agent method found in " + subAgentType.name() +
-                        ". Expected a method annotated with one of: @Agent, @SequenceAgent, @ParallelAgent, @LoopAgent, @ConditionalAgent or @A2AClientAgent. "
+                        ". Expected a method annotated with one of: @Agent, @SequenceAgent, @ParallelAgent, @ParallelMapperAgent, "
+                        +
+                        "@LoopAgent, @ConditionalAgent, @SupervisorAgent, @PlannerAgent, @A2AClientAgent, or @McpClientAgent. "
                         +
                         "Verify the class has the correct LangChain4j annotations.");
     }

--- a/langchain4j/deployment/src/main/java/io/quarkiverse/flow/langchain4j/deployment/Lc4jAnnotations.java
+++ b/langchain4j/deployment/src/main/java/io/quarkiverse/flow/langchain4j/deployment/Lc4jAnnotations.java
@@ -6,8 +6,12 @@ import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.declarative.A2AClientAgent;
 import dev.langchain4j.agentic.declarative.ConditionalAgent;
 import dev.langchain4j.agentic.declarative.LoopAgent;
+import dev.langchain4j.agentic.declarative.McpClientAgent;
 import dev.langchain4j.agentic.declarative.ParallelAgent;
+import dev.langchain4j.agentic.declarative.ParallelMapperAgent;
+import dev.langchain4j.agentic.declarative.PlannerAgent;
 import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.agentic.declarative.SupervisorAgent;
 
 /**
  * LangChain4j annotation DotNames used during Jandex scanning.
@@ -24,9 +28,13 @@ final class Lc4jAnnotations {
     static final DotName AGENT = DotName.createSimple(Agent.class.getName());
     static final DotName SEQUENCE_AGENT = DotName.createSimple(SequenceAgent.class.getName());
     static final DotName PARALLEL_AGENT = DotName.createSimple(ParallelAgent.class.getName());
+    static final DotName PARALLEL_MAPPER_AGENT = DotName.createSimple(ParallelMapperAgent.class.getName());
     static final DotName LOOP_AGENT = DotName.createSimple(LoopAgent.class.getName());
     static final DotName CONDITIONAL_AGENT = DotName.createSimple(ConditionalAgent.class.getName());
+    static final DotName SUPERVISOR_AGENT = DotName.createSimple(SupervisorAgent.class.getName());
+    static final DotName PLANNER_AGENT = DotName.createSimple(PlannerAgent.class.getName());
     static final DotName A2A_AGENT = DotName.createSimple(A2AClientAgent.class.getName());
+    static final DotName MCP_AGENT = DotName.createSimple(McpClientAgent.class.getName());
 
     /**
      * All agent annotations for iteration.
@@ -36,8 +44,12 @@ final class Lc4jAnnotations {
             AGENT,
             SEQUENCE_AGENT,
             PARALLEL_AGENT,
+            PARALLEL_MAPPER_AGENT,
             LOOP_AGENT,
             CONDITIONAL_AGENT,
-            A2A_AGENT
+            SUPERVISOR_AGENT,
+            PLANNER_AGENT,
+            A2A_AGENT,
+            MCP_AGENT
     };
 }

--- a/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/FlowLangChain4jProcessorTest.java
+++ b/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/FlowLangChain4jProcessorTest.java
@@ -107,4 +107,73 @@ public class FlowLangChain4jProcessorTest {
         assertNotNull(wf.getDocument(), "Workflow document should not be null");
     }
 
+    @Test
+    void shouldRegisterWorkflowForSequenceAgentWithParallelMapper() {
+        WorkflowDefinitionId expectedId = WorkflowNameUtils.newId(Agents.SequenceWithParallelMapperAgent.class);
+
+        WorkflowApplication app = Arc.container().instance(WorkflowApplication.class).get();
+
+        WorkflowDefinition definition = app.workflowDefinitions().get(expectedId);
+        assertNotNull(definition, "Expected workflow definition to be registered for SequenceWithParallelMapperAgent");
+
+        Workflow wf = definition.workflow();
+
+        // Verify the basic identity matches what the generated Flow set
+        assertEquals(expectedId.name(), wf.getDocument().getName(), "Workflow name should match WorkflowNameUtils");
+        assertEquals(expectedId.namespace(), wf.getDocument().getNamespace(),
+                "Workflow namespace should match WorkflowNameUtils");
+        assertEquals(expectedId.version(), wf.getDocument().getVersion(),
+                "Workflow version should match WorkflowNameUtils");
+
+        // KEY VALIDATION: The workflow was successfully generated and registered.
+        // This proves that @ParallelMapperAgent annotation was recognized during build-time processing.
+        assertNotNull(wf.getDocument(), "Workflow document should not be null");
+    }
+
+    @Test
+    void shouldRegisterWorkflowForSequenceAgentWithSupervisor() {
+        WorkflowDefinitionId expectedId = WorkflowNameUtils.newId(Agents.SequenceWithSupervisorAgent.class);
+
+        WorkflowApplication app = Arc.container().instance(WorkflowApplication.class).get();
+
+        WorkflowDefinition definition = app.workflowDefinitions().get(expectedId);
+        assertNotNull(definition, "Expected workflow definition to be registered for SequenceWithSupervisorAgent");
+
+        Workflow wf = definition.workflow();
+
+        // Verify the basic identity matches what the generated Flow set
+        assertEquals(expectedId.name(), wf.getDocument().getName(), "Workflow name should match WorkflowNameUtils");
+        assertEquals(expectedId.namespace(), wf.getDocument().getNamespace(),
+                "Workflow namespace should match WorkflowNameUtils");
+        assertEquals(expectedId.version(), wf.getDocument().getVersion(),
+                "Workflow version should match WorkflowNameUtils");
+
+        // KEY VALIDATION: The workflow was successfully generated and registered.
+        // This proves that @SupervisorAgent annotation was recognized during build-time processing.
+        assertNotNull(wf.getDocument(), "Workflow document should not be null");
+    }
+
+    @Test
+    void shouldRegisterWorkflowForSequenceAgentWithPlanner() {
+        WorkflowDefinitionId expectedId = WorkflowNameUtils.newId(Agents.SequenceWithPlannerAgent.class);
+
+        WorkflowApplication app = Arc.container().instance(WorkflowApplication.class).get();
+
+        WorkflowDefinition definition = app.workflowDefinitions().get(expectedId);
+        assertNotNull(definition, "Expected workflow definition to be registered for SequenceWithPlannerAgent");
+
+        Workflow wf = definition.workflow();
+
+        // Verify the basic identity matches what the generated Flow set
+        assertEquals(expectedId.name(), wf.getDocument().getName(), "Workflow name should match WorkflowNameUtils");
+        assertEquals(expectedId.namespace(), wf.getDocument().getNamespace(),
+                "Workflow namespace should match WorkflowNameUtils");
+        assertEquals(expectedId.version(), wf.getDocument().getVersion(),
+                "Workflow version should match WorkflowNameUtils");
+
+        // KEY VALIDATION: The workflow was successfully generated and registered.
+        // This proves that @PlannerAgent annotation was recognized during build-time processing.
+        assertNotNull(wf.getDocument(), "Workflow document should not be null");
+    }
+
 }

--- a/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/GizmoAgentFlowsHelperTest.java
+++ b/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/GizmoAgentFlowsHelperTest.java
@@ -22,8 +22,12 @@ import org.junit.jupiter.api.Test;
 
 import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.declarative.A2AClientAgent;
+import dev.langchain4j.agentic.declarative.McpClientAgent;
 import dev.langchain4j.agentic.declarative.ParallelAgent;
+import dev.langchain4j.agentic.declarative.ParallelMapperAgent;
+import dev.langchain4j.agentic.declarative.PlannerAgent;
 import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.agentic.declarative.SupervisorAgent;
 import dev.langchain4j.agentic.scope.AgenticScope;
 import io.quarkiverse.flow.Flow;
 import io.quarkiverse.flow.langchain4j.workflow.flow.AgenticFlow;
@@ -164,8 +168,11 @@ class GizmoAgentFlowsHelperTest {
 
         assertThatThrownBy(() -> computeTaskNames(index, subAgents)).isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("No agent method found").hasMessageContaining("ClassWithoutAgentAnnotation")
-                .hasMessageContaining(
-                        "@Agent, @SequenceAgent, @ParallelAgent, @LoopAgent, @ConditionalAgent or @A2AClientAgent");
+                .hasMessageContaining("@Agent").hasMessageContaining("@SequenceAgent")
+                .hasMessageContaining("@ParallelAgent").hasMessageContaining("@ParallelMapperAgent")
+                .hasMessageContaining("@LoopAgent").hasMessageContaining("@ConditionalAgent")
+                .hasMessageContaining("@SupervisorAgent").hasMessageContaining("@PlannerAgent")
+                .hasMessageContaining("@A2AClientAgent").hasMessageContaining("@McpClientAgent");
     }
 
     @Test
@@ -199,6 +206,51 @@ class GizmoAgentFlowsHelperTest {
         List<String> taskNames = computeTaskNames(index, subAgents);
 
         assertThat(taskNames).hasSize(1).containsExactly("callRemoteAgent");
+    }
+
+    @Test
+    @DisplayName("computeTaskNames should find methods with @ParallelMapperAgent annotation")
+    void test_computeTaskNames_parallelMapperAgent() throws IOException {
+        Index index = buildIndex(TestParallelMapperAgent.class);
+        List<Type> subAgents = List.of(
+                Type.create(DotName.createSimple(TestParallelMapperAgent.class.getName()), Type.Kind.CLASS));
+
+        List<String> taskNames = computeTaskNames(index, subAgents);
+
+        assertThat(taskNames).hasSize(1).containsExactly("processItems");
+    }
+
+    @Test
+    @DisplayName("computeTaskNames should find methods with @SupervisorAgent annotation")
+    void test_computeTaskNames_supervisorAgent() throws IOException {
+        Index index = buildIndex(TestSupervisorAgent.class);
+        List<Type> subAgents = List.of(Type.create(DotName.createSimple(TestSupervisorAgent.class.getName()), Type.Kind.CLASS));
+
+        List<String> taskNames = computeTaskNames(index, subAgents);
+
+        assertThat(taskNames).hasSize(1).containsExactly("orchestrate");
+    }
+
+    @Test
+    @DisplayName("computeTaskNames should find methods with @PlannerAgent annotation")
+    void test_computeTaskNames_plannerAgent() throws IOException {
+        Index index = buildIndex(TestPlannerAgent.class);
+        List<Type> subAgents = List.of(Type.create(DotName.createSimple(TestPlannerAgent.class.getName()), Type.Kind.CLASS));
+
+        List<String> taskNames = computeTaskNames(index, subAgents);
+
+        assertThat(taskNames).hasSize(1).containsExactly("plan");
+    }
+
+    @Test
+    @DisplayName("computeTaskNames should find methods with @McpClientAgent annotation")
+    void test_computeTaskNames_mcpClientAgent() throws IOException {
+        Index index = buildIndex(TestMcpClientAgent.class);
+        List<Type> subAgents = List.of(Type.create(DotName.createSimple(TestMcpClientAgent.class.getName()), Type.Kind.CLASS));
+
+        List<String> taskNames = computeTaskNames(index, subAgents);
+
+        assertThat(taskNames).hasSize(1).containsExactly("callMcpServer");
     }
 
     // ========== Helper Methods ==========
@@ -277,5 +329,37 @@ class GizmoAgentFlowsHelperTest {
     public interface TestA2AClientAgent {
         @A2AClientAgent(a2aServerUrl = "http://localhost:8080", outputKey = "result")
         String callRemoteAgent(String request);
+    }
+
+    /**
+     * Test agent with @ParallelMapperAgent annotation
+     */
+    public interface TestParallelMapperAgent {
+        @ParallelMapperAgent(subAgent = TestAgent1.class)
+        List<String> processItems(List<String> items);
+    }
+
+    /**
+     * Test agent with @SupervisorAgent annotation
+     */
+    public interface TestSupervisorAgent {
+        @SupervisorAgent(subAgents = { TestAgent1.class, TestAgent2.class })
+        String orchestrate(String request);
+    }
+
+    /**
+     * Test agent with @PlannerAgent annotation
+     */
+    public interface TestPlannerAgent {
+        @PlannerAgent(outputKey = "result", subAgents = { TestAgent1.class, TestAgent2.class })
+        String plan(String input);
+    }
+
+    /**
+     * Test agent with @McpClientAgent annotation
+     */
+    public interface TestMcpClientAgent {
+        @McpClientAgent(outputKey = "result")
+        String callMcpServer(String request);
     }
 }

--- a/langchain4j/runtime/src/test/java/io/quarkiverse/flow/langchain4j/Agents.java
+++ b/langchain4j/runtime/src/test/java/io/quarkiverse/flow/langchain4j/Agents.java
@@ -1,8 +1,13 @@
 package io.quarkiverse.flow.langchain4j;
 
+import java.util.List;
+
 import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.declarative.A2AClientAgent;
+import dev.langchain4j.agentic.declarative.ParallelMapperAgent;
+import dev.langchain4j.agentic.declarative.PlannerAgent;
 import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.agentic.declarative.SupervisorAgent;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 import io.quarkiverse.langchain4j.RegisterAiService;
@@ -93,5 +98,73 @@ public class Agents {
                 """)
         @Agent(description = "Process the fetched data locally", outputKey = "finalResult")
         String process(@V("remoteData") String data);
+    }
+
+    // ParallelMapperAgent test
+    @RegisterAiService
+    public interface SequenceWithParallelMapperAgent {
+        @SequenceAgent(outputKey = "results", subAgents = {
+                ItemsGenerator.class, ItemsMapper.class
+        })
+        List<String> processItems(@V("request") String request);
+    }
+
+    public interface ItemsGenerator {
+        @UserMessage("""
+                Generate a list of items based on: {{request}}
+                Return a comma-separated list.
+                """)
+        @Agent(description = "Generate items to process", outputKey = "items")
+        List<String> generateItems(@V("request") String request);
+    }
+
+    public interface ItemsMapper {
+        @ParallelMapperAgent(subAgent = ItemProcessor.class, outputKey = "results")
+        List<String> mapItems(@V("items") List<String> items);
+    }
+
+    public interface ItemProcessor {
+        @UserMessage("""
+                Process this item: {{item}}
+                Return the processed result.
+                """)
+        @Agent(description = "Process a single item", outputKey = "result")
+        String processItem(@V("item") String item);
+    }
+
+    // SupervisorAgent test
+    @RegisterAiService
+    public interface SequenceWithSupervisorAgent {
+        @SequenceAgent(outputKey = "finalResult", subAgents = {
+                TaskSupervisor.class
+        })
+        String superviseTasks(@V("request") String request);
+    }
+
+    public interface TaskSupervisor {
+        @UserMessage("""
+                You are a supervisor coordinating multiple agents.
+                Request: {{request}}
+                """)
+        @SupervisorAgent(subAgents = { CreativeWriter.class, AudienceEditor.class }, outputKey = "supervisorResult")
+        String supervise(@V("request") String request);
+    }
+
+    // PlannerAgent test
+    @RegisterAiService
+    public interface SequenceWithPlannerAgent {
+        @SequenceAgent(outputKey = "finalResult", subAgents = {
+                TaskPlanner.class
+        })
+        String planTasks(@V("request") String request);
+    }
+
+    public interface TaskPlanner {
+        @UserMessage("""
+                You are a planner creating execution plans.
+                Request: {{request}}
+                """)
+        @PlannerAgent(outputKey = "plan", subAgents = { CreativeWriter.class, StyleEditor.class })
+        String plan(@V("request") String request);
     }
 }


### PR DESCRIPTION
Fixes #728 

Since Quarkus LC4J doesn't support `McpClientAgent` yet, users using this annotation might face compatibility problems.