### PR TITLE
Fix #777 - Handle boxed JDK types in JandexMethodInputJsonSchema

### DIFF
--- a/langchain4j/deployment/src/main/java/io/quarkiverse/flow/langchain4j/deployment/JandexMethodInputJsonSchema.java
+++ b/langchain4j/deployment/src/main/java/io/quarkiverse/flow/langchain4j/deployment/JandexMethodInputJsonSchema.java
@@ -42,6 +42,14 @@ final class JandexMethodInputJsonSchema {
     private static final DotName MAP = DotName.createSimple(Map.class.getName());
     private static final DotName COLLECTION = DotName.createSimple(Collection.class.getName());
 
+    private static final java.util.Set<DotName> BOXED_NUMBER_TYPES = java.util.Set.of(
+            DotName.createSimple("java.lang.Byte"),
+            DotName.createSimple("java.lang.Short"),
+            DotName.createSimple("java.lang.Integer"),
+            DotName.createSimple("java.lang.Long"),
+            DotName.createSimple("java.lang.Float"),
+            DotName.createSimple("java.lang.Double"));
+
     private JandexMethodInputJsonSchema() {
     }
 
@@ -282,7 +290,7 @@ final class JandexMethodInputJsonSchema {
         if (typeName.equals(BOOLEAN)) {
             return false;
         }
-        if (isAssignableFrom(index, typeName, NUMBER)) {
+        if (BOXED_NUMBER_TYPES.contains(typeName) || isAssignableFrom(index, typeName, NUMBER)) {
             return false;
         }
         if (isAssignableFrom(index, typeName, MAP)) {
@@ -293,7 +301,7 @@ final class JandexMethodInputJsonSchema {
         }
 
         ClassInfo classInfo = index.getClassByName(typeName);
-        return classInfo == null || !classInfo.isEnum();
+        return classInfo != null && !classInfo.isEnum();
     }
 
     /**
@@ -350,7 +358,7 @@ final class JandexMethodInputJsonSchema {
             return "boolean";
         }
 
-        if (isAssignableFrom(index, typeName, NUMBER)) {
+        if (BOXED_NUMBER_TYPES.contains(typeName) || isAssignableFrom(index, typeName, NUMBER)) {
             return "number";
         }
 

--- a/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/JandexMethodInputJsonSchemaTest.java
+++ b/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/JandexMethodInputJsonSchemaTest.java
@@ -232,6 +232,22 @@ class JandexMethodInputJsonSchemaTest {
     }
 
     @Test
+    @DisplayName("test_boxed_jdk_types_do_not_throw_npe")
+    void test_boxed_jdk_types_do_not_throw_npe() throws Exception {
+        MethodInfo method = getMethod("withBoxedTypes", Integer.class, Long.class, Double.class, Boolean.class);
+
+        ObjectNode schema = JandexMethodInputJsonSchema.generateSchemaNode(index, method);
+
+        assertThat(schema).isNotNull();
+
+        ObjectNode properties = (ObjectNode) schema.get("properties");
+        assertThat(properties.get("travelers").get("type").asText()).isEqualTo("number");
+        assertThat(properties.get("distance").get("type").asText()).isEqualTo("number");
+        assertThat(properties.get("price").get("type").asText()).isEqualTo("number");
+        assertThat(properties.get("active").get("type").asText()).isEqualTo("boolean");
+    }
+
+    @Test
     @DisplayName("test_only_framework_params_returns_null")
     void test_only_framework_params_returns_null() throws Exception {
         MethodInfo method = getMethod("onlyFrameworkParams", AgenticScope.class);
@@ -296,6 +312,9 @@ class JandexMethodInputJsonSchemaTest {
         }
 
         public void onlyFrameworkParams(AgenticScope scope) {
+        }
+
+        public void withBoxedTypes(Integer travelers, Long distance, Double price, Boolean active) {
         }
     }
 


### PR DESCRIPTION
Fixes #777 

## Summary

- Fix `NullPointerException` in `JandexMethodInputJsonSchema` when agent method parameters use boxed JDK types (`Integer`, `Long`, `Double`, etc.) that are not in the Jandex index
- `isPojoLike` no longer treats unindexed types as POJOs (changed `classInfo == null` from `true` to `false`)
- `mapJavaTypeToJsonType` checks boxed number types by name before `isAssignableFrom`, which can't walk the superclass chain for unindexed JDK classes

## Test plan

- [x] Added `test_boxed_jdk_types_do_not_throw_npe` covering `Integer`, `Long`, `Double`, `Boolean` parameters
- [x] All 12 existing tests pass with zero regressions

Found via https://github.com/quarkusio/quarkus-workshop-langchain4j/pull/376