### PR TITLE
Upgrade Quarkus LangChain4j to 1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,31 +250,26 @@ Quarkus Flow discovers these methods at build time and registers generated workf
 
 ```java
 import dev.langchain4j.agentic.declarative.SequenceAgent;
-import io.quarkiverse.langchain4j.RegisterAiService;
 
 public final class Agents {
 
   // A generated workflow: chain sub-agents sequentially
-  @RegisterAiService
   public interface StoryCreatorWithConfigurableStyleEditor {
     @SequenceAgent(outputKey = "story", subAgents = { CreativeWriter.class, AudienceEditor.class, StyleEditor.class })
       String write(@V("topic") String topic, @V("style") String style, @V("audience") String audience);
   }
 
   // pseudo-snippet
-  @RegisterAiService
   public interface CreativeWriter {
 
   }
 
   // pseudo-snippet
-  @RegisterAiService
   public interface AudienceEditor {
 
   }
 
   // pseudo-snippet
-  @RegisterAiService
   public interface StyleEditor {
 
   }

--- a/docs/modules/ROOT/examples/org/acme/langchain4j/Agents.java
+++ b/docs/modules/ROOT/examples/org/acme/langchain4j/Agents.java
@@ -9,20 +9,16 @@ import dev.langchain4j.agentic.declarative.SequenceAgent;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
-import io.quarkiverse.langchain4j.RegisterAiService;
 
 /**
  * Example LangChain4j agentic workflows backed by Quarkus Flow.
  * <p>
  * When the app boots, quarkus-langchain4j creates beans for these
- *
- * @RegisterAiService interfaces. The quarkus-flow-langchain4j extension transparently builds WorkflowDefinitions for
- *                    the
- *
- * @SequenceAgent and @ParallelAgent methods and registers them in the Quarkus Flow runtime.
- *                <p>
- *                You will see them under the Quarkus Flow Dev UI: - document.name ~=
- *                "story-creator-with-configurable-style-editor" - document.name ~= "evening-planner-agent"
+ * <p>
+ * {@link SequenceAgent} and {@link ParallelAgent} methods and registers them in the Quarkus Flow runtime.
+ * <p>
+ * You will see them under the Quarkus Flow Dev UI: - document.name ~=
+ * "story-creator-with-configurable-style-editor" - document.name ~= "evening-planner-agent"
  */
 public final class Agents {
 
@@ -49,7 +45,6 @@ public final class Agents {
      * The Quarkus Flow integration builds a workflow whose input schema matches the method parameters (topic, style,
      * audience). In Dev UI, you’ll see a workflow with a document name derived from this class.
      */
-    @RegisterAiService
     public interface StoryCreatorWithConfigurableStyleEditor {
 
         @SequenceAgent(outputKey = "story", subAgents = { CreativeWriter.class, AudienceEditor.class,
@@ -57,7 +52,6 @@ public final class Agents {
         String write(@V("topic") String topic, @V("style") String style, @V("audience") String audience);
     }
 
-    @RegisterAiService
     public interface CreativeWriter {
 
         @Agent(name = "Creative writer", description = "Draft a short story about a topic.", outputKey = "story")
@@ -73,7 +67,6 @@ public final class Agents {
         String draft(@V("topic") String topic);
     }
 
-    @RegisterAiService
     public interface AudienceEditor {
 
         @Agent(name = "Audience editor", description = "Adapt story to a target audience.", outputKey = "story")
@@ -91,7 +84,6 @@ public final class Agents {
         String adapt(@V("story") String story, @V("audience") String audience);
     }
 
-    @RegisterAiService
     public interface StyleEditor {
 
         @Agent(name = "Style editor", description = "Adapt story to a specific writing style.", outputKey = "story")
@@ -121,7 +113,6 @@ public final class Agents {
      * The Quarkus Flow integration builds a fork-join style workflow where each branch represents one of the sub-agents
      * below.
      */
-    @RegisterAiService
     public interface EveningPlannerAgent {
         /**
          * LC4J post-processor that builds the final EveningPlan from the values written by the sub-agents + original
@@ -159,7 +150,6 @@ public final class Agents {
         String audience();
     }
 
-    @RegisterAiService
     public interface DinnerAgent {
 
         @Agent(name = "Dinner planner", outputKey = "dinner")
@@ -176,7 +166,6 @@ public final class Agents {
         String suggestDinner(@V("city") String city, @V("mood") Mood mood);
     }
 
-    @RegisterAiService
     public interface DrinksAgent {
 
         @Agent(name = "Drinks planner", outputKey = "drinks")
@@ -192,7 +181,6 @@ public final class Agents {
         String suggestDrinks(@V("city") String city, @V("mood") Mood mood);
     }
 
-    @RegisterAiService
     public interface ActivityAgent {
 
         @Agent(name = "Activity planner", outputKey = "activity")

--- a/docs/modules/ROOT/pages/concepts-agentic-langchain4j.adoc
+++ b/docs/modules/ROOT/pages/concepts-agentic-langchain4j.adoc
@@ -20,7 +20,7 @@ When you add the `quarkus-flow-langchain4j` extension to your project, Quarkus F
 It does not run a separate "AI Engine" at runtime. Instead, during the Quarkus build phase, it translates LangChain4j semantics directly into the CNCF Serverless Workflow vocabulary.
 
 === The Compilation Process
-1. **Scanning:** The extension scans your `@RegisterAiService` interfaces for methods annotated with Agentic routing annotations (like `@SequenceAgent` or `@ParallelAgent`).
+1. **Scanning:** The extension scans your interfaces for methods annotated with Agentic routing annotations (like `@SequenceAgent` or `@ParallelAgent`).
 2. **Translation:** For each annotated method, it programmatically generates a standard `WorkflowDefinition` bean.
 * A `@SequenceAgent` is translated into a linear sequence of standard `call` tasks.
 * A `@ParallelAgent` is translated into a `fork` / `join` state topology.

--- a/docs/modules/ROOT/pages/langchain4j.adoc
+++ b/docs/modules/ROOT/pages/langchain4j.adoc
@@ -299,7 +299,7 @@ The `quarkus-flow-langchain4j` extension acts as an ahead-of-time compiler for L
 
 When you start your application in dev mode (`./mvnw quarkus:dev`):
 
-1. Quarkus Flow scans your `@RegisterAiService` interfaces for Agentic Workflow annotations
+1. Quarkus Flow scans your interfaces for Agentic Workflow annotations (like `@SequenceAgent` or `@ParallelAgent`)
 2. It generates a standalone `WorkflowDefinition` for each annotated method at build time
 3. It derives JSON Schema from the method parameters for input validation
 4. The generated workflows are registered as first-class citizens in the workflow registry

--- a/docs/modules/ROOT/pages/schedule-agentic-workflows.adoc
+++ b/docs/modules/ROOT/pages/schedule-agentic-workflows.adoc
@@ -74,7 +74,6 @@ Use `event` to start the workflow whenever a CloudEvent of the given type is rec
 
 [source,java]
 ----
-@RegisterAiService
 public interface ConferenceReviewerPlanner {
 
     @ScheduleOn(event = "proposal.submitted")

--- a/examples/agentic-http/pom.xml
+++ b/examples/agentic-http/pom.xml
@@ -18,7 +18,7 @@
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
 
         <quarkus.flow.version>1.0.0-SNAPSHOT</quarkus.flow.version>
-        <io.quarkiverse.langchain4j.version>1.11.2</io.quarkiverse.langchain4j.version>
+        <io.quarkiverse.langchain4j.version>1.12.0</io.quarkiverse.langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/langchain4j-agentic-workflow/pom.xml
+++ b/examples/langchain4j-agentic-workflow/pom.xml
@@ -17,7 +17,7 @@
         <quarkus.flow.version>1.0.0-SNAPSHOT</quarkus.flow.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <io.quarkiverse.langchain4j.version>1.11.2</io.quarkiverse.langchain4j.version>
+        <io.quarkiverse.langchain4j.version>1.12.0</io.quarkiverse.langchain4j.version>
         <version.assertj>3.27.7</version.assertj>
         <org.wiremock.version>3.13.2</org.wiremock.version>
     </properties>

--- a/examples/langchain4j-agentic-workflow/src/main/java/org/acme/langchain4j/Agents.java
+++ b/examples/langchain4j-agentic-workflow/src/main/java/org/acme/langchain4j/Agents.java
@@ -1,7 +1,5 @@
 package org.acme.langchain4j;
 
-import static java.util.Objects.requireNonNullElse;
-
 import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.declarative.Output;
 import dev.langchain4j.agentic.declarative.ParallelAgent;
@@ -9,20 +7,18 @@ import dev.langchain4j.agentic.declarative.SequenceAgent;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
-import io.quarkiverse.langchain4j.RegisterAiService;
+
+import static java.util.Objects.requireNonNullElse;
 
 /**
  * Example LangChain4j agentic workflows backed by Quarkus Flow.
  * <p>
  * When the app boots, quarkus-langchain4j creates beans for these
- *
- * @RegisterAiService interfaces. The quarkus-flow-langchain4j extension transparently builds WorkflowDefinitions for
- *                    the
- *
- * @SequenceAgent and @ParallelAgent methods and registers them in the Quarkus Flow runtime.
- *                <p>
- *                You will see them under the Quarkus Flow Dev UI: - document.name ~=
- *                "story-creator-with-configurable-style-editor" - document.name ~= "evening-planner-agent"
+ * <p>
+ * {@link SequenceAgent} and {@link ParallelAgent} methods and registers them in the Quarkus Flow runtime.
+ * <p>
+ * You will see them under the Quarkus Flow Dev UI: - document.name ~=
+ * "story-creator-with-configurable-style-editor" - document.name ~= "evening-planner-agent"
  */
 public final class Agents {
 
@@ -49,7 +45,6 @@ public final class Agents {
      * The Quarkus Flow integration builds a workflow whose input schema matches the method parameters (topic, style,
      * audience). In Dev UI, you’ll see a workflow with a document name derived from this class.
      */
-    @RegisterAiService
     public interface StoryCreatorWithConfigurableStyleEditor {
 
         @SequenceAgent(outputKey = "story", subAgents = { CreativeWriter.class, AudienceEditor.class,
@@ -57,7 +52,6 @@ public final class Agents {
         String write(@V("topic") String topic, @V("style") String style, @V("audience") String audience);
     }
 
-    @RegisterAiService
     public interface CreativeWriter {
 
         @Agent(name = "Creative writer", description = "Draft a short story about a topic.", outputKey = "story")
@@ -73,7 +67,6 @@ public final class Agents {
         String draft(@V("topic") String topic);
     }
 
-    @RegisterAiService
     public interface AudienceEditor {
 
         @Agent(name = "Audience editor", description = "Adapt story to a target audience.", outputKey = "story")
@@ -91,7 +84,6 @@ public final class Agents {
         String adapt(@V("story") String story, @V("audience") String audience);
     }
 
-    @RegisterAiService
     public interface StyleEditor {
 
         @Agent(name = "Style editor", description = "Adapt story to a specific writing style.", outputKey = "story")
@@ -121,7 +113,6 @@ public final class Agents {
      * The Quarkus Flow integration builds a fork-join style workflow where each branch represents one of the sub-agents
      * below.
      */
-    @RegisterAiService
     public interface EveningPlannerAgent {
         /**
          * LC4J post-processor that builds the final EveningPlan from the values written by the sub-agents + original
@@ -159,7 +150,6 @@ public final class Agents {
         String audience();
     }
 
-    @RegisterAiService
     public interface DinnerAgent {
 
         @Agent(name = "Dinner planner", outputKey = "dinner")
@@ -176,7 +166,6 @@ public final class Agents {
         String suggestDinner(@V("city") String city, @V("mood") Mood mood);
     }
 
-    @RegisterAiService
     public interface DrinksAgent {
 
         @Agent(name = "Drinks planner", outputKey = "drinks")
@@ -192,7 +181,6 @@ public final class Agents {
         String suggestDrinks(@V("city") String city, @V("mood") Mood mood);
     }
 
-    @RegisterAiService
     public interface ActivityAgent {
 
         @Agent(name = "Activity planner", outputKey = "activity")

--- a/examples/newsletter-drafter/README.md
+++ b/examples/newsletter-drafter/README.md
@@ -115,7 +115,6 @@ public record NewsletterDraft(String title, String lead, String body) {}
 The AI Inner loop is defined using LangChain4j's powerful `@SequenceAgent`. With a single annotation, Quarkus wires together multiple specialized agents:
 
 ```java
