### PR TITLE
Add JacksonSerializers from SDK to native processors

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowNativeProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowNativeProcessor.java
@@ -50,7 +50,7 @@ final class FlowNativeProcessor {
 
     @BuildStep
     void registerSerializableFunctions(CombinedIndexBuildItem indexedClasses,
-                                       BuildProducer<LambdaCapturingTypeBuildItem> producer) {
+            BuildProducer<LambdaCapturingTypeBuildItem> producer) {
         indexedClasses.getIndex().getAllKnownImplementations(Flowable.class).stream().map(ClassInfo::toString)
                 .map(LambdaCapturingTypeBuildItem::new).forEach(producer::produce);
     }
@@ -58,12 +58,12 @@ final class FlowNativeProcessor {
     @BuildStep
     ReflectiveClassBuildItem registerForReflection() {
         return ReflectiveClassBuildItem.builder(
-                        "org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator",
-                        "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator",
-                        // Jackson serializers for WorkflowModel - needed when WorkflowModel is returned directly from REST endpoint
-                        "io.serverlessworkflow.impl.model.jackson.JacksonModel",
-                        "io.serverlessworkflow.impl.model.jackson.JacksonModelSerializer",
-                        "io.serverlessworkflow.impl.model.jackson.JacksonModelDeserializer")
+                "org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator",
+                "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator",
+                // Jackson serializers for WorkflowModel - needed when WorkflowModel is returned directly from REST endpoint
+                "io.serverlessworkflow.impl.model.jackson.JacksonModel",
+                "io.serverlessworkflow.impl.model.jackson.JacksonModelSerializer",
+                "io.serverlessworkflow.impl.model.jackson.JacksonModelDeserializer")
                 .constructors(true)
                 .methods(true)
                 .fields(true)

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowNativeProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowNativeProcessor.java
@@ -61,7 +61,6 @@ final class FlowNativeProcessor {
                 "org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator",
                 "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator",
                 // Jackson serializers for WorkflowModel - needed when WorkflowModel is returned directly from REST endpoint
-                "io.serverlessworkflow.impl.model.jackson.JacksonModel",
                 "io.serverlessworkflow.impl.model.jackson.JacksonModelSerializer",
                 "io.serverlessworkflow.impl.model.jackson.JacksonModelDeserializer")
                 .queryConstructors(true)

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowNativeProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowNativeProcessor.java
@@ -50,7 +50,7 @@ final class FlowNativeProcessor {
 
     @BuildStep
     void registerSerializableFunctions(CombinedIndexBuildItem indexedClasses,
-            BuildProducer<LambdaCapturingTypeBuildItem> producer) {
+                                       BuildProducer<LambdaCapturingTypeBuildItem> producer) {
         indexedClasses.getIndex().getAllKnownImplementations(Flowable.class).stream().map(ClassInfo::toString)
                 .map(LambdaCapturingTypeBuildItem::new).forEach(producer::produce);
     }
@@ -58,8 +58,12 @@ final class FlowNativeProcessor {
     @BuildStep
     ReflectiveClassBuildItem registerForReflection() {
         return ReflectiveClassBuildItem.builder(
-                "org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator",
-                "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator")
+                        "org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator",
+                        "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator",
+                        // Jackson serializers for WorkflowModel - needed when WorkflowModel is returned directly from REST endpoint
+                        "io.serverlessworkflow.impl.model.jackson.JacksonModel",
+                        "io.serverlessworkflow.impl.model.jackson.JacksonModelSerializer",
+                        "io.serverlessworkflow.impl.model.jackson.JacksonModelDeserializer")
                 .constructors(true)
                 .methods(true)
                 .fields(true)

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowNativeProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowNativeProcessor.java
@@ -64,6 +64,7 @@ final class FlowNativeProcessor {
                 "io.serverlessworkflow.impl.model.jackson.JacksonModel",
                 "io.serverlessworkflow.impl.model.jackson.JacksonModelSerializer",
                 "io.serverlessworkflow.impl.model.jackson.JacksonModelDeserializer")
+                .queryConstructors(true)
                 .constructors(true)
                 .methods(true)
                 .fields(true)

--- a/examples/auth-oauth2-oidc/src/main/java/org/acme/http/api/FlowResource.java
+++ b/examples/auth-oauth2-oidc/src/main/java/org/acme/http/api/FlowResource.java
@@ -73,6 +73,6 @@ public class FlowResource {
     @Path("/read-all-emails")
     public Response readAllEmails() {
         WorkflowModel model = multipleOAuth2Client.instance().start().join();
-        return Response.ok(model.asJavaObject()).build();
+        return Response.ok(model).build();
     }
 }

--- a/examples/auth-oauth2-oidc/src/main/java/org/acme/http/api/FlowResource.java
+++ b/examples/auth-oauth2-oidc/src/main/java/org/acme/http/api/FlowResource.java
@@ -73,6 +73,6 @@ public class FlowResource {
     @Path("/read-all-emails")
     public Response readAllEmails() {
         WorkflowModel model = multipleOAuth2Client.instance().start().join();
-        return Response.ok(model).build();
+        return Response.ok(model.asJavaObject()).build();
     }
 }


### PR DESCRIPTION
In native builds we are getting:

```log
2026-07-16 06:27:01,062 ERROR [io.quarkus.resteasy.reactive.jackson.runtime.mappers.NativeInvalidDefinitionExceptionMapper] (executor-thread-1) com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Class io.serverlessworkflow.impl.model.jackson.JacksonModelSerializer has no default (no arg) constructor
Request method:	GET
Request URI:	http://localhost:41573/quarkus-flow/read-all-emails
Proxy:			<none>
Request params:	<none>
Query params:	<none>
Form params:	<none>
Path params:	<none>
Headers:		Accept=application/json, application/javascript, text/javascript, text/json
				Content-Type=application/json
Cookies:		<none>
Multiparts:		<none>
Body:			<none>

HTTP/1.1 500 Internal Server Error
content-length: 0
```

This patch is to add the relevant SDK classes as `ReflectiveClassBuildItem` for native compilation.