### PR TITLE
feat: default CloudEvent source for emitted events (#776)

### DIFF
--- a/adr/2026-07-23-cloudevent-emit-defaults-design.md
+++ b/adr/2026-07-23-cloudevent-emit-defaults-design.md
@@ -1,0 +1,178 @@
+# Smart CloudEvent Defaults for Emitted Events
+
+**Date:** 2026-07-23
+**Issues:** [quarkus-flow#776](https://github.com/quarkiverse/quarkus-flow/issues/776), [sdk-java#1554](https://github.com/open-workflow-specification/sdk-java/issues/1554)
+**Status:** Part B (#776) implemented; Part A (#1554) implemented in an sdk-java branch, pending upstream release + version bump
+**SDK Version (current):** `7.25.1.Final`
+**Affected modules:** `core/runtime` (quarkus-flow); `impl/core`, `fluent/spec` (sdk-java)
+
+## Context
+
+When a workflow emits a CloudEvent (`emit.event.with`), the CNCF Serverless Workflow
+[spec requires](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#event-properties)
+`id`, `source`, and `type`. Today the produced events are under-specified:
+
+| Attribute | Current behavior | Layer responsible |
+|---|---|---|
+| `id` | Runtime auto-generates a UUID per emission — **good** | `EmitExecutor` (SDK) |
+| `type` | Runtime throws `IllegalArgumentException` if missing — **correct** | `EmitExecutor` (SDK) |
+| `source` | Runtime falls back to `URI.create("reference-impl")` — **weak, no traceability** | `CloudEventUtils.source()` (SDK) |
+| `time` | Omitted entirely unless the user sets it — **violates CloudEvents best practice** | `EmitExecutor` (SDK) |
+
+At the Quarkus Flow DSL layer, the `FlowDSL` emit helpers (`emitJson`, `producedJson`,
+`produced`, `producedBytes*`) only set `type` and `data`/`dataContentType`. Users must
+manually chain `.source(...)`, `.randomId()`, `.now()` to obtain well-formed, traceable
+events.
+
+The two issues are complementary and were filed as a dependent pair (#776 *depends on*
+#1554). This ADR defines **one design across both repositories** and the layer where each
+default belongs.
+
+## Key principle: where each default belongs
+
+The decisive question is *which layer has the information needed to compute a correct
+default*.
+
+- **Execution-time attributes** — `id`, `time`, and an identity-derived `source` — depend
+  on per-execution or per-definition runtime context that only the **SDK runtime**
+  (`EmitExecutor`) can see. A definition-time DSL helper cannot know the running
+  workflow's identity, and must not bake a per-execution value (`id`, `time`) into a
+  static definition.
+- **Definition-time ergonomics and overrides** — making the common path terse and letting
+  users override any attribute — belong in the **quarkus-flow DSL** (`FlowDSL`).
+
+This principle directly resolves the tension noted in #776 item 2 ("deriving `source` from
+workflow identity requires threading identity into the emit spec"): we do **not** thread
+identity through the DSL. The SDK runtime already holds it and is the right place to derive
+`source`.
+
+## Decision
+
+### Part A — sdk-java (#1554): fix the runtime defaults
+
+1. **Meaningful `source` default derived from workflow identity.**
+   `EmitExecutor.buildCloudEvent(...)` already receives the `WorkflowContext`, which exposes
+   `definition().id()` → `WorkflowDefinitionId(namespace, name, version)`. When no `source`
+   is supplied, derive it from that identity (rendered as `namespace:name:version` via the
+   existing `WorkflowDefinitionId.toString(":")`) rather than the opaque `"reference-impl"`.
+   Introduce an identity-aware helper (e.g. `CloudEventUtils.source(WorkflowDefinitionId)`)
+   and keep the no-arg `CloudEventUtils.source()` only as a last-resort static fallback,
+   changed from `"reference-impl"` to a self-identifying URN
+   (e.g. `urn:serverlessworkflow:sdk-java`).
+
+2. **Default `time` to "now".**
+   When the `timeFilter` is empty, set `ceBuilder.withTime(OffsetDateTime.now())` instead of
+   omitting the attribute (use `ifPresentOrElse`). Explicit user-provided `time`
+   (literal or expression) is untouched.
+
+3. **Application-level configurable default `source` (#1554 item 4).**
+   Add an optional default source on `WorkflowApplication` (builder method, e.g.
+   `withDefaultEventSource(URI)`), so an application can set the source once for all emitted
+   events. This is the seam quarkus-flow wires its config into (Part B).
+
+4. **Source precedence (highest wins):**
+   1. explicit per-emit `source` (DSL/definition)
+   2. application-level configured default source (if set)
+   3. identity-derived `source` (`namespace:name:version`)
+   4. static SDK fallback URN
+
+   Rationale: an explicit per-emit value is the most specific intent; an app-level default
+   is a deliberate global choice and so outranks the automatic identity derivation;
+   identity derivation is always better than an opaque constant.
+
+5. **Validation: keep runtime enforcement, add no bean-validation annotations.**
+   `EventProperties` is shared between *emit* and *filter* contexts, where required-ness
+   differs; annotating it with `@NotNull`/`@NotBlank` would break filter use. With `id`,
+   `source`, and `time` all now defaulted, `type` remains the only required emit attribute,
+   and `EmitExecutor` already throws when it is missing. We therefore **deliberately do not**
+   add model-level annotations and document why.
+
+### Part B — quarkus-flow (#776): inject a default `source` at the registrar seam
+
+**Chosen mechanism (implemented).** Rather than embedding a default in the static `FlowDSL`
+emit helpers (which run at *definition* time and cannot see workflow identity), the default
+`source` is injected at the one runtime seam both flow shapes share:
+`WorkflowRegistrarService.register(Workflow)`. Class-based flows (`Flow.descriptor()`) and
+YAML/JSON flows (`WorkflowReader.readWorkflowFromClasspath`) both call `register(...)` before
+`application.workflowDefinition(...)`, so a single injection point covers **both**.
+
+1. **`EmitEventSourceInjector` — recursive walker.** Before building the definition, walk the
+   workflow's task tree and, for every `EmitTask` whose `event.with.source` is null, set a
+   default. The walk is fully recursive over every container that can nest an emit: top-level
+   `do`, `DoTask.do`, `ForTask.do`, `ForkTask.fork.branches`, `TryTask.try` + `catch.do`, and
+   `ListenTask.foreach.do`. An explicit source (literal or expression) is never overwritten.
+
+2. **Identity-derived default, out of the box.** When no override is configured, the injected
+   value is the emitting workflow's identity `namespace:name:version`
+   (`WorkflowDefinitionId.of(workflow).toString(":")`) — matching Part A's SDK semantics, so a
+   plain `emitJson(type, Payload.class)` yields a traceable event with zero configuration and
+   no more `reference-impl`.
+
+3. **`FlowCloudEventsConfig` (`quarkus.flow.cloud-events`).**
+   - `source()` (`Optional<String>`) — a fixed global override; when set it replaces the
+     identity-derived value for all emits.
+   - `deriveSourceFromWorkflow()` (`@WithDefault("true")`) — escape hatch to disable injection
+     entirely and preserve raw SDK behavior.
+   - Precedence: explicit per-emit `source` → config `source()` → identity-derived → SDK
+     fallback (Part A).
+
+4. **`time` stays in the SDK (Part A).** `time` is a per-execution value and cannot be baked
+   into a definition, so it is *not* handled at this seam; it is delivered by Part A (#1554)
+   once the SDK dependency is bumped. Injecting `source` here needs **no** SDK change and works
+   against the current `7.25.1.Final`.
+
+An earlier draft proposed an app-level `withDefaultEventSource(...)` customizer for source; the
+registrar-seam injector makes that redundant for `source`, so it was dropped.
+
+### Sequencing / dependency
+
+Part B (source) ships independently against the current `7.25.1.Final` — no SDK bump required.
+Part A (`time` default, and the SDK's own `source`/validation improvements) ships in a future
+SDK release; quarkus-flow then bumps `io.serverlessworkflow.version` to inherit the `time`
+default. Recommended order: land Part B now → land Part A upstream → release SDK → bump the
+version in quarkus-flow (picks up `time`).
+
+## Consequences
+
+**Positive**
+- Emitted events are well-formed and traceable by default (`source` identifies the emitting
+  workflow; `time` is always present).
+- The common DSL path (`emitJson(type, Payload.class)`) produces a spec-compliant event with
+  no extra chaining.
+- Clear layer ownership: per-execution values stay in the runtime; ergonomics/config stay in
+  the DSL. No workflow identity is threaded through the DSL.
+- Override semantics are unchanged and explicit.
+
+**Negative / risks**
+- `OffsetDateTime.now()` in `EmitExecutor` introduces a real-clock dependency; tests must
+  assert on presence/bounds, not an exact value, and any deterministic-time need would
+  require a clock seam (out of scope here).
+- Changing the default `source` from `"reference-impl"` is a **behavioral change**:
+  consumers filtering or asserting on `source == "reference-impl"` will break. This is
+  acceptable for a pre-1.0 SDK but must be called out in SDK release notes.
+- Part B is blocked on an SDK release + version bump (see Sequencing).
+
+## Alternatives considered
+
+- **Embed defaults purely in the DSL (#776 item 1 as written).** Rejected as the primary
+  mechanism: the DSL cannot see workflow identity and would either hardcode a constant
+  `source` or illegally bake per-execution `id`/`time` into the definition.
+- **`FlowDSL.setDefaultSource(String)` mutable static.** Rejected: global mutable state,
+  not thread-safe across concurrently built applications, and not Quarkus-idiomatic. Config
+  property + application seam is preferred.
+- **Add `@NotNull`/`@NotBlank` to `EventProperties`.** Rejected: the type is shared with the
+  filter context; runtime validation in `EmitExecutor` is the correct enforcement point.
+- **Static SDK `source` such as `io.serverlessworkflow.sdk-java`.** Kept only as the final
+  fallback; identity-derived source is preferred for traceability.
+
+## Test plan (high level)
+
+- **sdk-java (#1554):** register a capturing `EventPublisher` via
+  `WorkflowApplication.builder().withEventPublisher(...)`, emit with no `source`/`time`, and
+  assert (a) `time` is present and close to now, (b) `source` equals the workflow identity, (c)
+  app-level default source overrides identity, (d) explicit per-emit `source` overrides the
+  app default, (e) missing `type` still throws.
+- **quarkus-flow (#776):** unit-test `EmitEventSourceInjector` for each nesting container
+  (`do`, `for`, `fork`, `try`/`catch`, `listen.foreach`), explicit-source preservation, and
+  null/blank no-ops; integration-test (`@QuarkusTest`) that a class-based emit flow with no
+  source gets the identity-derived `namespace:name:version` on its registered definition.

--- a/core/integration-tests/src/main/java/io/quarkiverse/flow/it/OrderEmitterWorkflow.java
+++ b/core/integration-tests/src/main/java/io/quarkiverse/flow/it/OrderEmitterWorkflow.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.flow.it;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkiverse.flow.Flow;
+import io.quarkiverse.flow.dsl.FlowDSL;
+import io.quarkiverse.flow.dsl.FlowWorkflowBuilder;
+import io.serverlessworkflow.api.types.Workflow;
+
+/**
+ * Emits a CloudEvent without declaring an explicit {@code source}, so that Quarkus Flow injects a default source
+ * derived from the workflow identity ({@code namespace:name:version}).
+ */
+@ApplicationScoped
+public class OrderEmitterWorkflow extends Flow {
+
+    public static final String NAME = "order-emitter";
+    public static final String NAMESPACE = "org.acme.events";
+
+    @Override
+    public Workflow descriptor() {
+        return FlowWorkflowBuilder.workflow(NAME, NAMESPACE)
+                .tasks(FlowDSL.emitJson("com.acme.order.placed.v1", Map.class))
+                .build();
+    }
+}

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/CloudEventDefaultSourceTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/CloudEventDefaultSourceTest.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.flow.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.serverlessworkflow.api.types.EmitTask;
+import io.serverlessworkflow.api.types.EventProperties;
+import io.serverlessworkflow.api.types.Task;
+import io.serverlessworkflow.api.types.UriTemplate;
+import io.serverlessworkflow.impl.WorkflowDefinitionId;
+
+/**
+ * Verifies the end-to-end wiring of {@code quarkus.flow.cloud-events}: when an emit task declares no source, the
+ * registrar injects a default source derived from the workflow identity.
+ */
+@QuarkusTest
+class CloudEventDefaultSourceTest {
+
+    @Inject
+    OrderEmitterWorkflow orderEmitter;
+
+    @Test
+    @DisplayName("emit_without_source_gets_identity_derived_default")
+    void emit_without_source_gets_identity_derived_default() {
+        WorkflowDefinitionId id = orderEmitter.definition().id();
+        String expectedSource = id.toString(":");
+
+        Task task = orderEmitter.definition().workflow().getDo().get(0).getTask();
+        EmitTask emit = task.getEmitTask();
+        assertThat(emit).as("first task should be an emit").isNotNull();
+
+        EventProperties props = emit.getEmit().getEvent().getWith();
+        assertThat(props.getSource()).as("source should have been injected").isNotNull();
+
+        UriTemplate template = props.getSource().getUriTemplate();
+        String actual = template.getLiteralUri() != null
+                ? template.getLiteralUri().toString()
+                : template.getLiteralUriTemplate();
+        assertThat(actual).isEqualTo(expectedSource);
+        assertThat(actual).isEqualTo(OrderEmitterWorkflow.NAMESPACE + ":" + OrderEmitterWorkflow.NAME + ":"
+                + id.version());
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowCloudEventsConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowCloudEventsConfig.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.flow.config;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+/**
+ * Configuration for the CloudEvents emitted by workflows ({@code emit} tasks).
+ * <p>
+ * By default, Quarkus Flow gives every emitted CloudEvent that does not declare its own {@code source} a traceable
+ * default derived from the emitting workflow's identity ({@code namespace:name:version}). This avoids the opaque
+ * {@code reference-impl} placeholder used by the underlying SDK when no source is present.
+ */
+@ConfigMapping(prefix = "quarkus.flow.cloud-events")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface FlowCloudEventsConfig {
+
+    /**
+     * Default {@code source} applied to emitted CloudEvents that do not declare their own source.
+     * <p>
+     * When set, this fixed value is used for every emitted event (unless the event sets its own {@code source}),
+     * overriding the workflow-identity-derived default. When unset, the source defaults to the emitting workflow's
+     * identity in the form {@code namespace:name:version}.
+     * <p>
+     * An explicit {@code source} on an individual {@code emit} task always takes precedence over this value.
+     */
+    Optional<String> source();
+
+    /**
+     * Whether to derive a default {@code source} from the emitting workflow's identity
+     * ({@code namespace:name:version}) for emitted CloudEvents that do not declare their own source.
+     * <p>
+     * Set to {@code false} to disable the default entirely and preserve the underlying SDK behavior (no source
+     * injection). Ignored when {@link #source()} is set, since an explicit default source always applies.
+     */
+    @WithDefault("true")
+    boolean deriveSourceFromWorkflow();
+}

--- a/core/runtime/src/main/java/io/quarkiverse/flow/internal/EmitEventSourceInjector.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/internal/EmitEventSourceInjector.java
@@ -1,0 +1,117 @@
+package io.quarkiverse.flow.internal;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import io.serverlessworkflow.api.types.EmitTask;
+import io.serverlessworkflow.api.types.EmitTaskConfiguration;
+import io.serverlessworkflow.api.types.EventProperties;
+import io.serverlessworkflow.api.types.EventSource;
+import io.serverlessworkflow.api.types.ForTask;
+import io.serverlessworkflow.api.types.ForkTask;
+import io.serverlessworkflow.api.types.ListenTask;
+import io.serverlessworkflow.api.types.Task;
+import io.serverlessworkflow.api.types.TaskItem;
+import io.serverlessworkflow.api.types.TryTask;
+import io.serverlessworkflow.api.types.UriTemplate;
+import io.serverlessworkflow.api.types.Workflow;
+
+/**
+ * Applies a default CloudEvent {@code source} to every {@code emit} task in a workflow that does not already declare
+ * its own source.
+ * <p>
+ * The traversal is fully recursive: {@code emit} tasks can be nested inside {@code do}, {@code fork} branches,
+ * {@code try}/{@code catch} blocks, {@code for} loops, and {@code listen} {@code foreach} iterators. Existing sources
+ * (literal or runtime expression) are never overwritten.
+ */
+public final class EmitEventSourceInjector {
+
+    private EmitEventSourceInjector() {
+    }
+
+    /**
+     * Injects {@code defaultSource} into every emit task of the given workflow that has an event {@code with} block
+     * but no {@code source}. No-op when the workflow or default source is absent.
+     *
+     * @param workflow the workflow whose emit tasks are visited (mutated in place)
+     * @param defaultSource the literal source to apply when an emit declares no source
+     */
+    public static void applyDefaultSource(Workflow workflow, String defaultSource) {
+        if (workflow == null || defaultSource == null || defaultSource.isBlank()) {
+            return;
+        }
+        visit(workflow.getDo(), defaultSource);
+    }
+
+    private static void visit(List<TaskItem> items, String defaultSource) {
+        if (items == null) {
+            return;
+        }
+        for (TaskItem item : items) {
+            if (item == null) {
+                continue;
+            }
+            visit(item.getTask(), defaultSource);
+        }
+    }
+
+    private static void visit(Task task, String defaultSource) {
+        if (task == null) {
+            return;
+        }
+        EmitTask emit = task.getEmitTask();
+        if (emit != null) {
+            applyToEmit(emit, defaultSource);
+            return;
+        }
+        if (task.getDoTask() != null) {
+            visit(task.getDoTask().getDo(), defaultSource);
+            return;
+        }
+        ForTask forTask = task.getForTask();
+        if (forTask != null) {
+            visit(forTask.getDo(), defaultSource);
+            return;
+        }
+        ForkTask forkTask = task.getForkTask();
+        if (forkTask != null && forkTask.getFork() != null) {
+            visit(forkTask.getFork().getBranches(), defaultSource);
+            return;
+        }
+        TryTask tryTask = task.getTryTask();
+        if (tryTask != null) {
+            visit(tryTask.getTry(), defaultSource);
+            if (tryTask.getCatch() != null) {
+                visit(tryTask.getCatch().getDo(), defaultSource);
+            }
+            return;
+        }
+        ListenTask listenTask = task.getListenTask();
+        if (listenTask != null && listenTask.getForeach() != null) {
+            visit(listenTask.getForeach().getDo(), defaultSource);
+        }
+    }
+
+    private static void applyToEmit(EmitTask emit, String defaultSource) {
+        EmitTaskConfiguration configuration = emit.getEmit();
+        if (configuration == null || configuration.getEvent() == null) {
+            return;
+        }
+        EventProperties properties = configuration.getEvent().getWith();
+        if (properties == null || properties.getSource() != null) {
+            return;
+        }
+        properties.setSource(literalSource(defaultSource));
+    }
+
+    private static EventSource literalSource(String value) {
+        EventSource source = new EventSource();
+        try {
+            source.withUriTemplate(new UriTemplate().withLiteralUri(new URI(value)));
+        } catch (URISyntaxException ex) {
+            source.withUriTemplate(new UriTemplate().withLiteralUriTemplate(value));
+        }
+        return source;
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/flow/internal/WorkflowRegistrarService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/internal/WorkflowRegistrarService.java
@@ -6,6 +6,7 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.quarkiverse.flow.config.FlowCloudEventsConfig;
 import io.quarkus.arc.Unremovable;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.impl.WorkflowApplication;
@@ -24,10 +25,28 @@ public class WorkflowRegistrarService {
     @Inject
     WorkflowApplication application;
 
+    @Inject
+    FlowCloudEventsConfig cloudEventsConfig;
+
     public WorkflowDefinition register(Workflow workflow) {
-        LOGGER.debug("Registering workflow {}", WorkflowDefinitionId.of(workflow));
+        final WorkflowDefinitionId id = WorkflowDefinitionId.of(workflow);
+        LOGGER.debug("Registering workflow {}", id);
+        applyDefaultEventSource(workflow, id);
         final WorkflowDefinition definition = application.workflowDefinition(workflow);
         return definition;
+    }
+
+    /**
+     * Applies the configured default CloudEvent {@code source} to emit tasks that declare no source. The default is
+     * either an explicit configured value ({@code quarkus.flow.cloud-events.source}) or, when unset and derivation is
+     * enabled, the workflow's identity as {@code namespace:name:version}.
+     */
+    private void applyDefaultEventSource(Workflow workflow, WorkflowDefinitionId id) {
+        final String defaultSource = cloudEventsConfig.source()
+                .orElseGet(() -> cloudEventsConfig.deriveSourceFromWorkflow() ? id.toString(":") : null);
+        if (defaultSource != null) {
+            EmitEventSourceInjector.applyDefaultSource(workflow, defaultSource);
+        }
     }
 
 }

--- a/core/runtime/src/test/java/io/quarkiverse/flow/internal/EmitEventSourceInjectorTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/flow/internal/EmitEventSourceInjectorTest.java
@@ -1,0 +1,168 @@
+package io.quarkiverse.flow.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.serverlessworkflow.api.types.DoTask;
+import io.serverlessworkflow.api.types.EmitEventDefinition;
+import io.serverlessworkflow.api.types.EmitTask;
+import io.serverlessworkflow.api.types.EmitTaskConfiguration;
+import io.serverlessworkflow.api.types.EventProperties;
+import io.serverlessworkflow.api.types.EventSource;
+import io.serverlessworkflow.api.types.ForTask;
+import io.serverlessworkflow.api.types.ForkTask;
+import io.serverlessworkflow.api.types.ForkTaskConfiguration;
+import io.serverlessworkflow.api.types.ListenTask;
+import io.serverlessworkflow.api.types.SubscriptionIterator;
+import io.serverlessworkflow.api.types.Task;
+import io.serverlessworkflow.api.types.TaskItem;
+import io.serverlessworkflow.api.types.TryTask;
+import io.serverlessworkflow.api.types.TryTaskCatch;
+import io.serverlessworkflow.api.types.UriTemplate;
+import io.serverlessworkflow.api.types.Workflow;
+
+class EmitEventSourceInjectorTest {
+
+    private static final String DEFAULT_SOURCE = "acme:order-processor:1.0.0";
+
+    @Test
+    @DisplayName("applies_default_source_to_top_level_emit_without_source")
+    void applies_default_source_to_top_level_emit_without_source() {
+        TaskItem emit = emit("emit", null);
+        Workflow workflow = new Workflow().withDo(List.of(emit));
+
+        EmitEventSourceInjector.applyDefaultSource(workflow, DEFAULT_SOURCE);
+
+        assertThat(sourceOf(emit)).isEqualTo(DEFAULT_SOURCE);
+    }
+
+    @Test
+    @DisplayName("preserves_explicit_source")
+    void preserves_explicit_source() {
+        TaskItem emit = emit("emit", "https://petstore.com");
+        Workflow workflow = new Workflow().withDo(List.of(emit));
+
+        EmitEventSourceInjector.applyDefaultSource(workflow, DEFAULT_SOURCE);
+
+        assertThat(sourceOf(emit)).isEqualTo("https://petstore.com");
+    }
+
+    @Test
+    @DisplayName("applies_default_source_to_emits_nested_in_every_container")
+    void applies_default_source_to_emits_nested_in_every_container() {
+        TaskItem inDo = emit("inDo", null);
+        TaskItem inFor = emit("inFor", null);
+        TaskItem inFork = emit("inFork", null);
+        TaskItem inTry = emit("inTry", null);
+        TaskItem inCatch = emit("inCatch", null);
+        TaskItem inListenForeach = emit("inForeach", null);
+
+        Workflow workflow = new Workflow()
+                .withDo(List.of(
+                        doItem("do", inDo),
+                        forItem("for", inFor),
+                        forkItem("fork", inFork),
+                        tryItem("try", inTry, inCatch),
+                        listenForeachItem("listen", inListenForeach)));
+
+        EmitEventSourceInjector.applyDefaultSource(workflow, DEFAULT_SOURCE);
+
+        assertThat(List.of(
+                sourceOf(inDo),
+                sourceOf(inFor),
+                sourceOf(inFork),
+                sourceOf(inTry),
+                sourceOf(inCatch),
+                sourceOf(inListenForeach)))
+                .containsOnly(DEFAULT_SOURCE);
+    }
+
+    @Test
+    @DisplayName("is_noop_for_null_or_blank_default_and_null_workflow")
+    void is_noop_for_null_or_blank_default_and_null_workflow() {
+        TaskItem emit = emit("emit", null);
+        Workflow workflow = new Workflow().withDo(List.of(emit));
+
+        EmitEventSourceInjector.applyDefaultSource(workflow, null);
+        EmitEventSourceInjector.applyDefaultSource(workflow, "  ");
+        EmitEventSourceInjector.applyDefaultSource(null, DEFAULT_SOURCE);
+
+        assertThat(sourceOf(emit)).isNull();
+    }
+
+    @Test
+    @DisplayName("skips_emit_without_with_block_without_error")
+    void skips_emit_without_with_block_without_error() {
+        // emit configuration with an event definition but no 'with' properties
+        EmitTask emit = new EmitTask()
+                .withEmit(new EmitTaskConfiguration().withEvent(new EmitEventDefinition()));
+        TaskItem item = new TaskItem("emit", new Task().withEmitTask(emit));
+        Workflow workflow = new Workflow().withDo(List.of(item));
+
+        EmitEventSourceInjector.applyDefaultSource(workflow, DEFAULT_SOURCE);
+
+        assertThat(emit.getEmit().getEvent().getWith()).isNull();
+    }
+
+    // ----- model builders -----
+
+    private static TaskItem emit(String name, String sourceOrNull) {
+        EventProperties props = new EventProperties().withType("com.acme.test.v1");
+        if (sourceOrNull != null) {
+            props.withSource(new EventSource()
+                    .withUriTemplate(new UriTemplate().withLiteralUri(URI.create(sourceOrNull))));
+        }
+        EmitTask emit = new EmitTask()
+                .withEmit(new EmitTaskConfiguration().withEvent(new EmitEventDefinition().withWith(props)));
+        return new TaskItem(name, new Task().withEmitTask(emit));
+    }
+
+    private static TaskItem doItem(String name, TaskItem... children) {
+        return new TaskItem(name, new Task().withDoTask(new DoTask().withDo(List.of(children))));
+    }
+
+    private static TaskItem forItem(String name, TaskItem... children) {
+        return new TaskItem(name, new Task().withForTask(new ForTask().withDo(List.of(children))));
+    }
+
+    private static TaskItem forkItem(String name, TaskItem... children) {
+        return new TaskItem(name,
+                new Task().withForkTask(
+                        new ForkTask().withFork(new ForkTaskConfiguration().withBranches(List.of(children)))));
+    }
+
+    private static TaskItem tryItem(String name, TaskItem tryChild, TaskItem catchChild) {
+        return new TaskItem(name,
+                new Task().withTryTask(new TryTask()
+                        .withTry(List.of(tryChild))
+                        .withCatch(new TryTaskCatch().withDo(List.of(catchChild)))));
+    }
+
+    private static TaskItem listenForeachItem(String name, TaskItem child) {
+        return new TaskItem(name,
+                new Task().withListenTask(
+                        new ListenTask().withForeach(new SubscriptionIterator().withDo(List.of(child)))));
+    }
+
+    // ----- assertions -----
+
+    private static String sourceOf(TaskItem item) {
+        EventProperties props = item.getTask().getEmitTask().getEmit().getEvent().getWith();
+        EventSource source = props.getSource();
+        if (source == null) {
+            return null;
+        }
+        UriTemplate template = source.getUriTemplate();
+        if (template != null) {
+            return template.getLiteralUri() != null
+                    ? template.getLiteralUri().toString()
+                    : template.getLiteralUriTemplate();
+        }
+        return source.getRuntimeExpression();
+    }
+}

--- a/docs/modules/ROOT/pages/messaging.adoc
+++ b/docs/modules/ROOT/pages/messaging.adoc
@@ -90,6 +90,26 @@ With this in place:
 * External producers can send CloudEvents to the `flow-in` topic to *start or continue* workflows.
 * Workflows can `emit` CloudEvents, which are then written to the `flow-out` topic.
 
+[#default-event-source]
+=== Default event `source`
+
+The CloudEvents specification requires every event to carry a `source`. If an `emit` task does not set one explicitly, Quarkus Flow injects a traceable default derived from the emitting workflow's identity, in the form `namespace:name:version` (for example `org.acme.events:order-emitter:1.0.0`). This applies to `emit` tasks anywhere in the workflow, including those nested inside `fork`, `try`/`catch`, `for`, and `listen` iterators.
+
+You can customize this behavior:
+
+[source,properties]
+----
+# Use a single fixed source for every emitted event instead of the workflow identity
+quarkus.flow.cloud-events.source=urn:acme:orders
+
+# Or disable the default entirely and leave source handling to the underlying SDK
+quarkus.flow.cloud-events.derive-source-from-workflow=false
+----
+
+An explicit `source` on an individual `emit` (for example `produced("event.type").source("https://my-app")`) always takes precedence over both the configured value and the identity-derived default.
+
+NOTE: The event `time` is set by the underlying runtime at emission and is out of scope for this DSL-level default.
+
 == 4. Enable lifecycle events (Optional)
 
 You can configure the engine to publish its internal state changes (e.g., when a workflow starts, suspends, or faults) to a dedicated Kafka topic. This is highly useful for building observability dashboards or audit logs.


### PR DESCRIPTION
## What & why

Fixes #776.

The `emit` DSL helpers only set `type` and `data`, so emitted CloudEvents had no `source` unless the user manually chained `.source(...)`. The underlying SDK then fell back to the opaque `reference-impl`, giving no traceability.

This PR gives every emitted CloudEvent that does not declare its own `source` a traceable default, with zero configuration required.

## How

The default is injected at `WorkflowRegistrarService.register(Workflow)` — the single runtime seam shared by **both** class-based flows (`Flow.descriptor()`) and YAML/JSON flows (`WorkflowReader.readWorkflowFromClasspath`). This is the only layer with the built workflow model *and* its identity in hand.

- **`EmitEventSourceInjector`** — a recursive walker over the task tree that sets a `source` on every `emit` that has none. It descends into every container that can nest an emit: top-level `do`, `DoTask.do`, `ForTask.do`, `ForkTask.fork.branches`, `TryTask.try` + `catch.do`, and `ListenTask.foreach.do`. An explicit source (literal or runtime expression) is **never** overwritten.
- **Default value** — the emitting workflow's identity, `namespace:name:version` (`WorkflowDefinitionId.of(workflow).toString(":")`).
- **`FlowCloudEventsConfig`** (`quarkus.flow.cloud-events`):
  - `source` — a fixed global override applied to all emits.
  - `derive-source-from-workflow` (default `true`) — escape hatch to disable injection entirely.
- **Precedence**: explicit per-emit `source` → configured `source` → identity-derived → SDK fallback.

### Scope note: `time`

The event `time` default is intentionally **not** handled here. `time` is a per-execution value that cannot be baked into a definition, so it belongs in the SDK runtime — see open-workflow-specification/sdk-java#1554. This PR needs no SDK change and works against the current `7.25.1.Final`; once that SDK change ships and the version is bumped, emitted events also get a default `time`.

## Design

See `adr/2026-07-23-cloudevent-emit-defaults-design.md` for the full design, the layering principle (per-execution values in the SDK runtime; `source` ergonomics at the quarkus-flow registrar seam), and the alternatives considered.

## Testing

- `EmitEventSourceInjectorTest` — unit tests for each nesting container, explicit-source preservation, and null/blank no-ops (5 tests, passing).
- Full `core/runtime` suite passes (219 tests).
- `CloudEventDefaultSourceTest` (`@QuarkusTest`) — asserts a class-based emit flow with no source gets the identity-derived `namespace:name:version` on its registered definition. Compiles locally; relies on CI to run (needs Dev Services / Docker).
- `messaging.adoc` documents the new default and config.

## Docs

New "Default event `source`" section in `messaging.adoc`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