-@RegisterAiService
 public interface AutoDraftCriticAgent {
     @SequenceAgent(
         outputKey = "draft", 

--- a/examples/newsletter-drafter/pom.xml
+++ b/examples/newsletter-drafter/pom.xml
@@ -21,7 +21,7 @@
         <failsafe-plugin.version>3.5.4</failsafe-plugin.version>
 
         <quarkus.flow.version>1.0.0-SNAPSHOT</quarkus.flow.version>
-        <io.quarkiverse.langchain4j.version>1.11.2</io.quarkiverse.langchain4j.version>
+        <io.quarkiverse.langchain4j.version>1.12.0</io.quarkiverse.langchain4j.version>
         <org.assertj.version>3.27.7</org.assertj.version>
     </properties>
 

--- a/examples/newsletter-drafter/src/main/java/org/acme/newsletter/agents/AutoDraftCriticAgent.java
+++ b/examples/newsletter-drafter/src/main/java/org/acme/newsletter/agents/AutoDraftCriticAgent.java
@@ -3,13 +3,9 @@ package org.acme.newsletter.agents;
 import dev.langchain4j.agentic.declarative.SequenceAgent;
 import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.V;
-import io.quarkiverse.langchain4j.RegisterAiService;
-import jakarta.enterprise.context.ApplicationScoped;
 import org.acme.newsletter.domain.NewsletterDraft;
 import org.acme.newsletter.domain.NewsletterRequest;
 
-@ApplicationScoped
-@RegisterAiService
 public interface AutoDraftCriticAgent {
 
     @SequenceAgent(description = "Draft, criticize, and review the generated newsletter", outputKey = "draft", subAgents = {

--- a/examples/newsletter-drafter/src/main/java/org/acme/newsletter/agents/CriticAgent.java
+++ b/examples/newsletter-drafter/src/main/java/org/acme/newsletter/agents/CriticAgent.java
@@ -5,13 +5,9 @@ import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
-import io.quarkiverse.langchain4j.RegisterAiService;
-import jakarta.enterprise.context.ApplicationScoped;
 import org.acme.newsletter.domain.CriticReview;
 import org.acme.newsletter.domain.NewsletterDraft;
 
-@ApplicationScoped
-@RegisterAiService
 @SystemMessage("""
          You are a meticulous reviewer of weekly investment newsletters.
           Your job is to evaluate the provided draft based on tone, clarity, factuality, and compliance.

--- a/examples/newsletter-drafter/src/main/java/org/acme/newsletter/agents/CriticEditorAgent.java
+++ b/examples/newsletter-drafter/src/main/java/org/acme/newsletter/agents/CriticEditorAgent.java
@@ -5,13 +5,9 @@ import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
-import io.quarkiverse.langchain4j.RegisterAiService;
-import jakarta.enterprise.context.ApplicationScoped;
 import org.acme.newsletter.domain.CriticReview;
 import org.acme.newsletter.domain.NewsletterDraft;
 
-@ApplicationScoped
-@RegisterAiService
 @SystemMessage("""
         You are a strict compliance and logic editor for a financial newsletter.
         Your job is to revise the provided draft based ONLY on the automated critic's feedback.

--- a/examples/newsletter-drafter/src/main/java/org/acme/newsletter/agents/DrafterAgent.java
+++ b/examples/newsletter-drafter/src/main/java/org/acme/newsletter/agents/DrafterAgent.java
@@ -5,13 +5,9 @@ import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
-import io.quarkiverse.langchain4j.RegisterAiService;
-import jakarta.enterprise.context.ApplicationScoped;
 import org.acme.newsletter.domain.NewsletterDraft;
 import org.acme.newsletter.domain.NewsletterRequest;
 
-@ApplicationScoped
-@RegisterAiService
 @SystemMessage("""
         You are an expert financial copywriter.
         Write a draft investment newsletter based on the provided inputs.

--- a/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/FlowLangChain4JSchedulableCronWithArgsProcessorTest.java
+++ b/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/FlowLangChain4JSchedulableCronWithArgsProcessorTest.java
@@ -14,7 +14,6 @@ import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.declarative.SequenceAgent;
 import dev.langchain4j.service.V;
 import io.quarkiverse.flow.langchain4j.annotations.ScheduleOn;
-import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class FlowLangChain4JSchedulableCronWithArgsProcessorTest {
@@ -34,7 +33,6 @@ public class FlowLangChain4JSchedulableCronWithArgsProcessorTest {
 
     static class Agentic {
 
-        @RegisterAiService
         public interface StoryPlanner {
             @SequenceAgent(subAgents = {
                     StoryCreator.class

--- a/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/FlowLangChain4JSchedulableIntervalWithArgsProcessorTest.java
+++ b/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/FlowLangChain4JSchedulableIntervalWithArgsProcessorTest.java
@@ -14,7 +14,6 @@ import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.declarative.SequenceAgent;
 import dev.langchain4j.service.V;
 import io.quarkiverse.flow.langchain4j.annotations.ScheduleOn;
-import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class FlowLangChain4JSchedulableIntervalWithArgsProcessorTest {
@@ -34,7 +33,6 @@ public class FlowLangChain4JSchedulableIntervalWithArgsProcessorTest {
 
     static class Agentic {
 
-        @RegisterAiService
         public interface StoryPlanner {
             @SequenceAgent(subAgents = {
                     StoryCreator.class

--- a/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/FlowLangChain4JSchedulableProcessorTest.java
+++ b/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/FlowLangChain4JSchedulableProcessorTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.declarative.SequenceAgent;
 import io.quarkiverse.flow.langchain4j.annotations.ScheduleOn;
-import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class FlowLangChain4JSchedulableProcessorTest {
@@ -33,7 +32,6 @@ public class FlowLangChain4JSchedulableProcessorTest {
 
     static class Agentic {
 
-        @RegisterAiService
         public interface StoryPlanner {
             @SequenceAgent(subAgents = {
                     StoryCreator.class

--- a/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/workflow/package-info.java
+++ b/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/workflow/package-info.java
@@ -29,7 +29,6 @@
  * <pre>
  * {
  *     &#64;code
- *     &#64;RegisterAiService
  *     public interface StoryWriter {
  *         @SequenceAgent(subAgents = { Writer.class, Editor.class })
  *         String writeStory(String topic);

--- a/langchain4j/runtime/src/test/java/io/quarkiverse/flow/langchain4j/Agents.java
+++ b/langchain4j/runtime/src/test/java/io/quarkiverse/flow/langchain4j/Agents.java
@@ -10,11 +10,9 @@ import dev.langchain4j.agentic.declarative.SequenceAgent;
 import dev.langchain4j.agentic.declarative.SupervisorAgent;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
-import io.quarkiverse.langchain4j.RegisterAiService;
 
 public class Agents {
 
-    @RegisterAiService
     public interface StoryCreatorWithConfigurableStyleEditor {
         @SequenceAgent(outputKey = "story", subAgents = {
                 CreativeWriter.class, AudienceEditor.class, StyleEditor.class
@@ -77,7 +75,6 @@ public class Agents {
 
     }
 
-    @RegisterAiService
     public interface SequenceWithA2AAgent {
         @SequenceAgent(outputKey = "finalResult", subAgents = {
                 RemoteDataFetcher.class, LocalProcessor.class
@@ -101,7 +98,6 @@ public class Agents {
     }
 
     // ParallelMapperAgent test
-    @RegisterAiService
     public interface SequenceWithParallelMapperAgent {
         @SequenceAgent(outputKey = "results", subAgents = {
                 ItemsGenerator.class, ItemsMapper.class
@@ -133,7 +129,6 @@ public class Agents {
     }
 
     // SupervisorAgent test
-    @RegisterAiService
     public interface SequenceWithSupervisorAgent {
         @SequenceAgent(outputKey = "finalResult", subAgents = {
                 TaskSupervisor.class
@@ -151,7 +146,6 @@ public class Agents {
     }
 
     // PlannerAgent test
-    @RegisterAiService
     public interface SequenceWithPlannerAgent {
         @SequenceAgent(outputKey = "finalResult", subAgents = {
                 TaskPlanner.class

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
         <io.quarkiverse.jackson-jq.version>2.5.2</io.quarkiverse.jackson-jq.version>
         <com.github.zafarkhaja.version>0.10.2</com.github.zafarkhaja.version>
-        <io.quarkiverse.langchain4j.version>1.11.2</io.quarkiverse.langchain4j.version>
+        <io.quarkiverse.langchain4j.version>1.12.0</io.quarkiverse.langchain4j.version>
 
         <!-- Tests and Docs -->
         <org.assertj.version>3.27.7</org.assertj.version>


### PR DESCRIPTION
Manually upgrade Quarkus LC4J to 1.12.0 because we've been using `@RegisterAiService` wrongly.