### PR TITLE
Refactor FlowMetricsConfig usage and improve metrics handling in FaultToleranceProvider and WorkflowApplicationCreator

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
@@ -310,18 +310,14 @@ class FlowProcessor {
     @BuildStep
     void registerWorkflowApp(WorkflowApplicationRecorder recorder,
             ShutdownContextBuildItem shutdown,
-            Optional<MetricsCapabilityBuildItem> metricsCapability,
             BuildProducer<SyntheticBeanBuildItem> beans) {
-
-        boolean isMicrometerSupported = metricsCapability
-                .map(capability -> capability.metricsSupported(MetricsFactory.MICROMETER)).orElse(false);
 
         beans.produce(SyntheticBeanBuildItem.configure(WorkflowApplication.class)
                 .scope(ApplicationScoped.class)
                 .unremovable()
                 .setRuntimeInit()
                 .addInjectionPoint(ClassType.create(DotName.createSimple(WorkflowApplicationCreator.class)))
-                .createWith(recorder.workflowAppCreator(shutdown, isMicrometerSupported))
+                .createWith(recorder.workflowAppCreator(shutdown))
                 .done());
         LOG.info("Flow: Registering Workflow Application bean: {}", WorkflowApplication.class.getName());
     }

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/faulttolerance/FaultToleranceCircuitBreakerTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/faulttolerance/FaultToleranceCircuitBreakerTest.java
@@ -18,8 +18,6 @@ import io.smallrye.faulttolerance.api.TypedGuard;
 
 public class FaultToleranceCircuitBreakerTest {
 
-    private static final boolean micrometerNotSupported = false;
-
     @Test
     void should_open_circuit_breaker_after_failure_threshold() {
         FlowHttpConfig flowHttpConfig = new SmallRyeConfigBuilder()
@@ -41,7 +39,7 @@ public class FaultToleranceCircuitBreakerTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("payment", "process", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("payment", "process"));
 
         AtomicInteger callCount = new AtomicInteger(0);
 
@@ -81,7 +79,7 @@ public class FaultToleranceCircuitBreakerTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("payment", "process", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("payment", "process"));
 
         AtomicInteger callCount = new AtomicInteger(0);
 
@@ -125,7 +123,7 @@ public class FaultToleranceCircuitBreakerTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("payment", "process", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("payment", "process"));
 
         AtomicInteger callCount = new AtomicInteger(0);
 
@@ -169,7 +167,7 @@ public class FaultToleranceCircuitBreakerTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("payment", "validate", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("payment", "validate"));
 
         AtomicInteger callCount = new AtomicInteger(0);
 
@@ -208,7 +206,7 @@ public class FaultToleranceCircuitBreakerTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("order", "create", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("order", "create"));
 
         AtomicInteger callCount = new AtomicInteger(0);
 
@@ -246,7 +244,7 @@ public class FaultToleranceCircuitBreakerTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("inventory", "check", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("inventory", "check"));
 
         AtomicInteger callCount = new AtomicInteger(0);
 
@@ -301,7 +299,7 @@ public class FaultToleranceCircuitBreakerTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("shipping", "calculate", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("shipping", "calculate"));
 
         AtomicInteger callCount = new AtomicInteger(0);
 
@@ -350,7 +348,7 @@ public class FaultToleranceCircuitBreakerTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("notification", "send", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("notification", "send"));
 
         AtomicInteger callCount = new AtomicInteger(0);
 
@@ -402,7 +400,7 @@ public class FaultToleranceCircuitBreakerTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("user", "register", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("user", "register"));
 
         AtomicInteger callCount = new AtomicInteger(0);
 
@@ -448,7 +446,7 @@ public class FaultToleranceCircuitBreakerTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("billing", "charge", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("billing", "charge"));
 
         AtomicInteger callCount = new AtomicInteger(0);
 
@@ -486,7 +484,7 @@ public class FaultToleranceCircuitBreakerTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("analytics", "track", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("analytics", "track"));
 
         AtomicInteger callCount = new AtomicInteger(0);
 
@@ -537,7 +535,7 @@ public class FaultToleranceCircuitBreakerTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("cache", "invalidate", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("cache", "invalidate"));
 
         AtomicInteger callCount = new AtomicInteger(0);
 

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/faulttolerance/FaultToleranceRetryTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/faulttolerance/FaultToleranceRetryTest.java
@@ -21,8 +21,6 @@ import io.smallrye.faulttolerance.api.TypedGuard;
 
 public class FaultToleranceRetryTest {
 
-    private static final boolean micrometerNotSupported = false;
-
     @Test
     void should_create_type_guard_with_retry_enabled_and_five_retries() {
 
@@ -39,7 +37,7 @@ public class FaultToleranceRetryTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("any", "any", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("any", "any"));
 
         AtomicInteger atomicInteger = new AtomicInteger(0);
 
@@ -73,7 +71,7 @@ public class FaultToleranceRetryTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("any", "any", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("any", "any"));
 
         AtomicInteger atomicInteger = new AtomicInteger(0);
 
@@ -108,7 +106,7 @@ public class FaultToleranceRetryTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("any", "any", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("any", "any"));
 
         AtomicInteger atomicInteger = new AtomicInteger(0);
 
@@ -145,7 +143,7 @@ public class FaultToleranceRetryTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("transfer", "any", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("transfer", "any"));
 
         AtomicInteger atomicInteger = new AtomicInteger(0);
 
@@ -186,7 +184,7 @@ public class FaultToleranceRetryTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("transfer", "notify", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("transfer", "notify"));
 
         AtomicInteger atomicInteger = new AtomicInteger(0);
 
@@ -223,7 +221,7 @@ public class FaultToleranceRetryTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> guard = sut
-                .guardFor(new WorkflowTaskContext("transfer", "notify", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("transfer", "notify"));
 
         List<Long> executionTimes = new CopyOnWriteArrayList<>();
 
@@ -264,7 +262,7 @@ public class FaultToleranceRetryTest {
         FaultToleranceProvider sut = new FaultToleranceProvider(flowHttpConfig, flowMetricsConfig);
 
         TypedGuard<CompletionStage<WorkflowModel>> typeGuard = sut
-                .guardFor(new WorkflowTaskContext("any", "any", micrometerNotSupported));
+                .guardFor(new WorkflowTaskContext("any", "any"));
 
         AtomicInteger atomicInteger = new AtomicInteger(0);
 

--- a/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowMetricsConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowMetricsConfig.java
@@ -14,10 +14,11 @@ import io.smallrye.config.WithDefault;
  * <strong>Note:</strong> Changes to metrics configuration require an application restart to take effect.
  * The metrics listener is registered at startup and cannot be dynamically added or removed.
  * <p>
- * To enable metrics:
+ * Metrics are auto-enabled when Micrometer is present on the classpath.
+ * To explicitly control metrics, configure:
  *
  * <pre>
- * <code>quarkus.flow.metrics.enabled=true</code>
+ * <code>quarkus.flow.metrics.enabled=true</code> or <code>quarkus.flow.metrics.enabled=false</code>
  * </pre>
  *
  * Then restart the application (no rebuild required).
@@ -34,12 +35,14 @@ public interface FlowMetricsConfig {
     /**
      * Enables or disables metrics collection for Quarkus Flow.
      * <p>
+     * When not explicitly configured, metrics are auto-enabled if Micrometer is present on the classpath,
+     * and auto-disabled otherwise.
+     * <p>
      * When set to {@code false}, no metrics are published.
      * <p>
      * <strong>Restart required:</strong> Changing this property requires an application restart to take effect.
      */
-    @WithDefault("true")
-    boolean enabled();
+    Optional<Boolean> enabled();
 
     /**
      * Prefix applied to all exported metric names.

--- a/core/runtime/src/main/java/io/quarkiverse/flow/providers/FaultToleranceProvider.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/providers/FaultToleranceProvider.java
@@ -135,7 +135,7 @@ public class FaultToleranceProvider {
             circuitBreakerBuilder.failOn(DEFAULT_CLASSES);
         }
 
-        if (ctx.isMicrometerSupported() && flowMetricsConfig.enabled()) {
+        if (flowMetricsConfig.enabled().orElse(true)) {
             circuitBreakerBuilder
                     .onFailure(() -> sendCircuitBreakerFailure(ctx))
                     .onPrevented(() -> sendCircuitBreakerPrevented(ctx))
@@ -151,7 +151,7 @@ public class FaultToleranceProvider {
             HttpClientConfig.ResilienceConfig resilienceConfig) {
         TypedGuard.Builder.RetryBuilder<CompletionStage<WorkflowModel>> retryBuilder = builder.withRetry();
 
-        if (ctx.isMicrometerSupported() && flowMetricsConfig.enabled()) {
+        if (flowMetricsConfig.enabled().orElse(true)) {
             retryBuilder
                     .onRetry(() -> sendOnRetryMetric(ctx))
                     .onFailure(() -> sendOnFailureMetric(ctx));

--- a/core/runtime/src/main/java/io/quarkiverse/flow/providers/WorkflowTaskContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/providers/WorkflowTaskContext.java
@@ -1,4 +1,4 @@
 package io.quarkiverse.flow.providers;
 
-public record WorkflowTaskContext(String workflowName, String taskName, boolean isMicrometerSupported) {
+public record WorkflowTaskContext(String workflowName, String taskName) {
 }

--- a/core/runtime/src/main/java/io/quarkiverse/flow/recorders/WorkflowApplicationCreator.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/recorders/WorkflowApplicationCreator.java
@@ -107,15 +107,11 @@ public class WorkflowApplicationCreator {
     @Inject
     FlowMetricsConfig metricsConfig;
 
-    public WorkflowApplication create(boolean isMicrometerSupported) {
+    public WorkflowApplication create() {
         final Builder builder = WorkflowApplication.builder();
         if (tracingConfig.enabled().orElse(launchMode.isDevOrTest())) {
             LOG.debug("Flow: Tracing enabled");
             builder.withListener(new TraceLoggerExecutionListener());
-        }
-        if (metricsConfig.enabled() && !isMicrometerSupported) {
-            LOG.warn("Quarkus Flow metrics enabled but Micrometer not available. " +
-                    "Add 'quarkus-micrometer-registry-prometheus' dependency to enable metrics.");
         }
 
         builder.withContextFactory(new JavaModelFactory()).withModelFactory(new JacksonModelFactory());
@@ -130,7 +126,7 @@ public class WorkflowApplicationCreator {
         injectConfigManager(builder);
         injectHttpClientProvider(builder);
         injectMicrometerListener(builder);
-        injectFaultTolerance(builder, isMicrometerSupported);
+        injectFaultTolerance(builder);
         injectCustomListeners(builder);
 
         customizers.stream().forEachOrdered(customizer -> customizer.customize(builder));
@@ -251,7 +247,7 @@ public class WorkflowApplicationCreator {
         builder.withExpressionFactory(new JQExpressionFactory(jqScopeSupplier));
     }
 
-    private void injectFaultTolerance(Builder builder, boolean isMicrometerSupported) {
+    private void injectFaultTolerance(Builder builder) {
         LOG.debug("Flow: Bound FaultToleranceProvider bean: {}", faultToleranceProvider.getClass().getName());
         builder.withCallableProxy(new CallableTaskProxyBuilder() {
             @Override
@@ -260,7 +256,7 @@ public class WorkflowApplicationCreator {
                     String workflowName = workflowContext.definition().workflow().getDocument().getName();
                     String taskName = taskContext.taskName();
                     TypedGuard<CompletionStage<WorkflowModel>> guard = faultToleranceProvider
-                            .guardFor(new WorkflowTaskContext(workflowName, taskName, isMicrometerSupported));
+                            .guardFor(new WorkflowTaskContext(workflowName, taskName));
 
                     return guard.get(() -> delegate.apply(workflowContext, taskContext, input)).toCompletableFuture();
                 };

--- a/core/runtime/src/main/java/io/quarkiverse/flow/recorders/WorkflowApplicationRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/recorders/WorkflowApplicationRecorder.java
@@ -11,10 +11,10 @@ import io.serverlessworkflow.impl.WorkflowApplication;
 public class WorkflowApplicationRecorder {
 
     public Function<SyntheticCreationalContext<WorkflowApplication>, WorkflowApplication> workflowAppCreator(
-            ShutdownContext shutdownContext, boolean isMicrometerSupported) {
+            ShutdownContext shutdownContext) {
         return context -> {
             WorkflowApplicationCreator creator = context.getInjectedReference(WorkflowApplicationCreator.class);
-            WorkflowApplication app = creator.create(isMicrometerSupported);
+            WorkflowApplication app = creator.create();
             shutdownContext.addShutdownTask(app::close);
             return app;
         };

--- a/docs/modules/ROOT/pages/includes/quarkus-flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow.adoc
@@ -1592,6 +1592,8 @@ endif::add-copy-button-to-config-props[]
 --
 Enables or disables metrics collection for Quarkus Flow.
 
+When not explicitly configured, metrics are auto-enabled if Micrometer is present on the classpath, and auto-disabled otherwise.
+
 When set to `false`, no metrics are published.
 
 *Restart required:* Changing this property requires an application restart to take effect.
@@ -1605,7 +1607,7 @@ Environment variable: `+++QUARKUS_FLOW_METRICS_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|
 
 a| [[quarkus-flow_quarkus-flow-metrics-prefix]] [.property-path]##link:#quarkus-flow_quarkus-flow-metrics-prefix[`+++quarkus.flow.metrics.prefix+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.flow.adoc
@@ -1592,6 +1592,8 @@ endif::add-copy-button-to-config-props[]
 --
 Enables or disables metrics collection for Quarkus Flow.
 
+When not explicitly configured, metrics are auto-enabled if Micrometer is present on the classpath, and auto-disabled otherwise.
+
 When set to `false`, no metrics are published.
 
 *Restart required:* Changing this property requires an application restart to take effect.
@@ -1605,7 +1607,7 @@ Environment variable: `+++QUARKUS_FLOW_METRICS_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|
 
 a| [[quarkus-flow_quarkus-flow-metrics-prefix]] [.property-path]##link:#quarkus-flow_quarkus-flow-metrics-prefix[`+++quarkus.flow.metrics.prefix+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/workflow/runtime/RuntimeWorkflowApplicationProvider.java
+++ b/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/workflow/runtime/RuntimeWorkflowApplicationProvider.java
@@ -38,6 +38,6 @@ public class RuntimeWorkflowApplicationProvider {
      */
     public WorkflowApplication getRuntimeApplication() {
         // Create a NEW instance each time to ensure isolation between workflows
-        return creator.create(false);
+        return creator.create();
     }
 }


### PR DESCRIPTION
## Description

Activation and deactivation are optional and silently based on `Micrometer`.
Closes: #751
Before submitting this PR, please ensure:

- [X] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [X] Code follows the project's code conventions
- [X] Tests have been added/updated to cover the changes
- [X] Documentation has been updated (if user-facing changes)
- [X] Commit messages are clear and follow conventional commits style
- [X] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [X] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)