### PR TITLE
[Fix_#773] Fix OIDC authentication and namespace authorization in Runner

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-flow-runner.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-runner.adoc
@@ -162,19 +162,9 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Namespaces allowed for this API key.
+Namespaces authorized for this API key.
 
-When not configured (empty), the key has access to all namespaces. When configured, the key can only access workflows in the specified namespaces.
-
-Example:
-
-```
-# Restrict to specific namespaces
-quarkus.flow.runner.security.api-keys."team-key".namespaces=team-a,team-b
-
-# Or leave empty for all namespaces (default)
-quarkus.flow.runner.security.api-keys."admin-key".roles=flow-admin
-```
+The value `"++*++"` grants access to all namespaces. When omitted, this property defaults to `"++*++"` for backward compatibility.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -185,7 +175,7 @@ Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__NAMES
 endif::add-copy-button-to-env-var[]
 --
 |list of string
-|
+|`+++*+++`
 
 a| [[quarkus-flow-runner_quarkus-flow-runner-security-namespace-claim]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-namespace-claim[`+++quarkus.flow.runner.security.namespace.claim+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -195,21 +185,25 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-JWT claim name containing authorized namespace(s).
+JWT claim containing the namespaces authorized for the current identity.
 
 Used when `type=OIDC`. The claim can contain:
 
- - Single string value (e.g., `"my-namespace"`)
- - Array of strings (e.g., `++[++"ns1", "ns2"++]++`)
+ - A single namespace, for example `"team-a"`
+ - An array of namespaces, for example `++[++"team-a", "team-b"++]++`
+ - A comma-separated string, for example `"team-a,team-b"`
+ - The exact value `"++*++"` to authorize all current and future namespaces
 
 
+
+For a non-admin OIDC identity, a missing, null, empty, or blank claim grants no namespace access when namespace validation is enabled. Identities with the `flow-admin` role bypass namespace restrictions.
+
+Namespace matching is exact and case-sensitive. Partial wildcard values such as `"team-++*++"` are not supported.
 
 Example:
 
 ```
-quarkus.flow.runner.security.namespace.claim=namespace
-# or for multi-namespace support:
-quarkus.flow.runner.security.namespace.claim=namespaces
+quarkus.flow.runner.security.namespace.claim = namespace
 ```
 
 
@@ -231,11 +225,18 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Enable or disable namespace validation.
+Enables or disables namespace authorization.
 
-When `true`, requests are validated against the namespace in the request path and the user's authorized namespaces (from JWT claim or API key configuration).
+When enabled:
 
-When `false`, namespace validation is skipped (all users can access all namespaces). Use only in development.
+ - Identities with the `flow-admin` role can access all namespaces.
+ - The exact namespace value `"++*++"` authorizes all namespaces.
+ - Explicit namespace values authorize only those namespaces.
+ - A missing, null, empty, or blank namespace set grants no access to a non-admin identity.
+
+
+
+When disabled, namespace authorization is skipped and access is controlled only through role-based authorization.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-flow-runner_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-runner_quarkus.flow.adoc
@@ -162,19 +162,9 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Namespaces allowed for this API key.
+Namespaces authorized for this API key.
 
-When not configured (empty), the key has access to all namespaces. When configured, the key can only access workflows in the specified namespaces.
-
-Example:
-
-```
-# Restrict to specific namespaces
-quarkus.flow.runner.security.api-keys."team-key".namespaces=team-a,team-b
-
-# Or leave empty for all namespaces (default)
-quarkus.flow.runner.security.api-keys."admin-key".roles=flow-admin
-```
+The value `"++*++"` grants access to all namespaces. When omitted, this property defaults to `"++*++"` for backward compatibility.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -185,7 +175,7 @@ Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__NAMES
 endif::add-copy-button-to-env-var[]
 --
 |list of string
-|
+|`+++*+++`
 
 a| [[quarkus-flow-runner_quarkus-flow-runner-security-namespace-claim]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-namespace-claim[`+++quarkus.flow.runner.security.namespace.claim+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -195,21 +185,25 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-JWT claim name containing authorized namespace(s).
+JWT claim containing the namespaces authorized for the current identity.
 
 Used when `type=OIDC`. The claim can contain:
 
- - Single string value (e.g., `"my-namespace"`)
- - Array of strings (e.g., `++[++"ns1", "ns2"++]++`)
+ - A single namespace, for example `"team-a"`
+ - An array of namespaces, for example `++[++"team-a", "team-b"++]++`
+ - A comma-separated string, for example `"team-a,team-b"`
+ - The exact value `"++*++"` to authorize all current and future namespaces
 
 
+
+For a non-admin OIDC identity, a missing, null, empty, or blank claim grants no namespace access when namespace validation is enabled. Identities with the `flow-admin` role bypass namespace restrictions.
+
+Namespace matching is exact and case-sensitive. Partial wildcard values such as `"team-++*++"` are not supported.
 
 Example:
 
 ```
-quarkus.flow.runner.security.namespace.claim=namespace
-# or for multi-namespace support:
-quarkus.flow.runner.security.namespace.claim=namespaces
+quarkus.flow.runner.security.namespace.claim = namespace
 ```
 
 
@@ -231,11 +225,18 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Enable or disable namespace validation.
+Enables or disables namespace authorization.
 
-When `true`, requests are validated against the namespace in the request path and the user's authorized namespaces (from JWT claim or API key configuration).
+When enabled:
 
-When `false`, namespace validation is skipped (all users can access all namespaces). Use only in development.
+ - Identities with the `flow-admin` role can access all namespaces.
+ - The exact namespace value `"++*++"` authorizes all namespaces.
+ - Explicit namespace values authorize only those namespaces.
+ - A missing, null, empty, or blank namespace set grants no access to a non-admin identity.
+
+
+
+When disabled, namespace authorization is skipped and access is controlled only through role-based authorization.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/runner.adoc
+++ b/docs/modules/ROOT/pages/runner.adoc
@@ -222,7 +222,13 @@ quarkus.flow.runner.security.namespace.claim=namespace
 **JWT token requirements:**
 
 * Must contain a `roles` claim with `flow-admin` or `flow-invoker`
-* Must contain a `namespace` claim (string or array) for namespace authorization
+* A user with the `flow-admin` role can access all namespaces. The namespace
+  claim is optional and is not used to restrict an administrator.
+* A non-admin user must have an authorized namespace claim when namespace
+  validation is enabled.
+* For non-admin users, a missing, null, empty, or blank namespace claim grants
+  no namespace access and requests to a namespace are rejected with
+  `403 Forbidden`.
 * Example token payload:
 
 [source,json]
@@ -233,6 +239,31 @@ quarkus.flow.runner.security.namespace.claim=namespace
   "namespace": ["examples", "team-a"]
 }
 ----
+
+**Non-admin with unrestricted namespace access:**
+
+[source,json]
+----
+{
+  "sub": "automation@example.com",
+  "roles": ["flow-invoker"],
+  "namespace": ["*"]
+}
+----
+
+**Administrator without a namespace claim:**
+
+[source,json]
+----
+{
+  "sub": "administrator@example.com",
+  "roles": ["flow-admin"]
+}
+----
+
+The administrator can access every namespace even though the token does not
+contain a namespace claim.
+
 [[rest-api]]
 **API usage:**
 
@@ -450,6 +481,13 @@ The claim can contain:
 * Single namespace: `"namespace": "team-a"`
 * Array of namespaces: `"namespace": ["team-a", "team-b"]`
 * Comma-separated string: `"namespace": "team-a,team-b"`
+* Wildcard `*`, which grants access to all namespaces: `"namespace": "*"`
+  The wildcard can also be included in an array: `"namespace": ["*"]`
+
+IMPORTANT: Only the exact namespace value `*` grants access to all namespaces.
+Namespace matching is exact and case-sensitive. Values such as `team-*`,
+`my*`, `**`, or ` * ` are treated as ordinary namespace names and do not act
+as wildcard patterns.
 
 **Disabling namespace validation:**
 
@@ -820,7 +858,7 @@ yamllint workflows/
 **Causes:**
 
 * User not authorized for the workflow's namespace
-* Namespace claim missing from JWT token (OIDC mode)
+* Namespace claim missing, empty or contains only blank values from JWT token (OIDC mode and non-admin)
 * API key not configured with required namespaces (API_KEY mode)
 
 **Solutions:**

--- a/runner/integration-tests/src/test/java/io/quarkiverse/flow/runner/it/DefaultTestProfile.java
+++ b/runner/integration-tests/src/test/java/io/quarkiverse/flow/runner/it/DefaultTestProfile.java
@@ -16,6 +16,9 @@ public class DefaultTestProfile implements QuarkusTestProfile {
                 // Explicitly disable security for non-security tests
                 "quarkus.flow.runner.security.type", "none",
 
+                // Disable the default OIDC tenant in every non-OIDC user
+                "quarkus.oidc.tenant-enabled", "false",
+
                 // Use random port to avoid conflicts
                 "quarkus.http.test-port", "0",
 

--- a/runner/integration-tests/src/test/java/io/quarkiverse/flow/runner/it/SecurityAbacNamespaceProfile.java
+++ b/runner/integration-tests/src/test/java/io/quarkiverse/flow/runner/it/SecurityAbacNamespaceProfile.java
@@ -18,6 +18,9 @@ public class SecurityAbacNamespaceProfile implements QuarkusTestProfile {
         // Enable API Key authentication
         config.put("quarkus.flow.runner.security.type", "api-key");
 
+        // Disable the default OIDC tenant in every non-OIDC user
+        config.put("quarkus.oidc.tenant-enabled", "false");
+
         // Admin key with access to ALL namespaces (no restriction)
         config.put("quarkus.flow.runner.security.api-keys.admin-key.secret", "admin-all-namespaces");
         config.put("quarkus.flow.runner.security.api-keys.admin-key.roles", "flow-admin");

--- a/runner/integration-tests/src/test/java/io/quarkiverse/flow/runner/it/SecurityApiKeyProfile.java
+++ b/runner/integration-tests/src/test/java/io/quarkiverse/flow/runner/it/SecurityApiKeyProfile.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.flow.runner.it;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import io.quarkus.test.junit.QuarkusTestProfile;
@@ -12,28 +13,47 @@ public class SecurityApiKeyProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Map.of(
-                // Enable API Key authentication
-                "quarkus.flow.runner.security.type", "api-key",
+        Map<String, String> config = new HashMap<>();
+        // Enable API Key authentication
+        config.put("quarkus.flow.runner.security.type", "api-key");
 
-                // Admin API key with flow-admin role
-                "quarkus.flow.runner.security.api-keys.admin-key.secret", "test-admin-secret-key-123",
-                "quarkus.flow.runner.security.api-keys.admin-key.roles", "flow-admin",
+        // Admin API key with flow-admin role
+        config.put("quarkus.flow.runner.security.api-keys.admin-key.secret", "test-admin-secret-key-123");
+        config.put("quarkus.flow.runner.security.api-keys.admin-key.roles", "flow-admin");
 
-                // Invoker API key with flow-invoker role
-                "quarkus.flow.runner.security.api-keys.invoker-key.secret", "test-invoker-secret-key-456",
-                "quarkus.flow.runner.security.api-keys.invoker-key.roles", "flow-invoker",
+        // Disable the default OIDC tenant in every non-OIDC user
+        config.put("quarkus.oidc.tenant-enabled", "false");
 
-                // Disable namespace validation for simpler testing
-                "quarkus.flow.runner.security.namespace.validate", "false",
+        // Invoker API key with flow-admin role
+        config.put(
+                "quarkus.flow.runner.security.api-keys.admin-key.secret",
+                "test-admin-secret-key-123");
+        config.put(
+                "quarkus.flow.runner.security.api-keys.admin-key.roles",
+                "flow-admin");
 
-                // Use random port to avoid conflicts
-                "quarkus.http.test-port", "0",
+        // Invoker API key with flow-invoker role
+        config.put(
+                "quarkus.flow.runner.security.api-keys.invoker-key.secret",
+                "test-invoker-secret-key-456");
+        config.put(
+                "quarkus.flow.runner.security.api-keys.invoker-key.roles",
+                "flow-invoker");
 
-                // Disable Keycloak DevServices (not needed for API_KEY security mode)
-                "quarkus.oidc.devservices.enabled", "false",
-                "quarkus.keycloak.devservices.enabled", "false",
-                "quarkus.oidc.auth-server-url", "http://localhost.not.used");
+        // Disable namespace validation for simpler testing
+        config.put(
+                "quarkus.flow.runner.security.namespace.validate",
+                "false");
+
+        // Use random port to avoid conflicts
+        config.put("quarkus.http.test-port", "0");
+
+        // Disable Keycloak DevServices (not needed for API_KEY security mode)
+        config.put("quarkus.oidc.devservices.enabled", "false");
+        config.put("quarkus.keycloak.devservices.enabled", "false");
+        config.put("quarkus.oidc.auth-server-url", "http://localhost.not.used");
+
+        return config;
     }
 
     @Override

--- a/runner/integration-tests/src/test/java/io/quarkiverse/flow/runner/it/SecurityNoneProfile.java
+++ b/runner/integration-tests/src/test/java/io/quarkiverse/flow/runner/it/SecurityNoneProfile.java
@@ -16,6 +16,9 @@ public class SecurityNoneProfile implements QuarkusTestProfile {
                 // Disable security (development mode)
                 "quarkus.flow.runner.security.type", "none",
 
+                // Disable the default OIDC tenant in every non-OIDC user
+                "quarkus.oidc.tenant-enabled", "false",
+
                 // Use random port to avoid conflicts
                 "quarkus.http.test-port", "0",
 

--- a/runner/integration-tests/src/test/java/io/quarkiverse/flow/runner/it/SecurityOidcAbacIT.java
+++ b/runner/integration-tests/src/test/java/io/quarkiverse/flow/runner/it/SecurityOidcAbacIT.java
@@ -27,7 +27,7 @@ import io.quarkus.test.security.oidc.OidcSecurity;
 class SecurityOidcAbacIT {
 
     @Test
-    @TestSecurity(user = "alice", roles = "flow-admin")
+    @TestSecurity(user = "alice", roles = "flow-invoker")
     @OidcSecurity(claims = { @Claim(key = "namespace", value = "test-namespace") })
     @DisplayName("test_access_allowed_to_authorized_namespace")
     void test_access_allowed_to_authorized_namespace() {
@@ -86,7 +86,7 @@ class SecurityOidcAbacIT {
     }
 
     @Test
-    @TestSecurity(user = "carol", roles = "flow-admin")
+    @TestSecurity(user = "carol", roles = "flow-invoker")
     @OidcSecurity(claims = { @Claim(key = "namespace", value = "[\"test-namespace\",\"team-a\"]") })
     @DisplayName("test_multiple_namespaces_in_jwt_claim")
     void test_multiple_namespaces_in_jwt_claim() {
@@ -119,7 +119,7 @@ class SecurityOidcAbacIT {
     }
 
     @Test
-    @TestSecurity(user = "alice", roles = "flow-admin")
+    @TestSecurity(user = "alice", roles = "flow-invoker")
     @OidcSecurity(claims = { @Claim(key = "namespace", value = "test-namespace") })
     @DisplayName("test_list_all_definitions_filtered_by_namespaces")
     void test_list_all_definitions_filtered_by_namespaces() {
@@ -147,7 +147,7 @@ class SecurityOidcAbacIT {
     }
 
     @Test
-    @TestSecurity(user = "alice", roles = "flow-admin")
+    @TestSecurity(user = "alice", roles = "flow-invoker")
     @OidcSecurity(claims = { @Claim(key = "namespace", value = "test-namespace") })
     @DisplayName("test_get_specific_definition_with_namespace_validation")
     void test_get_specific_definition_with_namespace_validation() {
@@ -162,7 +162,7 @@ class SecurityOidcAbacIT {
     }
 
     @Test
-    @TestSecurity(user = "bob", roles = "flow-admin")
+    @TestSecurity(user = "bob", roles = "flow-invoker")
     @OidcSecurity(claims = { @Claim(key = "namespace", value = "team-a") })
     @DisplayName("test_get_specific_definition_unauthorized_namespace")
     void test_get_specific_definition_unauthorized_namespace() {
@@ -194,12 +194,60 @@ class SecurityOidcAbacIT {
 
     @Test
     @TestSecurity(user = "admin", roles = "flow-admin")
-    @OidcSecurity(claims = { @Claim(key = "namespace", value = "team-a") })
-    @DisplayName("test_admin_role_still_requires_namespace_authorization")
-    void test_admin_role_still_requires_namespace_authorization() {
-        // Even flow-admin role must respect namespace restrictions
+    @OidcSecurity
+    @DisplayName("test_oidc_admin_without_namespace_claim_allows_all_namespaces")
+    void test_oidc_admin_without_namespace_claim_allows_all_namespaces() {
+        given()
+                .queryParam("namespace", "test-namespace")
+                .when()
+                .get("/q/flow/definitions")
+                .then()
+                .statusCode(200);
 
-        // Admin can access team-a
+        given()
+                .queryParam("namespace", "another-namespace")
+                .when()
+                .get("/q/flow/definitions")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @TestSecurity(user = "bob", roles = "flow-invoker")
+    @OidcSecurity
+    @DisplayName("test_oidc_invoker_without_namespace_claim_is_denied")
+    void test_oidc_invoker_without_namespace_claim_is_denied() {
+        given()
+                .queryParam("namespace", "test-namespace")
+                .when()
+                .get("/q/flow/definitions")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @TestSecurity(user = "bob", roles = "flow-invoker")
+    @OidcSecurity(claims = {
+            @Claim(key = "namespace", value = "")
+    })
+    @DisplayName("test_oidc_invoker_with_blank_namespace_claim_is_denied")
+    void test_oidc_invoker_with_blank_namespace_claim_is_denied() {
+        given()
+                .queryParam("namespace", "test-namespace")
+                .when()
+                .get("/q/flow/definitions")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @TestSecurity(user = "admin", roles = "flow-admin")
+    @OidcSecurity(claims = {
+            @Claim(key = "namespace", value = "team-a")
+    })
+    @DisplayName("test_admin_role_bypasses_namespace_authorization")
+    void test_admin_role_bypasses_namespace_authorization() {
+        // Explicitly listed namespace.
         given()
                 .queryParam("namespace", "team-a")
                 .when()
@@ -207,13 +255,13 @@ class SecurityOidcAbacIT {
                 .then()
                 .statusCode(200);
 
-        // But admin cannot access test-namespace (not in their namespace claim)
+        // Namespace not listed in the claim is still allowed for admins.
         given()
                 .queryParam("namespace", "test-namespace")
                 .when()
                 .get("/q/flow/definitions")
                 .then()
-                .statusCode(403);
+                .statusCode(200);
     }
 
     @Test
@@ -239,7 +287,7 @@ class SecurityOidcAbacIT {
     }
 
     @Test
-    @TestSecurity(user = "alice", roles = "flow-admin")
+    @TestSecurity(user = "alice", roles = "flow-invoker")
     @OidcSecurity(claims = { @Claim(key = "namespace", value = "test-namespace") })
     @DisplayName("test_get_latest_definition_with_namespace_validation")
     void test_get_latest_definition_with_namespace_validation() {

--- a/runner/integration-tests/src/test/java/io/quarkiverse/flow/runner/it/SecurityOidcIT.java
+++ b/runner/integration-tests/src/test/java/io/quarkiverse/flow/runner/it/SecurityOidcIT.java
@@ -12,6 +12,8 @@ import io.quarkiverse.flow.runner.model.ExecutionResponse;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.oidc.Claim;
+import io.quarkus.test.security.oidc.OidcSecurity;
 import io.serverlessworkflow.impl.WorkflowStatus;
 
 /**
@@ -98,6 +100,7 @@ class SecurityOidcIT {
 
     @Test
     @TestSecurity(user = "bob", roles = "flow-invoker")
+    @OidcSecurity(claims = { @Claim(key = "namespace", value = "test-namespace") })
     @DisplayName("test_execute_workflow_with_invoker_role")
     void test_execute_workflow_with_invoker_role() {
         Map<String, Object> input = Map.of("name", "OIDC Invoker");
@@ -132,6 +135,7 @@ class SecurityOidcIT {
 
     @Test
     @TestSecurity(user = "bob", roles = "flow-invoker")
+    @OidcSecurity(claims = { @Claim(key = "namespace", value = "test-namespace") })
     @DisplayName("test_get_definition_yaml_with_valid_token")
     void test_get_definition_yaml_with_valid_token() {
         given()
@@ -191,6 +195,7 @@ class SecurityOidcIT {
 
     @Test
     @TestSecurity(user = "alice", roles = "flow-invoker")
+    @OidcSecurity(claims = { @Claim(key = "namespace", value = "test-namespace") })
     @DisplayName("test_execute_latest_workflow_version")
     void test_execute_latest_workflow_version() {
         Map<String, Object> input = Map.of("name", "Latest Version");

--- a/runner/runner/runtime/src/test/java/io/quarkiverse/flow/runner/security/NamespaceAuthorizationServiceTest.java
+++ b/runner/runner/runtime/src/test/java/io/quarkiverse/flow/runner/security/NamespaceAuthorizationServiceTest.java
@@ -1,0 +1,280 @@
+package io.quarkiverse.flow.runner.security;
+
+import static io.quarkiverse.flow.runner.security.AuthzConsts.CLAIM_NAMESPACES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkiverse.flow.runner.FlowRunnerConfig;
+import io.quarkus.security.identity.SecurityIdentity;
+
+@DisplayName("NamespaceAuthorizationService Unit Tests")
+class NamespaceAuthorizationServiceTest {
+
+    private NamespaceAuthorizationService service;
+    private FlowRunnerConfig config;
+    private FlowRunnerConfig.Security security;
+    private FlowRunnerConfig.Security.Namespace namespaceConfig;
+    private SecurityIdentity securityIdentity;
+    private ObjectMapper objectMapper;
+    private JsonWebToken jsonWebToken;
+
+    @BeforeEach
+    void setUp() {
+        service = new NamespaceAuthorizationService();
+        config = mock(FlowRunnerConfig.class);
+        security = mock(FlowRunnerConfig.Security.class);
+        namespaceConfig = mock(FlowRunnerConfig.Security.Namespace.class);
+        securityIdentity = mock(SecurityIdentity.class);
+        objectMapper = new ObjectMapper();
+        jsonWebToken = mock(JsonWebToken.class);
+
+        service.config = config;
+        service.securityIdentity = securityIdentity;
+        service.objectMapper = objectMapper;
+
+        when(config.security()).thenReturn(security);
+        when(security.namespace()).thenReturn(namespaceConfig);
+        when(namespaceConfig.claim()).thenReturn("namespace");
+    }
+
+    @Test
+    @DisplayName("test_get_authorized_namespaces_returns_null_when_no_attribute")
+    void test_get_authorized_namespaces_returns_null_when_no_attribute() {
+        // Given
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(null);
+        when(securityIdentity.getAttribute("namespace")).thenReturn(null);
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("test_get_authorized_namespaces_from_standard_claim")
+    void test_get_authorized_namespaces_from_standard_claim() {
+        // Given - Set attribute as API_KEY mechanism would
+        Set<String> namespaces = Set.of("team-a", "team-b");
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(namespaces);
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).containsExactlyInAnyOrder("team-a", "team-b");
+    }
+
+    @Test
+    @DisplayName("test_get_authorized_namespaces_from_configured_claim")
+    void test_get_authorized_namespaces_from_configured_claim() {
+        // Given - OIDC mode with custom claim name
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(null);
+        when(namespaceConfig.claim()).thenReturn("custom_namespaces");
+        List<String> namespaces = List.of("ns1", "ns2", "ns3");
+        when(securityIdentity.getAttribute("custom_namespaces")).thenReturn(namespaces);
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).containsExactlyInAnyOrder("ns1", "ns2", "ns3");
+    }
+
+    @Test
+    @DisplayName("test_convert_set_to_set")
+    void test_convert_set_to_set() {
+        // Given
+        Set<String> namespaces = Set.of("a", "b", "c");
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(namespaces);
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).isEqualTo(namespaces);
+    }
+
+    @Test
+    @DisplayName("test_convert_list_to_set")
+    void test_convert_list_to_set() {
+        // Given - From OIDC JWT array claim
+        List<String> namespaces = List.of("x", "y", "z");
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(namespaces);
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).containsExactlyInAnyOrder("x", "y", "z");
+    }
+
+    @Test
+    @DisplayName("test_convert_single_string_to_set")
+    void test_convert_single_string_to_set() {
+        // Given
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn("single-namespace");
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).containsExactly("single-namespace");
+    }
+
+    @Test
+    @DisplayName("test_convert_comma_separated_string_to_set")
+    void test_convert_comma_separated_string_to_set() {
+        // Given
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn("ns1,ns2,ns3");
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).containsExactlyInAnyOrder("ns1", "ns2", "ns3");
+    }
+
+    @Test
+    @DisplayName("test_convert_comma_separated_string_with_spaces_to_set")
+    void test_convert_comma_separated_string_with_spaces_to_set() {
+        // Given - Spaces should be trimmed
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn("ns1, ns2 , ns3");
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).containsExactlyInAnyOrder("ns1", "ns2", "ns3");
+    }
+
+    @Test
+    @DisplayName("test_convert_blank_string_returns_null")
+    void test_convert_blank_string_returns_null() {
+        // Given - Empty string means all namespaces allowed
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn("");
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("test_convert_whitespace_string_returns_null")
+    void test_convert_whitespace_string_returns_null() {
+        // Given
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn("   ");
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("test_convert_comma_separated_with_blank_entries_filters_them")
+    void test_convert_comma_separated_with_blank_entries_filters_them() {
+        // Given - Blank entries should be filtered out
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn("ns1,,ns2, ,ns3");
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).containsExactlyInAnyOrder("ns1", "ns2", "ns3");
+    }
+
+    @Test
+    @DisplayName("test_convert_other_object_type_to_set")
+    void test_convert_other_object_type_to_set() {
+        // Given - Fallback to toString()
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(42);
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).containsExactly("42");
+    }
+
+    @Test
+    @DisplayName("test_empty_set_attribute_returns_empty_set")
+    void test_empty_set_attribute_returns_empty_set() {
+        // Given
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(Set.of());
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("test_fallback_to_configured_claim_when_standard_claim_missing")
+    void test_fallback_to_configured_claim_when_standard_claim_missing() {
+        // Given
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(null);
+        when(namespaceConfig.claim()).thenReturn("app_namespaces");
+        when(securityIdentity.getAttribute("app_namespaces")).thenReturn(Set.of("app-ns"));
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).containsExactly("app-ns");
+    }
+
+    @Test
+    @DisplayName("test_standard_claim_takes_precedence_over_configured_claim")
+    void test_standard_claim_takes_precedence_over_configured_claim() {
+        // Given - Both present, standard should win
+        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(Set.of("standard-ns"));
+        when(namespaceConfig.claim()).thenReturn("custom_namespaces");
+        when(securityIdentity.getAttribute("custom_namespaces")).thenReturn(Set.of("custom-ns"));
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).containsExactly("standard-ns");
+    }
+
+    @Test
+    @DisplayName("test_convert_json_array_claim_to_set")
+    void test_convert_json_array_claim_to_set() {
+        // Given - OIDC JWT array claim can contain JsonString values
+        JsonArray namespaces = Json.createArrayBuilder()
+                .add("team-a")
+                .add("team-b")
+                .build();
+        when(securityIdentity.getAttribute(CLAIM_NAMESPACES)).thenReturn(null);
+        when(securityIdentity.getAttribute("namespace")).thenReturn(null);
+        when(securityIdentity.getPrincipal()).thenReturn(jsonWebToken);
+        doReturn(namespaces).when(jsonWebToken).getClaim("namespace");
+
+        // When
+        Set<String> result = service.getAuthorizedNamespaces();
+
+        // Then
+        assertThat(result).containsExactlyInAnyOrder("team-a", "team-b");
+    }
+}

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/FlowRunnerConfig.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/FlowRunnerConfig.java
@@ -28,11 +28,13 @@ import io.smallrye.config.WithDefault;
  * quarkus.flow.runner.security.type=api-key
  * quarkus.flow.runner.security.api-keys."invoker".secret=${FLOW_API_KEY}
  * quarkus.flow.runner.security.api-keys."invoker".roles=flow-invoker
+ * quarkus.flow.runner.security.api-keys."invoker".namespaces=*
  * </pre>
  *
  * @see <a href="https://github.com/quarkiverse/quarkus-flow/issues/52">Issue #52</a>
  * @see <a href="https://docs.quarkiverse.io/quarkus-flow/dev/">Quarkus Flow Documentation</a>
  */
+
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 @ConfigMapping(prefix = "quarkus.flow.runner")
 public interface FlowRunnerConfig {
@@ -141,19 +143,25 @@ public interface FlowRunnerConfig {
         /**
          * API Key definitions (only used when {@code type=API_KEY}).
          * <p>
-         * Each key is mapped to a set of roles. Example:
+         * Each key is mapped to roles and authorized namespaces. Example:
          *
          * <pre>
+         * # Administrators always have access to all namespaces
          * quarkus.flow.runner.security.api-keys."admin".secret=${ADMIN_KEY}
          * quarkus.flow.runner.security.api-keys."admin".roles=flow-admin
          *
+         * # Explicit unrestricted access for a non-admin key
          * quarkus.flow.runner.security.api-keys."invoker".secret=${INVOKER_KEY}
          * quarkus.flow.runner.security.api-keys."invoker".roles=flow-invoker
+         * quarkus.flow.runner.security.api-keys."invoker".namespaces=*
+         *
+         * # Restricted access
+         * quarkus.flow.runner.security.api-keys."team-a".secret=${TEAM_A_KEY}
+         * quarkus.flow.runner.security.api-keys."team-a".roles=flow-invoker
+         * quarkus.flow.runner.security.api-keys."team-a".namespaces=team-a
          * </pre>
          * <p>
-         * Clients send the secret in the {@code Authorization: Bearer <secret>} header.
-         * The key name (e.g., "admin", "invoker") is for configuration organization only
-         * and is not sent by clients.
+         * The {@code namespaces} property defaults to {@code "*"} when omitted.
          *
          * @return map of API key names to their configuration
          */
@@ -229,24 +237,15 @@ public interface FlowRunnerConfig {
             Set<String> roles();
 
             /**
-             * Namespaces allowed for this API key.
+             * Namespaces authorized for this API key.
              * <p>
-             * When not configured (empty), the key has access to all namespaces.
-             * When configured, the key can only access workflows in the specified namespaces.
-             * <p>
-             * Example:
+             * The value {@code "*"} grants access to all namespaces. When omitted, this
+             * property defaults to {@code "*"} for backward compatibility.
              *
-             * <pre>
-             * # Restrict to specific namespaces
-             * quarkus.flow.runner.security.api-keys."team-key".namespaces=team-a,team-b
-             *
-             * # Or leave empty for all namespaces (default)
-             * quarkus.flow.runner.security.api-keys."admin-key".roles=flow-admin
-             * </pre>
-             *
-             * @return optional set of authorized namespace names, empty means all namespaces allowed
+             * @return the configured authorized namespaces
              */
-            Optional<Set<String>> namespaces();
+            @WithDefault("*")
+            Set<String> namespaces();
         }
 
         /**
@@ -257,39 +256,54 @@ public interface FlowRunnerConfig {
          */
         interface Namespace {
             /**
-             * JWT claim name containing authorized namespace(s).
+             * JWT claim containing the namespaces authorized for the current identity.
              * <p>
              * Used when {@code type=OIDC}. The claim can contain:
              * <ul>
-             * <li>Single string value (e.g., {@code "my-namespace"})</li>
-             * <li>Array of strings (e.g., {@code ["ns1", "ns2"]})</li>
+             * <li>A single namespace, for example {@code "team-a"}</li>
+             * <li>An array of namespaces, for example
+             * {@code ["team-a", "team-b"]}</li>
+             * <li>A comma-separated string, for example
+             * {@code "team-a,team-b"}</li>
+             * <li>The exact value {@code "*"} to authorize all current and future
+             * namespaces</li>
              * </ul>
+             * <p>
+             * For a non-admin OIDC identity, a missing, null, empty, or blank claim grants
+             * no namespace access when namespace validation is enabled. Identities with
+             * the {@code flow-admin} role bypass namespace restrictions.
+             * <p>
+             * Namespace matching is exact and case-sensitive. Partial wildcard values
+             * such as {@code "team-*"} are not supported.
              * <p>
              * Example:
              *
              * <pre>
-             * quarkus.flow.runner.security.namespace.claim=namespace
-             * # or for multi-namespace support:
-             * quarkus.flow.runner.security.namespace.claim=namespaces
+             * quarkus.flow.runner.security.namespace.claim = namespace
              * </pre>
              *
-             * @return the JWT claim name (default: {@code "namespace"})
+             * @return the JWT claim name, defaulting to {@code "namespace"}
              */
             @WithDefault("namespace")
             String claim();
 
             /**
-             * Enable or disable namespace validation.
+             * Enables or disables namespace authorization.
              * <p>
-             * When {@code true}, requests are validated against the namespace in the
-             * request path and the user's authorized namespaces (from JWT claim or
-             * API key configuration).
+             * When enabled:
+             * <ul>
+             * <li>Identities with the {@code flow-admin} role can access all
+             * namespaces.</li>
+             * <li>The exact namespace value {@code "*"} authorizes all namespaces.</li>
+             * <li>Explicit namespace values authorize only those namespaces.</li>
+             * <li>A missing, null, empty, or blank namespace set grants no access to a
+             * non-admin identity.</li>
+             * </ul>
              * <p>
-             * When {@code false}, namespace validation is skipped (all users can
-             * access all namespaces). Use only in development.
+             * When disabled, namespace authorization is skipped and access is controlled
+             * only through role-based authorization.
              *
-             * @return {@code true} if namespace validation is enabled (default),
-             *         {@code false} to disable
+             * @return {@code true} when namespace validation is enabled
              */
             @WithDefault("true")
             boolean validate();

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/resources/DefinitionResource.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/resources/DefinitionResource.java
@@ -27,11 +27,13 @@ import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import io.quarkiverse.flow.internal.WorkflowVersionComparator;
+import io.quarkiverse.flow.runner.FlowRunnerConfig;
 import io.quarkiverse.flow.runner.model.WorkflowDefinitionHeader;
 import io.quarkiverse.flow.runner.model.WorkflowFormatUtils;
 import io.quarkiverse.flow.runner.security.AuthzConsts;
 import io.quarkiverse.flow.runner.security.FlowRunnerEndpoint;
 import io.quarkiverse.flow.runner.security.NamespaceAuthorizationService;
+import io.quarkus.security.identity.SecurityIdentity;
 import io.serverlessworkflow.api.WorkflowFormat;
 import io.serverlessworkflow.api.WorkflowWriter;
 import io.serverlessworkflow.api.types.Document;
@@ -51,6 +53,12 @@ public class DefinitionResource {
     @Inject
     NamespaceAuthorizationService namespaceAuth;
 
+    @Inject
+    FlowRunnerConfig config;
+
+    @Inject
+    SecurityIdentity securityIdentity;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "List workflow definitions", description = "Returns metadata for all registered workflow definitions. "
@@ -62,27 +70,41 @@ public class DefinitionResource {
     @APIResponse(responseCode = "401", description = "Authentication required - missing or invalid credentials")
     @APIResponse(responseCode = "403", description = "Access denied to requested namespace (when namespace query parameter is provided)")
     public Response listDefinitions(
-            @Parameter(description = "Filter workflows by specific namespace (optional). " +
-                    "If provided and namespace validation is enabled, user must have access to this namespace. " +
-                    "If omitted, returns workflows from all authorized namespaces.") @QueryParam("namespace") String namespace) {
+            @Parameter(description = "Filter workflows by specific namespace (optional). "
+                    + "If provided and namespace validation is enabled, user must have access to this namespace. "
+                    + "If omitted, returns workflows from all authorized namespaces.") @QueryParam("namespace") String namespace) {
+
         Stream<WorkflowDefinition> definitions = application.workflowDefinitions().values().stream();
 
-        if (namespace != null) {
-            // Specific filter for the required namespace
-            // our ContainerFilter should block access to the method if user doesn't have access to it
-            definitions = definitions.filter(def -> namespace.equals(def.workflow().getDocument().getNamespace()));
-        } else {
-            // Filter by namespaces that our user has access
+        if (namespace != null && !namespace.isBlank()) {
+            // Access to this namespace is validated by NamespaceAuthorizationFilter.
+            definitions = definitions.filter(
+                    definition -> namespace.equals(
+                            definition.workflow()
+                                    .getDocument()
+                                    .getNamespace()));
+        } else if (config.security().namespace().validate()
+                && !securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN)) {
+
             Set<String> authorizedNamespaces = namespaceAuth.getAuthorizedNamespaces();
-            if (authorizedNamespaces != null && !authorizedNamespaces.isEmpty()) {
-                definitions = definitions
-                        .filter(def -> authorizedNamespaces.contains(def.workflow().getDocument().getNamespace()));
+
+            if (authorizedNamespaces == null
+                    || authorizedNamespaces.isEmpty()) {
+                definitions = Stream.empty();
+            } else if (!authorizedNamespaces.contains("*")) {
+                definitions = definitions.filter(
+                        definition -> authorizedNamespaces.contains(
+                                definition.workflow()
+                                        .getDocument()
+                                        .getNamespace()));
             }
         }
 
-        return Response.ok(definitions
-                .map(definition -> WorkflowDefinitionHeader.from(definition.workflow()))
-                .toList())
+        return Response.ok(
+                definitions
+                        .map(definition -> WorkflowDefinitionHeader.from(
+                                definition.workflow()))
+                        .toList())
                 .build();
     }
 

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/security/ApiKeyAuthenticationMechanism.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/security/ApiKeyAuthenticationMechanism.java
@@ -10,7 +10,6 @@ import java.util.stream.Collectors;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 
@@ -25,10 +24,25 @@ import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
+/**
+ * Authenticates requests using configured API keys.
+ * <p>
+ * Each API key is mapped to a principal, a set of roles, and a normalized set
+ * of authorized namespaces. The namespace configuration is propagated to the
+ * resulting {@link SecurityIdentity} through the
+ * {@link AuthzConsts#CLAIM_NAMESPACES} attribute.
+ * <p>
+ * Namespace values are normalized by trimming surrounding whitespace and
+ * removing null or blank entries. Consequently, values such as {@code " * "}
+ * are normalized to the exact wildcard value {@code "*"}.
+ * <p>
+ * This authentication mechanism does not make namespace authorization
+ * decisions. The exact value {@code "*"} and explicit namespace values are
+ * interpreted by the namespace authorization layer.
+ */
 @ApplicationScoped
 @Unremovable
 @Priority(Priorities.AUTHENTICATION)
-@Alternative
 public class ApiKeyAuthenticationMechanism implements HttpAuthenticationMechanism {
 
     @Inject
@@ -72,26 +86,21 @@ public class ApiKeyAuthenticationMechanism implements HttpAuthenticationMechanis
 
         if (matchingKey.isPresent()) {
             String keyName = matchingKey.get().getKey();
-            Set<String> roles = matchingKey.get().getValue().roles();
-            Optional<Set<String>> namespacesOpt = matchingKey.get().getValue().namespaces();
 
-            // Build security identity with principal name and roles
+            FlowRunnerConfig.Security.ApiKey apiKeyConfig = matchingKey.get().getValue();
+
+            Set<String> roles = apiKeyConfig.roles();
+            Set<String> namespaces = normalizeNamespaces(apiKeyConfig.namespaces());
+
+            // Build security identity with principal name and roles.
             QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder()
                     .setPrincipal(() -> "api-key:" + keyName);
+
             roles.forEach(builder::addRole);
 
-            // Add namespaces attribute if configured
-            namespacesOpt.ifPresent(namespaces -> {
-                if (!namespaces.isEmpty()) {
-                    Set<String> nonBlankNs = namespaces.stream()
-                            .filter(Objects::nonNull)
-                            .filter(ns -> !ns.isBlank())
-                            .collect(Collectors.toSet());
-                    if (!nonBlankNs.isEmpty()) {
-                        builder.addAttribute(CLAIM_NAMESPACES, nonBlankNs);
-                    }
-                }
-            });
+            // Always propagate the normalized namespace set, including an empty set.
+            // The namespace authorization layer interprets "*" and enforces access.
+            builder.addAttribute(CLAIM_NAMESPACES, namespaces);
 
             return Uni.createFrom().item(builder.build());
         }
@@ -109,4 +118,31 @@ public class ApiKeyAuthenticationMechanism implements HttpAuthenticationMechanis
         return Uni.createFrom().item(new ChallengeData(401, "Bearer", "Invalid or missing API Key"));
     }
 
+    /**
+     * Normalizes the namespace values configured for an API key.
+     * <p>
+     * Null and blank entries are removed, and surrounding whitespace is trimmed.
+     * An absent or empty namespace set is normalized to an empty set. The exact
+     * wildcard value {@code "*"} is preserved; values such as {@code " * "} are
+     * normalized to {@code "*"}.
+     * <p>
+     * This method does not interpret namespace permissions. In particular, it
+     * does not implement wildcard matching. The normalized values are propagated
+     * to the {@link SecurityIdentity}, and the authorization layer determines
+     * whether a namespace is allowed.
+     *
+     * @param namespaces the configured namespace values
+     * @return an immutable, normalized namespace set
+     */
+    private Set<String> normalizeNamespaces(Set<String> namespaces) {
+        if (namespaces == null || namespaces.isEmpty()) {
+            return Set.of();
+        }
+
+        return namespaces.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(namespace -> !namespace.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
+    }
 }

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/security/AuthzConsts.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/security/AuthzConsts.java
@@ -6,6 +6,7 @@ public final class AuthzConsts {
     public static final String ROLE_INVOKER = "flow-invoker";
     public static final String USER_ANONYMOUS = "anonymous";
     public static final String CLAIM_NAMESPACES = "namespaces";
+    public static final String ALL_NAMESPACES = "*";
 
     private AuthzConsts() {
     }

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/security/NamespaceAuthorizationFilter.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/security/NamespaceAuthorizationFilter.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.flow.runner.security;
 
+import static io.quarkiverse.flow.runner.security.AuthzConsts.ALL_NAMESPACES;
+
 import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -11,6 +13,7 @@ import org.jboss.resteasy.reactive.server.ServerRequestFilter;
 
 import io.quarkiverse.flow.runner.FlowRunnerConfig;
 import io.quarkus.arc.Unremovable;
+import io.quarkus.security.identity.SecurityIdentity;
 
 /**
  * Modern RESTEasy Reactive filter that enforces namespace-level authorization (ABAC).
@@ -28,12 +31,13 @@ import io.quarkus.arc.Unremovable;
  * the filter allows the request through and the resource method handles filtering
  * by authorized namespaces.
  * <p>
- * Authorized namespaces are extracted from {@link io.quarkus.security.identity.SecurityIdentity} attributes
- * set by authentication mechanisms during login. An empty or null namespace set
- * means the user has access to all namespaces.
+ * Authorized namespaces are extracted from {@link SecurityIdentity} attributes
+ * set by the active authentication mechanism.
  * <p>
- * <strong>Implementation Note:</strong> Uses {@code @ServerRequestFilter} (RESTEasy Reactive modern approach)
- * instead of the legacy {@code ContainerRequestFilter} interface.
+ * For non-admin identities, a null, empty, or blank namespace set grants no
+ * namespace access. The normalized value {@code "*"} grants access to all
+ * current and future namespaces. Identities with the {@code flow-admin} role
+ * bypass namespace authorization.
  *
  * @see NamespaceAuthorizationService
  */
@@ -50,6 +54,9 @@ public class NamespaceAuthorizationFilter {
 
     @Inject
     UriInfo uriInfo;
+
+    @Inject
+    SecurityIdentity securityIdentity;
 
     /**
      * Server request filter method that validates namespace access.
@@ -79,26 +86,73 @@ public class NamespaceAuthorizationFilter {
      * <p>
      * Authorization logic:
      * <ul>
-     * <li>If authorized namespaces is null or empty → all namespaces allowed (pass)</li>
-     * <li>If namespace is in authorized set → allowed (pass)</li>
-     * <li>Otherwise → denied (throws 403 Forbidden)</li>
+     * <li>If the identity has the {@code flow-admin} role, all namespaces are
+     * allowed.</li>
+     * <li>If the authorized namespace set is null, empty, or contains only blank
+     * values, access is denied.</li>
+     * <li>If the authorized namespace set contains the exact value {@code "*"},
+     * all namespaces are allowed.</li>
+     * <li>If the authorized namespace set contains the requested namespace,
+     * access is allowed.</li>
+     * <li>Otherwise, access is denied with {@code 403 Forbidden}.</li>
      * </ul>
+     * <p>
+     * Namespace matching is exact and case-sensitive. Values such as
+     * {@code "team-*"}, {@code "my*"}, or {@code "**"} are not wildcard
+     * expressions.
      *
      * @param namespace the namespace to validate access for
-     * @throws ForbiddenException if user does not have access to the namespace
+     * @throws ForbiddenException if the current user is not authorized for the
+     *         namespace
      */
     private void validateNamespaceAccess(String namespace) {
-        Set<String> authorizedNamespaces = namespaceAuthzService.getAuthorizedNamespaces();
-
-        // Empty or null = all namespaces allowed
-        if (authorizedNamespaces == null || authorizedNamespaces.isEmpty()) {
+        // Admin bypass applies to every authentication mechanism.
+        if (securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN)) {
             return;
         }
 
-        // Check specific namespace
-        if (!authorizedNamespaces.contains(namespace)) {
-            throw new ForbiddenException("Access denied to namespace: " + namespace);
+        Set<String> authorizedNamespaces = namespaceAuthzService.getAuthorizedNamespaces();
+
+        if (hasNoAuthorizedNamespaces(authorizedNamespaces)) {
+            throw new ForbiddenException(
+                    "The authenticated identity has no authorized namespaces");
         }
+
+        if (authorizedNamespaces.contains(ALL_NAMESPACES)
+                || authorizedNamespaces.contains(namespace)) {
+            return;
+        }
+
+        throw new ForbiddenException(
+                "The authenticated identity is not authorized for namespace: "
+                        + namespace);
+    }
+
+    /**
+     * Determines whether the authorized namespace set grants no namespace access.
+     * <p>
+     * A namespace set grants no access when it is:
+     * <ul>
+     * <li>{@code null}</li>
+     * <li>Empty</li>
+     * <li>Composed only of {@code null}, empty, or blank values</li>
+     * </ul>
+     * <p>
+     * This helper does not evaluate roles. The caller must apply the
+     * {@code flow-admin} bypass before calling this method.
+     *
+     * @param authorizedNamespaces the configured namespaces for the current
+     *        identity, or {@code null} when none are available
+     * @return {@code true} when no non-blank authorized namespace is present;
+     *         otherwise {@code false}
+     */
+    private boolean hasNoAuthorizedNamespaces(
+            Set<String> authorizedNamespaces) {
+
+        return authorizedNamespaces == null
+                || authorizedNamespaces.isEmpty()
+                || authorizedNamespaces.stream()
+                        .allMatch(namespace -> namespace == null || namespace.isBlank());
     }
 
     /**

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/security/NamespaceAuthorizationService.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/security/NamespaceAuthorizationService.java
@@ -4,13 +4,15 @@ import static io.quarkiverse.flow.runner.security.AuthzConsts.CLAIM_NAMESPACES;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
@@ -92,7 +94,7 @@ public class NamespaceAuthorizationService {
         }
 
         if (attr == null) {
-            return null; // All namespaces allowed
+            return Set.of();
         }
 
         return convertToSet(attr);
@@ -137,35 +139,94 @@ public class NamespaceAuthorizationService {
      */
     @SuppressWarnings("unchecked")
     private Set<String> convertToSet(Object attr) {
-        if (attr instanceof Set) {
-            return (Set<String>) attr;
-        } else if (attr instanceof Collection) {
-            return new HashSet<>((Collection<String>) attr);
-        } else if (attr instanceof String ns) {
-            // Handle JSON array string: ["ns1","ns2"] or ["ns1", "ns2"]
-            if (ns.startsWith("[") && ns.endsWith("]")) {
+        if (attr instanceof Collection<?> collection) {
+            return collection.stream()
+                    .map(this::normalizeNamespaceValue)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toUnmodifiableSet());
+        }
+
+        if (attr instanceof JsonNode jsonNode) {
+            if (jsonNode.isNull() || jsonNode.isMissingNode()) {
+                return Set.of();
+            }
+
+            if (jsonNode.isArray()) {
+                return StreamSupport.stream(jsonNode.spliterator(), false)
+                        .map(this::normalizeNamespaceValue)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toUnmodifiableSet());
+            }
+
+            String value = normalizeNamespaceValue(jsonNode);
+            return value == null ? Set.of() : Set.of(value);
+        }
+
+        if (attr instanceof String rawValue) {
+            String value = rawValue.trim();
+
+            if (value.isEmpty()) {
+                return Set.of();
+            }
+
+            // JSON array represented as a string.
+            if (value.startsWith("[") && value.endsWith("]")) {
                 try {
-                    JsonNode jsonNode = objectMapper.readTree(ns);
+                    JsonNode jsonNode = objectMapper.readTree(value);
+
                     if (jsonNode.isArray()) {
-                        return StreamSupport.stream(jsonNode.spliterator(), false)
-                                .map(JsonNode::asText)
-                                .filter(s -> !s.isBlank())
-                                .collect(Collectors.toSet());
+                        return StreamSupport.stream(
+                                jsonNode.spliterator(),
+                                false)
+                                .map(this::normalizeNamespaceValue)
+                                .filter(Objects::nonNull)
+                                .collect(Collectors.toUnmodifiableSet());
                     }
-                } catch (Exception e) {
-                    // Not valid JSON, fall through to other parsing strategies
+                } catch (Exception ignored) {
+                    // Not valid JSON; continue with the other formats.
                 }
             }
-            // Handle comma-separated string: ns1,ns2
-            if (ns.contains(",")) {
-                return Arrays.stream(ns.split(","))
+
+            if (value.contains(",")) {
+                return Arrays.stream(value.split(","))
                         .map(String::trim)
-                        .filter(s -> !s.isBlank())
-                        .collect(Collectors.toSet());
+                        .filter(namespace -> !namespace.isEmpty())
+                        .collect(Collectors.toUnmodifiableSet());
             }
-            return ns.isBlank() ? null : Set.of(ns);
+
+            return Set.of(value);
         }
-        return Set.of(attr.toString());
+
+        String value = normalizeNamespaceValue(attr);
+        return value == null ? Set.of() : Set.of(value);
     }
 
+    private String claimValueAsString(Object value) {
+        if (value == null || value == JsonValue.NULL) {
+            return null;
+        }
+
+        if (value instanceof JsonString jsonString) {
+            return jsonString.getString();
+        }
+
+        if (value instanceof JsonNode jsonNode) {
+            return jsonNode.isNull() || jsonNode.isMissingNode()
+                    ? null
+                    : jsonNode.asText();
+        }
+
+        return value.toString();
+    }
+
+    private String normalizeNamespaceValue(Object value) {
+        String namespace = claimValueAsString(value);
+
+        if (namespace == null) {
+            return null;
+        }
+
+        namespace = namespace.trim();
+        return namespace.isEmpty() ? null : namespace;
+    }
 }

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/security/PermitAllAuthenticationMechanism.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/security/PermitAllAuthenticationMechanism.java
@@ -2,7 +2,6 @@ package io.quarkiverse.flow.runner.security;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 
@@ -17,7 +16,6 @@ import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
-@Alternative
 @Priority(Priorities.AUTHENTICATION)
 @ApplicationScoped
 @Unremovable

--- a/runner/runtime/src/test/java/io/quarkiverse/flow/runner/resources/DefinitionResourceTest.java
+++ b/runner/runtime/src/test/java/io/quarkiverse/flow/runner/resources/DefinitionResourceTest.java
@@ -2,6 +2,8 @@ package io.quarkiverse.flow.runner.resources;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -16,8 +18,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.flow.runner.FlowRunnerConfig;
 import io.quarkiverse.flow.runner.model.WorkflowDefinitionHeader;
+import io.quarkiverse.flow.runner.security.AuthzConsts;
 import io.quarkiverse.flow.runner.security.NamespaceAuthorizationService;
+import io.quarkus.security.identity.SecurityIdentity;
 import io.serverlessworkflow.api.types.Document;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.api.types.WorkflowMetadata;
@@ -32,19 +37,50 @@ class DefinitionResourceTest {
     private WorkflowApplication mockApplication;
     private HttpHeaders mockHeaders;
     private NamespaceAuthorizationService mockNamespaceAuth;
+    private FlowRunnerConfig config;
+    private FlowRunnerConfig.Security securityConfig;
+    private FlowRunnerConfig.Security.Namespace namespaceConfig;
+    private SecurityIdentity securityIdentity;
 
     @BeforeEach
     void setUp() {
         resource = new DefinitionResource();
+
         mockApplication = mock(WorkflowApplication.class);
         mockHeaders = mock(HttpHeaders.class);
         mockNamespaceAuth = mock(NamespaceAuthorizationService.class);
 
+        config = mock(FlowRunnerConfig.class);
+        securityConfig = mock(FlowRunnerConfig.Security.class);
+        namespaceConfig = mock(FlowRunnerConfig.Security.Namespace.class);
+        securityIdentity = mock(SecurityIdentity.class);
+
         resource.application = mockApplication;
         resource.namespaceAuth = mockNamespaceAuth;
+        resource.config = config;
+        resource.securityIdentity = securityIdentity;
 
-        // Default: return null (all namespaces allowed) unless test overrides
-        when(mockNamespaceAuth.getAuthorizedNamespaces()).thenReturn(null);
+        when(config.security()).thenReturn(securityConfig);
+        when(securityConfig.namespace()).thenReturn(namespaceConfig);
+        when(namespaceConfig.validate()).thenReturn(true);
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(false);
+
+        // Default authorization for tests not specifically testing restrictions.
+        when(mockNamespaceAuth.getAuthorizedNamespaces())
+                .thenReturn(Set.of("*"));
+
+        WorkflowDefinition examplesDefinition = createMockDefinition("examples", "greeting", "1.0.0");
+
+        WorkflowDefinition teamDefinition = createMockDefinition("team-a", "order-processing", "1.0.0");
+
+        when(mockApplication.workflowDefinitions()).thenReturn(Map.of(
+                new WorkflowDefinitionId(
+                        "examples", "greeting", "1.0.0"),
+                examplesDefinition,
+                new WorkflowDefinitionId(
+                        "team-a", "order-processing", "1.0.0"),
+                teamDefinition));
     }
 
     @Test
@@ -52,6 +88,8 @@ class DefinitionResourceTest {
     void test_list_definitions_returns_empty_list_when_no_workflows() {
         // Given
         when(mockApplication.workflowDefinitions()).thenReturn(Map.of());
+        when(mockNamespaceAuth.getAuthorizedNamespaces())
+                .thenReturn(Set.of("*"));
 
         // When
         Response response = resource.listDefinitions(null);
@@ -65,24 +103,72 @@ class DefinitionResourceTest {
     @Test
     @DisplayName("test_list_definitions_returns_all_workflows_when_no_namespace_filter")
     void test_list_definitions_returns_all_workflows_when_no_namespace_filter() {
-        // Given
-        WorkflowDefinition def1 = createMockDefinition("ns1", "wf1", "1.0.0");
-        WorkflowDefinition def2 = createMockDefinition("ns2", "wf2", "2.0.0");
+        when(mockNamespaceAuth.getAuthorizedNamespaces())
+                .thenReturn(Set.of("*"));
 
-        when(mockApplication.workflowDefinitions()).thenReturn(Map.of(
-                new WorkflowDefinitionId("ns1", "wf1", "1.0.0"), def1,
-                new WorkflowDefinitionId("ns2", "wf2", "2.0.0"), def2));
-
-        // When
         Response response = resource.listDefinitions(null);
 
-        // Then
         assertThat(response.getStatus()).isEqualTo(200);
+
         @SuppressWarnings("unchecked")
-        List<WorkflowDefinitionHeader> headers = (List<WorkflowDefinitionHeader>) response.getEntity();
-        assertThat(headers).hasSize(2);
-        assertThat(headers).extracting(WorkflowDefinitionHeader::namespace)
-                .containsExactlyInAnyOrder("ns1", "ns2");
+        List<WorkflowDefinitionHeader> definitions = (List<WorkflowDefinitionHeader>) response.getEntity();
+
+        assertThat(definitions).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("test_list_definitions_returns_all_for_wildcard_namespace")
+    void test_list_definitions_returns_all_for_wildcard_namespace() {
+        when(mockNamespaceAuth.getAuthorizedNamespaces())
+                .thenReturn(Set.of("*"));
+
+        Response response = resource.listDefinitions(null);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        @SuppressWarnings("unchecked")
+        List<WorkflowDefinitionHeader> definitions = (List<WorkflowDefinitionHeader>) response.getEntity();
+
+        assertThat(definitions)
+                .extracting(WorkflowDefinitionHeader::namespace)
+                .containsExactlyInAnyOrder("examples", "team-a");
+    }
+
+    @Test
+    @DisplayName("test_list_definitions_returns_all_for_admin")
+    void test_list_definitions_returns_all_for_admin() {
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(true);
+
+        Response response = resource.listDefinitions(null);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        @SuppressWarnings("unchecked")
+        List<WorkflowDefinitionHeader> definitions = (List<WorkflowDefinitionHeader>) response.getEntity();
+
+        assertThat(definitions).hasSize(2);
+
+        verify(mockNamespaceAuth, never())
+                .getAuthorizedNamespaces();
+    }
+
+    @Test
+    @DisplayName("test_list_definitions_returns_all_when_namespace_validation_is_disabled")
+    void test_list_definitions_returns_all_when_namespace_validation_is_disabled() {
+        when(namespaceConfig.validate()).thenReturn(false);
+
+        Response response = resource.listDefinitions(null);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        @SuppressWarnings("unchecked")
+        List<WorkflowDefinitionHeader> definitions = (List<WorkflowDefinitionHeader>) response.getEntity();
+
+        assertThat(definitions).hasSize(2);
+
+        verify(mockNamespaceAuth, never())
+                .getAuthorizedNamespaces();
     }
 
     @Test
@@ -123,6 +209,8 @@ class DefinitionResourceTest {
 
         when(mockApplication.workflowDefinitions())
                 .thenReturn(Map.of(new WorkflowDefinitionId("test-ns", "test-wf", "1.5.0"), def));
+        when(mockNamespaceAuth.getAuthorizedNamespaces())
+                .thenReturn(Set.of("*"));
 
         // When
         Response response = resource.listDefinitions(null);
@@ -296,51 +384,35 @@ class DefinitionResourceTest {
     }
 
     @Test
-    @DisplayName("test_list_definitions_returns_all_when_authorized_namespaces_is_null")
-    void test_list_definitions_returns_all_when_authorized_namespaces_is_null() {
-        // Given - null means all namespaces allowed
-        WorkflowDefinition def1 = createMockDefinition("ns1", "wf1", "1.0.0");
-        WorkflowDefinition def2 = createMockDefinition("ns2", "wf2", "2.0.0");
-        WorkflowDefinition def3 = createMockDefinition("ns3", "wf3", "1.0.0");
+    @DisplayName("test_list_definitions_returns_empty_when_authorized_namespaces_is_null")
+    void test_list_definitions_returns_empty_when_authorized_namespaces_is_null() {
+        when(mockNamespaceAuth.getAuthorizedNamespaces())
+                .thenReturn(null);
 
-        when(mockApplication.workflowDefinitions()).thenReturn(Map.of(
-                new WorkflowDefinitionId("ns1", "wf1", "1.0.0"), def1,
-                new WorkflowDefinitionId("ns2", "wf2", "2.0.0"), def2,
-                new WorkflowDefinitionId("ns3", "wf3", "1.0.0"), def3));
-
-        when(mockNamespaceAuth.getAuthorizedNamespaces()).thenReturn(null);
-
-        // When
         Response response = resource.listDefinitions(null);
 
-        // Then - Should return all workflows
         assertThat(response.getStatus()).isEqualTo(200);
+
         @SuppressWarnings("unchecked")
-        List<WorkflowDefinitionHeader> headers = (List<WorkflowDefinitionHeader>) response.getEntity();
-        assertThat(headers).hasSize(3);
+        List<WorkflowDefinitionHeader> definitions = (List<WorkflowDefinitionHeader>) response.getEntity();
+
+        assertThat(definitions).isEmpty();
     }
 
     @Test
-    @DisplayName("test_list_definitions_returns_all_when_authorized_namespaces_is_empty")
-    void test_list_definitions_returns_all_when_authorized_namespaces_is_empty() {
-        // Given - empty set means all namespaces allowed
-        WorkflowDefinition def1 = createMockDefinition("ns1", "wf1", "1.0.0");
-        WorkflowDefinition def2 = createMockDefinition("ns2", "wf2", "2.0.0");
+    @DisplayName("test_list_definitions_returns_empty_when_authorized_namespaces_is_empty")
+    void test_list_definitions_returns_empty_when_authorized_namespaces_is_empty() {
+        when(mockNamespaceAuth.getAuthorizedNamespaces())
+                .thenReturn(Set.of());
 
-        when(mockApplication.workflowDefinitions()).thenReturn(Map.of(
-                new WorkflowDefinitionId("ns1", "wf1", "1.0.0"), def1,
-                new WorkflowDefinitionId("ns2", "wf2", "2.0.0"), def2));
-
-        when(mockNamespaceAuth.getAuthorizedNamespaces()).thenReturn(Set.of());
-
-        // When
         Response response = resource.listDefinitions(null);
 
-        // Then - Should return all workflows
         assertThat(response.getStatus()).isEqualTo(200);
+
         @SuppressWarnings("unchecked")
-        List<WorkflowDefinitionHeader> headers = (List<WorkflowDefinitionHeader>) response.getEntity();
-        assertThat(headers).hasSize(2);
+        List<WorkflowDefinitionHeader> definitions = (List<WorkflowDefinitionHeader>) response.getEntity();
+
+        assertThat(definitions).isEmpty();
     }
 
     @Test

--- a/runner/runtime/src/test/java/io/quarkiverse/flow/runner/security/AuthenticationMechanismRegistrationTest.java
+++ b/runner/runtime/src/test/java/io/quarkiverse/flow/runner/security/AuthenticationMechanismRegistrationTest.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.flow.runner.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Alternative;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Authentication mechanism registration tests")
+class AuthenticationMechanismRegistrationTest {
+
+    private static final int RUNNER_MECHANISM_PRIORITY = 1000;
+
+    @Test
+    @DisplayName("API key mechanism must not replace built-in mechanisms")
+    void apiKeyMechanismMustNotBeAlternative() {
+        assertIsNonAlternativeRunnerMechanism(
+                ApiKeyAuthenticationMechanism.class);
+    }
+
+    @Test
+    @DisplayName("Permit-all mechanism must not replace built-in mechanisms")
+    void permitAllMechanismMustNotBeAlternative() {
+        assertIsNonAlternativeRunnerMechanism(
+                PermitAllAuthenticationMechanism.class);
+    }
+
+    private void assertIsNonAlternativeRunnerMechanism(Class<?> mechanismClass) {
+        assertThat(
+                mechanismClass.isAnnotationPresent(Alternative.class))
+                .as("%s must not be a CDI alternative",
+                        mechanismClass.getSimpleName())
+                .isFalse();
+
+        Priority priority = mechanismClass.getAnnotation(Priority.class);
+
+        assertThat(priority)
+                .as("%s must declare an authentication priority",
+                        mechanismClass.getSimpleName())
+                .isNotNull();
+
+        assertThat(priority.value())
+                .as("%s priority", mechanismClass.getSimpleName())
+                .isEqualTo(RUNNER_MECHANISM_PRIORITY);
+    }
+}

--- a/runner/runtime/src/test/java/io/quarkiverse/flow/runner/security/NamespaceAuthorizationFilterTest.java
+++ b/runner/runtime/src/test/java/io/quarkiverse/flow/runner/security/NamespaceAuthorizationFilterTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.security.Principal;
 import java.util.Set;
 
 import jakarta.ws.rs.ForbiddenException;
@@ -14,11 +15,15 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.UriInfo;
 
+import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.quarkiverse.flow.runner.FlowRunnerConfig;
+import io.quarkus.security.identity.SecurityIdentity;
 
 /**
  * Unit tests for {@link NamespaceAuthorizationFilter}.
@@ -36,19 +41,25 @@ class NamespaceAuthorizationFilterTest {
     private FlowRunnerConfig.Security.Namespace namespaceConfig;
     private NamespaceAuthorizationService namespaceAuthzService;
     private UriInfo uriInfo;
+    private SecurityIdentity securityIdentity;
+    private JsonWebToken jsonWebToken;
 
     @BeforeEach
     void setUp() {
         filter = new NamespaceAuthorizationFilter();
+
         config = mock(FlowRunnerConfig.class);
         security = mock(FlowRunnerConfig.Security.class);
         namespaceConfig = mock(FlowRunnerConfig.Security.Namespace.class);
         namespaceAuthzService = mock(NamespaceAuthorizationService.class);
         uriInfo = mock(UriInfo.class);
+        securityIdentity = mock(SecurityIdentity.class);
+        jsonWebToken = mock(JsonWebToken.class);
 
         filter.config = config;
         filter.namespaceAuthzService = namespaceAuthzService;
         filter.uriInfo = uriInfo;
+        filter.securityIdentity = securityIdentity;
 
         when(config.security()).thenReturn(security);
         when(security.namespace()).thenReturn(namespaceConfig);
@@ -56,7 +67,7 @@ class NamespaceAuthorizationFilterTest {
 
     @Test
     @DisplayName("test_filter_skips_when_validation_disabled")
-    void test_filter_skips_when_validation_disabled() throws Exception {
+    void test_filter_skips_when_validation_disabled() {
         // Given
         when(namespaceConfig.validate()).thenReturn(false);
 
@@ -69,11 +80,13 @@ class NamespaceAuthorizationFilterTest {
 
     @Test
     @DisplayName("test_filter_skips_when_no_namespace_in_request")
-    void test_filter_skips_when_no_namespace_in_request() throws Exception {
+    void test_filter_skips_when_no_namespace_in_request() {
         // Given
         when(namespaceConfig.validate()).thenReturn(true);
+
         MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
         when(uriInfo.getPathParameters()).thenReturn(pathParams);
         when(uriInfo.getQueryParameters()).thenReturn(queryParams);
 
@@ -85,188 +98,432 @@ class NamespaceAuthorizationFilterTest {
     }
 
     @Test
-    @DisplayName("test_filter_allows_when_authorized_namespaces_is_null")
-    void test_filter_allows_when_authorized_namespaces_is_null() throws Exception {
-        // Given
+    @DisplayName("test_filter_denies_when_authorized_namespaces_is_null")
+    void test_filter_denies_when_authorized_namespaces_is_null() {
         when(namespaceConfig.validate()).thenReturn(true);
-        MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
-        pathParams.putSingle("namespace", "team-a");
-        when(uriInfo.getPathParameters()).thenReturn(pathParams);
-        when(namespaceAuthzService.getAuthorizedNamespaces()).thenReturn(null);
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(false);
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(null);
 
-        // When/Then
-        assertThatCode(() -> filter.filter()).doesNotThrowAnyException();
+        setPathNamespace("team-a");
+
+        assertThatThrownBy(filter::filter)
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage(
+                        "The authenticated identity has no authorized namespaces");
     }
 
     @Test
-    @DisplayName("test_filter_allows_when_authorized_namespaces_is_empty")
-    void test_filter_allows_when_authorized_namespaces_is_empty() throws Exception {
-        // Given
+    @DisplayName("test_filter_denies_when_authorized_namespaces_is_empty")
+    void test_filter_denies_when_authorized_namespaces_is_empty() {
         when(namespaceConfig.validate()).thenReturn(true);
-        MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
-        pathParams.putSingle("namespace", "team-a");
-        when(uriInfo.getPathParameters()).thenReturn(pathParams);
-        when(namespaceAuthzService.getAuthorizedNamespaces()).thenReturn(Set.of());
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(false);
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of());
 
-        // When/Then
-        assertThatCode(() -> filter.filter()).doesNotThrowAnyException();
+        setPathNamespace("team-a");
+
+        assertThatThrownBy(filter::filter)
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage(
+                        "The authenticated identity has no authorized namespaces");
     }
 
     @Test
-    @DisplayName("test_filter_allows_when_namespace_in_authorized_set")
-    void test_filter_allows_when_namespace_in_authorized_set() throws Exception {
-        // Given
-        when(namespaceConfig.validate()).thenReturn(true);
-        MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
-        pathParams.putSingle("namespace", "team-a");
-        when(uriInfo.getPathParameters()).thenReturn(pathParams);
-        when(namespaceAuthzService.getAuthorizedNamespaces()).thenReturn(Set.of("team-a", "team-b"));
+    @DisplayName("test_filter_denies_api_key_identity_with_empty_namespaces")
+    void test_filter_denies_api_key_identity_with_empty_namespaces() {
+        Principal apiKeyPrincipal = mock(Principal.class);
 
-        // When/Then
-        assertThatCode(() -> filter.filter()).doesNotThrowAnyException();
+        when(namespaceConfig.validate()).thenReturn(true);
+        when(securityIdentity.getPrincipal()).thenReturn(apiKeyPrincipal);
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(false);
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of());
+
+        setPathNamespace("team-a");
+
+        assertThatThrownBy(filter::filter)
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("no authorized namespaces");
     }
 
     @Test
-    @DisplayName("test_filter_denies_when_namespace_not_in_authorized_set")
-    void test_filter_denies_when_namespace_not_in_authorized_set() throws Exception {
+    @DisplayName("test_filter_rejects_oidc_invoker_without_namespace_claim")
+    void test_filter_rejects_oidc_invoker_without_namespace_claim() {
         // Given
         when(namespaceConfig.validate()).thenReturn(true);
-        MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
-        pathParams.putSingle("namespace", "team-c");
-        when(uriInfo.getPathParameters()).thenReturn(pathParams);
-        when(namespaceAuthzService.getAuthorizedNamespaces()).thenReturn(Set.of("team-a", "team-b"));
+        setPathNamespace("team-a");
+
+        when(securityIdentity.getPrincipal())
+                .thenReturn(jsonWebToken);
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(false);
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(null);
 
         // When/Then
         assertThatThrownBy(() -> filter.filter())
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessageContaining("Access denied to namespace: team-c");
+                .hasMessageContaining("no authorized namespaces");
+    }
+
+    @Test
+    @DisplayName("test_filter_rejects_oidc_invoker_with_empty_namespaces")
+    void test_filter_rejects_oidc_invoker_with_empty_namespaces() {
+        // Given
+        when(namespaceConfig.validate()).thenReturn(true);
+        setPathNamespace("team-a");
+
+        when(securityIdentity.getPrincipal())
+                .thenReturn(jsonWebToken);
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(false);
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of());
+
+        // When/Then
+        assertThatThrownBy(() -> filter.filter())
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void test_filter_rejects_oidc_invoker_with_blank_namespaces() {
+        when(namespaceConfig.validate()).thenReturn(true);
+        when(securityIdentity.getPrincipal()).thenReturn(jsonWebToken);
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(false);
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of("", "   "));
+
+        setPathNamespace("team-a");
+
+        assertThatThrownBy(() -> filter.filter())
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("no authorized namespaces");
+    }
+
+    @Test
+    @DisplayName("test_filter_allows_oidc_admin_without_namespace_claim")
+    void test_filter_allows_oidc_admin_without_namespace_claim() {
+        // Given
+        when(namespaceConfig.validate()).thenReturn(true);
+        when(securityIdentity.getPrincipal()).thenReturn(jsonWebToken);
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(true);
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(null);
+
+        setPathNamespace("team-a");
+
+        // When/Then
+        assertThatCode(() -> filter.filter())
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("test_filter_allows_oidc_admin_with_empty_namespaces")
+    void test_filter_allows_oidc_admin_with_empty_namespaces() {
+        // Given
+        when(namespaceConfig.validate()).thenReturn(true);
+        setPathNamespace("team-a");
+
+        when(securityIdentity.getPrincipal())
+                .thenReturn(jsonWebToken);
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(true);
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of());
+
+        // When/Then
+        assertThatCode(() -> filter.filter())
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("test_filter_allows_when_namespace_in_authorized_set")
+    void test_filter_allows_when_namespace_in_authorized_set() {
+        // Given
+        when(namespaceConfig.validate()).thenReturn(true);
+        setPathNamespace("team-a");
+
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of("team-a", "team-b"));
+
+        // When/Then
+        assertThatCode(() -> filter.filter())
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("test_filter_denies_when_namespace_not_in_authorized_set")
+    void test_filter_denies_when_namespace_not_in_authorized_set() {
+        // Given
+        when(namespaceConfig.validate()).thenReturn(true);
+        setPathNamespace("team-c");
+
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of("team-a", "team-b"));
+
+        // When/Then
+        assertThatThrownBy(() -> filter.filter())
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining(
+                        "not authorized for namespace: team-c");
     }
 
     @Test
     @DisplayName("test_extract_namespace_from_path_parameter")
-    void test_extract_namespace_from_path_parameter() throws Exception {
+    void test_extract_namespace_from_path_parameter() {
         // Given
         when(namespaceConfig.validate()).thenReturn(true);
-        MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
-        pathParams.putSingle("namespace", "my-namespace");
-        when(uriInfo.getPathParameters()).thenReturn(pathParams);
-        when(namespaceAuthzService.getAuthorizedNamespaces()).thenReturn(Set.of("my-namespace"));
+        setPathNamespace("my-namespace");
+
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of("my-namespace"));
 
         // When/Then
-        assertThatCode(() -> filter.filter()).doesNotThrowAnyException();
+        assertThatCode(() -> filter.filter())
+                .doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("test_extract_namespace_from_query_parameter")
-    void test_extract_namespace_from_query_parameter() throws Exception {
+    void test_extract_namespace_from_query_parameter() {
         // Given
         when(namespaceConfig.validate()).thenReturn(true);
+
         MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
         queryParams.putSingle("namespace", "query-namespace");
+
         when(uriInfo.getPathParameters()).thenReturn(pathParams);
         when(uriInfo.getQueryParameters()).thenReturn(queryParams);
-        when(namespaceAuthzService.getAuthorizedNamespaces()).thenReturn(Set.of("query-namespace"));
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of("query-namespace"));
 
         // When/Then
-        assertThatCode(() -> filter.filter()).doesNotThrowAnyException();
+        assertThatCode(() -> filter.filter())
+                .doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("test_path_parameter_takes_precedence_over_query_parameter")
-    void test_path_parameter_takes_precedence_over_query_parameter() throws Exception {
+    void test_path_parameter_takes_precedence_over_query_parameter() {
         // Given
         when(namespaceConfig.validate()).thenReturn(true);
+
         MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
-        pathParams.putSingle("namespace", "path-ns");
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        pathParams.putSingle("namespace", "path-ns");
         queryParams.putSingle("namespace", "query-ns");
+
         when(uriInfo.getPathParameters()).thenReturn(pathParams);
         when(uriInfo.getQueryParameters()).thenReturn(queryParams);
-        when(namespaceAuthzService.getAuthorizedNamespaces()).thenReturn(Set.of("path-ns"));
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of("path-ns"));
 
-        // When/Then - Should validate against path-ns, not query-ns
-        assertThatCode(() -> filter.filter()).doesNotThrowAnyException();
+        // When/Then
+        assertThatCode(() -> filter.filter())
+                .doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("test_blank_path_parameter_falls_back_to_query_parameter")
-    void test_blank_path_parameter_falls_back_to_query_parameter() throws Exception {
+    void test_blank_path_parameter_falls_back_to_query_parameter() {
         // Given
         when(namespaceConfig.validate()).thenReturn(true);
+
         MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
-        pathParams.putSingle("namespace", "   "); // Blank
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        pathParams.putSingle("namespace", "   ");
         queryParams.putSingle("namespace", "query-ns");
+
         when(uriInfo.getPathParameters()).thenReturn(pathParams);
         when(uriInfo.getQueryParameters()).thenReturn(queryParams);
-        when(namespaceAuthzService.getAuthorizedNamespaces()).thenReturn(Set.of("query-ns"));
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of("query-ns"));
 
         // When/Then
-        assertThatCode(() -> filter.filter()).doesNotThrowAnyException();
+        assertThatCode(() -> filter.filter())
+                .doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("test_filter_validates_multiple_namespaces_correctly")
-    void test_filter_validates_multiple_namespaces_correctly() throws Exception {
+    void test_filter_validates_multiple_namespaces_correctly() {
         // Given
         when(namespaceConfig.validate()).thenReturn(true);
-        when(namespaceAuthzService.getAuthorizedNamespaces()).thenReturn(Set.of("ns1", "ns2", "ns3"));
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of("ns1", "ns2", "ns3"));
 
-        // Test each authorized namespace
-        for (String ns : new String[] { "ns1", "ns2", "ns3" }) {
-            MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
-            pathParams.putSingle("namespace", ns);
-            when(uriInfo.getPathParameters()).thenReturn(pathParams);
+        // When/Then
+        for (String namespace : new String[] {
+                "ns1",
+                "ns2",
+                "ns3"
+        }) {
+            setPathNamespace(namespace);
 
-            // When/Then
-            assertThatCode(() -> filter.filter()).doesNotThrowAnyException();
+            assertThatCode(() -> filter.filter())
+                    .doesNotThrowAnyException();
         }
     }
 
     @Test
     @DisplayName("test_filter_case_sensitive_namespace_matching")
-    void test_filter_case_sensitive_namespace_matching() throws Exception {
+    void test_filter_case_sensitive_namespace_matching() {
         // Given
         when(namespaceConfig.validate()).thenReturn(true);
-        MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
-        pathParams.putSingle("namespace", "Team-A"); // Different case
-        when(uriInfo.getPathParameters()).thenReturn(pathParams);
-        when(namespaceAuthzService.getAuthorizedNamespaces()).thenReturn(Set.of("team-a"));
+        setPathNamespace("Team-A");
 
-        // When/Then - Should fail (case-sensitive)
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of("team-a"));
+
+        // When/Then
         assertThatThrownBy(() -> filter.filter())
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessageContaining("Access denied to namespace: Team-A");
+                .hasMessageContaining(
+                        "not authorized for namespace: Team-A");
     }
 
     @Test
     @DisplayName("test_filter_with_single_authorized_namespace")
-    void test_filter_with_single_authorized_namespace() throws Exception {
+    void test_filter_with_single_authorized_namespace() {
         // Given
         when(namespaceConfig.validate()).thenReturn(true);
-        MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
-        pathParams.putSingle("namespace", "only-ns");
-        when(uriInfo.getPathParameters()).thenReturn(pathParams);
-        when(namespaceAuthzService.getAuthorizedNamespaces()).thenReturn(Set.of("only-ns"));
+        setPathNamespace("only-ns");
+
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of("only-ns"));
 
         // When/Then
-        assertThatCode(() -> filter.filter()).doesNotThrowAnyException();
+        assertThatCode(() -> filter.filter())
+                .doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("test_filter_error_message_contains_namespace")
-    void test_filter_error_message_contains_namespace() throws Exception {
+    void test_filter_error_message_contains_namespace() {
         // Given
         when(namespaceConfig.validate()).thenReturn(true);
-        MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
-        pathParams.putSingle("namespace", "forbidden-namespace");
-        when(uriInfo.getPathParameters()).thenReturn(pathParams);
-        when(namespaceAuthzService.getAuthorizedNamespaces()).thenReturn(Set.of("allowed"));
+        setPathNamespace("forbidden-namespace");
+
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of("allowed"));
 
         // When/Then
         assertThatThrownBy(() -> filter.filter())
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessageContaining("forbidden-namespace");
+    }
+
+    @Test
+    @DisplayName("test_filter_allows_oidc_invoker_for_authorized_namespace")
+    void test_filter_allows_oidc_invoker_for_authorized_namespace() {
+        // Given
+        when(namespaceConfig.validate()).thenReturn(true);
+        setPathNamespace("team-a");
+
+        when(securityIdentity.getPrincipal())
+                .thenReturn(jsonWebToken);
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(false);
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of("team-a", "team-b"));
+
+        // When/Then
+        assertThatCode(() -> filter.filter())
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("test_filter_allows_oidc_invoker_with_exact_wildcard")
+    void test_filter_allows_oidc_invoker_with_exact_wildcard() {
+        when(namespaceConfig.validate()).thenReturn(true);
+        when(securityIdentity.getPrincipal()).thenReturn(jsonWebToken);
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(false);
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of("*"));
+
+        setPathNamespace("any-namespace");
+
+        assertThatCode(() -> filter.filter())
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "my*",
+            "*test",
+            "team-*",
+            "**",
+            " * "
+    })
+    @DisplayName("test_filter_rejects_oidc_non_exact_wildcard")
+    void test_filter_rejects_oidc_non_exact_wildcard(
+            String namespaceClaim) {
+
+        when(namespaceConfig.validate()).thenReturn(true);
+        when(securityIdentity.getPrincipal()).thenReturn(jsonWebToken);
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(false);
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of(namespaceClaim));
+
+        setPathNamespace("team-a");
+
+        assertThatThrownBy(() -> filter.filter())
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void test_filter_allows_all_namespaces_with_wildcard() {
+        when(namespaceConfig.validate()).thenReturn(true);
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(false);
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of("*"));
+
+        setPathNamespace("new-team-d");
+
+        assertThatCode(filter::filter)
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "team-*",
+            "my*",
+            "**",
+            "*-suffix"
+    })
+    void test_filter_rejects_partial_wildcards(String configuredNamespace) {
+        when(namespaceConfig.validate()).thenReturn(true);
+        when(securityIdentity.hasRole(AuthzConsts.ROLE_ADMIN))
+                .thenReturn(false);
+        when(namespaceAuthzService.getAuthorizedNamespaces())
+                .thenReturn(Set.of(configuredNamespace));
+
+        setPathNamespace("team-a");
+
+        assertThatThrownBy(filter::filter)
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining(
+                        "not authorized for namespace: team-a");
+    }
+
+    private void setPathNamespace(String namespace) {
+        MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
+
+        pathParams.putSingle("namespace", namespace);
+
+        when(uriInfo.getPathParameters()).thenReturn(pathParams);
     }
 }

--- a/runner/runtime/src/test/java/io/quarkiverse/flow/runner/security/NamespaceAuthorizationServiceTest.java
+++ b/runner/runtime/src/test/java/io/quarkiverse/flow/runner/security/NamespaceAuthorizationServiceTest.java
@@ -1,247 +1,221 @@
 package io.quarkiverse.flow.runner.security;
 
+import static io.quarkiverse.flow.runner.security.AuthzConsts.CLAIM_NAMESPACES;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Set;
 
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.quarkiverse.flow.runner.FlowRunnerConfig;
 import io.quarkus.security.identity.SecurityIdentity;
 
-@DisplayName("NamespaceAuthorizationService Unit Tests")
+@DisplayName("Namespace authorization service tests")
 class NamespaceAuthorizationServiceTest {
+
+    private static final String CLAIM_NAME = "namespace";
 
     private NamespaceAuthorizationService service;
     private FlowRunnerConfig config;
     private FlowRunnerConfig.Security security;
     private FlowRunnerConfig.Security.Namespace namespaceConfig;
     private SecurityIdentity securityIdentity;
+    private JsonWebToken jsonWebToken;
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
         service = new NamespaceAuthorizationService();
+
         config = mock(FlowRunnerConfig.class);
         security = mock(FlowRunnerConfig.Security.class);
         namespaceConfig = mock(FlowRunnerConfig.Security.Namespace.class);
         securityIdentity = mock(SecurityIdentity.class);
+        jsonWebToken = mock(JsonWebToken.class);
+        objectMapper = new ObjectMapper();
 
         service.config = config;
         service.securityIdentity = securityIdentity;
+        service.objectMapper = objectMapper;
 
         when(config.security()).thenReturn(security);
         when(security.namespace()).thenReturn(namespaceConfig);
-        when(namespaceConfig.claim()).thenReturn("namespace");
+        when(namespaceConfig.claim()).thenReturn(CLAIM_NAME);
     }
 
     @Test
-    @DisplayName("test_get_authorized_namespaces_returns_null_when_no_attribute")
-    void test_get_authorized_namespaces_returns_null_when_no_attribute() {
-        // Given
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(null);
-        when(securityIdentity.getAttribute("namespace")).thenReturn(null);
+    @DisplayName("JSON-P array claim values are normalized to Java strings")
+    void shouldNormalizeJsonArrayClaim() {
+        JsonArray claim = Json.createArrayBuilder()
+                .add("team-a")
+                .add("team-b")
+                .build();
 
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
+        useJwtClaim(claim);
 
-        // Then
-        assertThat(result).isNull();
+        assertThat(service.getAuthorizedNamespaces())
+                .containsExactlyInAnyOrder("team-a", "team-b");
     }
 
     @Test
-    @DisplayName("test_get_authorized_namespaces_from_standard_claim")
-    void test_get_authorized_namespaces_from_standard_claim() {
-        // Given - Set attribute as API_KEY mechanism would
-        Set<String> namespaces = Set.of("team-a", "team-b");
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(namespaces);
+    @DisplayName("Jackson array claim values are normalized")
+    void shouldNormalizeJacksonArrayClaim() throws Exception {
+        JsonNode claim = objectMapper.readTree("""
+                ["team-a", "team-b"]
+                """);
 
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
+        useJwtClaim(claim);
 
-        // Then
-        assertThat(result).containsExactlyInAnyOrder("team-a", "team-b");
+        assertThat(service.getAuthorizedNamespaces())
+                .containsExactlyInAnyOrder("team-a", "team-b");
     }
 
     @Test
-    @DisplayName("test_get_authorized_namespaces_from_configured_claim")
-    void test_get_authorized_namespaces_from_configured_claim() {
-        // Given - OIDC mode with custom claim name
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(null);
-        when(namespaceConfig.claim()).thenReturn("custom_namespaces");
-        List<String> namespaces = List.of("ns1", "ns2", "ns3");
-        when(securityIdentity.getAttribute("custom_namespaces")).thenReturn(namespaces);
+    @DisplayName("Serialized JSON array claims are parsed")
+    void shouldNormalizeSerializedJsonArrayClaim() {
+        useJwtClaim("""
+                ["team-a", "team-b", "team-a", " "]
+                """);
 
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
-
-        // Then
-        assertThat(result).containsExactlyInAnyOrder("ns1", "ns2", "ns3");
+        assertThat(service.getAuthorizedNamespaces())
+                .containsExactlyInAnyOrder("team-a", "team-b");
     }
 
     @Test
-    @DisplayName("test_convert_set_to_set")
-    void test_convert_set_to_set() {
-        // Given
-        Set<String> namespaces = Set.of("a", "b", "c");
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(namespaces);
+    @DisplayName("Comma-separated namespace claims are parsed")
+    void shouldNormalizeCommaSeparatedClaim() {
+        useJwtClaim("team-a, team-b, team-a");
 
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
-
-        // Then
-        assertThat(result).isEqualTo(namespaces);
+        assertThat(service.getAuthorizedNamespaces())
+                .containsExactlyInAnyOrder("team-a", "team-b");
     }
 
     @Test
-    @DisplayName("test_convert_list_to_set")
-    void test_convert_list_to_set() {
-        // Given - From OIDC JWT array claim
-        List<String> namespaces = List.of("x", "y", "z");
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(namespaces);
+    @DisplayName("Collection values are trimmed and blank values removed")
+    void shouldNormalizeCollectionValues() {
+        useJwtClaim(List.of(
+                " team-a ",
+                "",
+                "   ",
+                "team-b",
+                "team-a"));
 
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
-
-        // Then
-        assertThat(result).containsExactlyInAnyOrder("x", "y", "z");
+        assertThat(service.getAuthorizedNamespaces())
+                .containsExactlyInAnyOrder("team-a", "team-b");
     }
 
     @Test
-    @DisplayName("test_convert_single_string_to_set")
-    void test_convert_single_string_to_set() {
-        // Given
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn("single-namespace");
+    @DisplayName("Present empty collection remains an empty set")
+    void shouldPreserveEmptyCollection() {
+        useJwtClaim(List.of());
 
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
-
-        // Then
-        assertThat(result).containsExactly("single-namespace");
+        assertThat(service.getAuthorizedNamespaces())
+                .isNotNull()
+                .isEmpty();
     }
 
     @Test
-    @DisplayName("test_convert_comma_separated_string_to_set")
-    void test_convert_comma_separated_string_to_set() {
-        // Given
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn("ns1,ns2,ns3");
+    @DisplayName("Missing namespace claim returns null")
+    void shouldReturnEmptySetWhenClaimIsMissing() {
+        useJwtClaim(null);
 
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
-
-        // Then
-        assertThat(result).containsExactlyInAnyOrder("ns1", "ns2", "ns3");
+        assertThat(service.getAuthorizedNamespaces())
+                .isNotNull().isEmpty();
     }
 
     @Test
-    @DisplayName("test_convert_comma_separated_string_with_spaces_to_set")
-    void test_convert_comma_separated_string_with_spaces_to_set() {
-        // Given - Spaces should be trimmed
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn("ns1, ns2 , ns3");
+    @DisplayName("Standard namespaces attribute takes precedence")
+    void shouldPreferStandardNamespacesAttribute() {
+        when(securityIdentity.getAttribute(CLAIM_NAMESPACES))
+                .thenReturn(Set.of("api-key-namespace"));
 
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
+        when(securityIdentity.getAttribute(CLAIM_NAME))
+                .thenReturn(Set.of("configured-claim-namespace"));
 
-        // Then
-        assertThat(result).containsExactlyInAnyOrder("ns1", "ns2", "ns3");
+        assertThat(service.getAuthorizedNamespaces())
+                .containsExactly("api-key-namespace");
+
+        verify(securityIdentity, never())
+                .getAttribute(CLAIM_NAME);
+        verify(jsonWebToken, never())
+                .getClaim(CLAIM_NAME);
     }
 
     @Test
-    @DisplayName("test_convert_blank_string_returns_null")
-    void test_convert_blank_string_returns_null() {
-        // Given - Empty string means all namespaces allowed
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn("");
+    @DisplayName("Configured identity attribute takes precedence over JWT")
+    void shouldPreferConfiguredIdentityAttributeOverJwtClaim() {
+        when(securityIdentity.getAttribute(CLAIM_NAMESPACES))
+                .thenReturn(null);
 
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
+        when(securityIdentity.getAttribute(CLAIM_NAME))
+                .thenReturn(Set.of("identity-attribute-namespace"));
 
-        // Then
-        assertThat(result).isNull();
+        when(securityIdentity.getPrincipal())
+                .thenReturn(jsonWebToken);
+
+        doReturn(Set.of("jwt-namespace"))
+                .when(jsonWebToken)
+                .getClaim(CLAIM_NAME);
+
+        assertThat(service.getAuthorizedNamespaces())
+                .containsExactly("identity-attribute-namespace");
+
+        verify(jsonWebToken, never())
+                .getClaim(CLAIM_NAME);
     }
 
     @Test
-    @DisplayName("test_convert_whitespace_string_returns_null")
-    void test_convert_whitespace_string_returns_null() {
-        // Given
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn("   ");
+    void shouldNormalizePaddedWildcardString() {
+        when(securityIdentity.getAttribute(CLAIM_NAMESPACES))
+                .thenReturn(" * ");
 
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
-
-        // Then
-        assertThat(result).isNull();
+        assertThat(service.getAuthorizedNamespaces())
+                .containsExactly("*");
     }
 
     @Test
-    @DisplayName("test_convert_comma_separated_with_blank_entries_filters_them")
-    void test_convert_comma_separated_with_blank_entries_filters_them() {
-        // Given - Blank entries should be filtered out
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn("ns1,,ns2, ,ns3");
+    void shouldNormalizePaddedWildcardInCollection() {
+        when(securityIdentity.getAttribute(CLAIM_NAMESPACES))
+                .thenReturn(Set.of(" * "));
 
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
-
-        // Then
-        assertThat(result).containsExactlyInAnyOrder("ns1", "ns2", "ns3");
+        assertThat(service.getAuthorizedNamespaces())
+                .containsExactly("*");
     }
 
     @Test
-    @DisplayName("test_convert_other_object_type_to_set")
-    void test_convert_other_object_type_to_set() {
-        // Given - Fallback to toString()
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(42);
+    void shouldNormalizePaddedWildcardInJsonArrayString() {
+        when(securityIdentity.getAttribute(CLAIM_NAMESPACES))
+                .thenReturn("[\" * \"]");
 
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
-
-        // Then
-        assertThat(result).containsExactly("42");
+        assertThat(service.getAuthorizedNamespaces())
+                .containsExactly("*");
     }
 
-    @Test
-    @DisplayName("test_empty_set_attribute_returns_empty_set")
-    void test_empty_set_attribute_returns_empty_set() {
-        // Given
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(Set.of());
+    private void useJwtClaim(Object claim) {
+        when(securityIdentity.getAttribute(CLAIM_NAMESPACES))
+                .thenReturn(null);
+        when(securityIdentity.getAttribute(CLAIM_NAME))
+                .thenReturn(null);
+        when(securityIdentity.getPrincipal())
+                .thenReturn(jsonWebToken);
 
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
-
-        // Then
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    @DisplayName("test_fallback_to_configured_claim_when_standard_claim_missing")
-    void test_fallback_to_configured_claim_when_standard_claim_missing() {
-        // Given
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(null);
-        when(namespaceConfig.claim()).thenReturn("app_namespaces");
-        when(securityIdentity.getAttribute("app_namespaces")).thenReturn(Set.of("app-ns"));
-
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
-
-        // Then
-        assertThat(result).containsExactly("app-ns");
-    }
-
-    @Test
-    @DisplayName("test_standard_claim_takes_precedence_over_configured_claim")
-    void test_standard_claim_takes_precedence_over_configured_claim() {
-        // Given - Both present, standard should win
-        when(securityIdentity.getAttribute(AuthzConsts.CLAIM_NAMESPACES)).thenReturn(Set.of("standard-ns"));
-        when(namespaceConfig.claim()).thenReturn("custom_namespaces");
-        when(securityIdentity.getAttribute("custom_namespaces")).thenReturn(Set.of("custom-ns"));
-
-        // When
-        Set<String> result = service.getAuthorizedNamespaces();
-
-        // Then
-        assertThat(result).containsExactly("standard-ns");
+        doReturn(claim)
+                .when(jsonWebToken)
+                .getClaim(CLAIM_NAME);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-flow/issues/773

Now the behavior is following these rules:
| Identity | Namespace set | Requested namespace | Result |
|---|---|---|---|
| Non-OIDC | Missing (for backward compatibility considered as *) or wildcard | Any namespace | Allow |
| Non-OIDC | empty — no namespace assigned| Any namespace | Deny |
| OIDC invoker | Missing or empty — no namespace assigned | Any namespace | Deny |
| OIDC invoker | Wildcard * | Any namespace | Allow |
| OIDC invoker | Non-empty claim | Requested namespace is present in the claim | Allow |
| OIDC invoker | Non-empty claim | Requested namespace is not present in the claim | Deny |
| OIDC admin | Missing, empty, or non-empty | Any namespace | Allow |

***
The previous implementation failed or only partially satisfied two rules:

| Rule | Previous behavior | Status before |
|---|---|---|
| Non-OIDC + missing/empty namespaces → Allow | Missing namespace restrictions were treated as unrestricted access. | ✅ Met |
| OIDC invoker + missing/empty namespaces → Deny | Missing or empty namespaces were also treated as unrestricted access, so the invoker was allowed. | ❌ Not met |
| OIDC invoker + requested namespace present → Allow | Worked for normal Java `String` values, but could fail when the JWT claim contained JSON-P `JsonString` values. | ⚠️ Partially met |
| OIDC invoker + requested namespace absent → Deny | The requested namespace was not found, so access was denied. | ✅ Met |
| OIDC admin → Allow | Administrator access was already preserved. | ✅ Met |

Basically, second scenario means that OIDC invoker is authenticated, but now it has changed blank/null/empty namespace claim for wildcard (*) to allow all of them.

***

For OIDC:
- flow-admin + any/missing claim         → 200
- flow-invoker + matching namespace      → 200
- flow-invoker + exact "*"               → 200
- flow-invoker + unauthorized namespace  → 403
- flow-invoker + missing claim      → 403
- flow-invoker + blank claim        → 403

