### PR TITLE
Remove multi-thread from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           cache: maven
 
       - name: Run build to validate formatting (core only)
-        run: mvn -B clean install -T 1C -P!docs -DskipTests -DskipITs=true -Dquarkus.log.level=OFF -Dquarkus.langchain4j.ollama.devservices.enabled=false -ntp
+        run: mvn -B clean install -P!docs -DskipTests -DskipITs=true -Dquarkus.log.level=OFF -Dquarkus.langchain4j.ollama.devservices.enabled=false -ntp
 
       - name: Upload core artifacts for examples-it
         uses: actions/upload-artifact@v7
@@ -115,7 +115,7 @@ jobs:
 
       - name: Build with Maven (Linux, skip docs and examples)
         if: matrix.os == 'ubuntu-latest'
-        run: mvn -B clean install -T 1C -Dno-format -P!docs -DskipITs=true -Dquarkus.log.level=OFF -Dquarkus.langchain4j.ollama.devservices.enabled=false -Drestassured.config.http.client.params.SO_TIMEOUT=${{ env.RESTASSURED_TIMEOUT_MS }} -ntp
+        run: mvn -B clean install -Dno-format -P!docs -DskipITs=true -Dquarkus.log.level=OFF -Dquarkus.langchain4j.ollama.devservices.enabled=false -Drestassured.config.http.client.params.SO_TIMEOUT=${{ env.RESTASSURED_TIMEOUT_MS }} -ntp
 
       - name: Build with Maven (Windows, skip docs and examples)
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
Quick PR to remove multi-thread from CI to avoid flakiness of `-deployment` modules not in the classpath.