### PR TITLE
[Fix_#739] Durable Kubernetes readiness config property is reported as unrecognized

### DIFF
--- a/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/LeaseAcquisitionHealthCheck.java
+++ b/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/LeaseAcquisitionHealthCheck.java
@@ -3,12 +3,12 @@ package io.quarkiverse.flow.durable.kube;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 import org.eclipse.microprofile.health.Readiness;
 
+import io.quarkiverse.flow.durable.kube.config.FlowDurableKubeConfig;
 import io.quarkiverse.flow.durable.kube.config.LeaseGroupConfig;
 import io.quarkiverse.flow.durable.kube.config.PoolConfig;
 
@@ -33,12 +33,14 @@ public class LeaseAcquisitionHealthCheck implements HealthCheck {
     @Inject
     LocalStrategy localStrategy;
 
-    @ConfigProperty(name = "quarkus.flow.durable.kube.health.readiness.require-lease", defaultValue = "true")
-    boolean requireLease;
+    @Inject
+    FlowDurableKubeConfig durableKubeConfig;
 
     @Override
     public HealthCheckResponse call() {
         boolean enabled = leaseConfig.member().enabled() && !localStrategy.enabled();
+        boolean requireLease = durableKubeConfig.health().readiness().requireLease();
+
         String lease = memberLeaseCoordinator.currentLeaseOrNull();
 
         HealthCheckResponseBuilder b = HealthCheckResponse.named(NAME)

--- a/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/config/FlowDurableKubeConfig.java
+++ b/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/config/FlowDurableKubeConfig.java
@@ -10,8 +10,12 @@ import io.smallrye.config.WithDefault;
 @ConfigMapping(prefix = "quarkus.flow.durable.kube")
 public interface FlowDurableKubeConfig {
 
+    Health health();
+
     @ConfigGroup
     interface Health {
+
+        Readiness readiness();
 
         @ConfigGroup
         interface Readiness {


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-flow/issues/739