### PR TITLE
Fix #781 - Fix validation errors in example workflows

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/flow/internal/WorkflowNameUtils.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/internal/WorkflowNameUtils.java
@@ -38,7 +38,7 @@ public final class WorkflowNameUtils {
         int lastDollar = classNamePart.lastIndexOf('$');
         String simpleName = lastDollar >= 0 ? classNamePart.substring(lastDollar + 1) : classNamePart;
 
-        return new WorkflowDefinitionId(packageName, safeName(simpleName),
+        return new WorkflowDefinitionId(safeName(packageName), safeName(simpleName),
                 WorkflowDefinitionId.DEFAULT_VERSION);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/flow/internal/WorkflowNameUtils.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/internal/WorkflowNameUtils.java
@@ -19,7 +19,7 @@ public final class WorkflowNameUtils {
     }
 
     public static WorkflowDefinitionId newId(Class<?> clazz) {
-        return new WorkflowDefinitionId(clazz.getPackageName(), safeNameFromClass(clazz, null),
+        return new WorkflowDefinitionId(safeName(clazz.getPackageName()), safeNameFromClass(clazz, null),
                 WorkflowDefinitionId.DEFAULT_VERSION);
     }
 

--- a/examples/auth-oauth2-oidc/src/main/java/org/acme/http/workflows/oauth2/OpenAPIWithOAuth2Flow.java
+++ b/examples/auth-oauth2-oidc/src/main/java/org/acme/http/workflows/oauth2/OpenAPIWithOAuth2Flow.java
@@ -21,7 +21,7 @@ public class OpenAPIWithOAuth2Flow extends Flow {
 
     @Override
     public Workflow descriptor() {
-        return FlowWorkflowBuilder.workflow()
+        return FlowWorkflowBuilder.workflow("openapi-with-oauth2", "quarkus-flow")
                 .use(u -> u.secrets("openapi"))
                 .tasks(t -> {
                     t.openapi("imageService", f ->

--- a/examples/auth-oauth2-oidc/src/main/java/org/acme/http/workflows/oauth2/PasswordGrantTypeFlow.java
+++ b/examples/auth-oauth2-oidc/src/main/java/org/acme/http/workflows/oauth2/PasswordGrantTypeFlow.java
@@ -22,7 +22,7 @@ public class PasswordGrantTypeFlow extends Flow {
     @Override
     public Workflow descriptor() {
         return FlowWorkflowBuilder.workflow(
-                "grant-type-password", "quarkus.flow")
+                "grant-type-password", "quarkus-flow")
                 .use(u -> u.secrets("password-grant"))
                 .tasks(
                         FlowDSL.http()

--- a/examples/auth-oauth2-oidc/src/main/java/org/acme/http/workflows/oauth2/TokenExchangeGrantTypeFlow.java
+++ b/examples/auth-oauth2-oidc/src/main/java/org/acme/http/workflows/oauth2/TokenExchangeGrantTypeFlow.java
@@ -23,7 +23,7 @@ public class TokenExchangeGrantTypeFlow extends Flow {
     @Override
     public Workflow descriptor() {
         return FlowWorkflowBuilder.workflow(
-                "token-exchange", "quarkus.flow")
+                "token-exchange", "quarkus-flow")
                 .use(use -> use.secrets("exchangeSecrets"))
                 .tasks(
                         FlowDSL.http()

--- a/examples/durable-workflows-k8s/pom.xml
+++ b/examples/durable-workflows-k8s/pom.xml
@@ -82,6 +82,16 @@
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                            <goal>native-image-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/examples/micrometer-prometheus/src/main/java/org/acme/FaultedWorkflow.java
+++ b/examples/micrometer-prometheus/src/main/java/org/acme/FaultedWorkflow.java
@@ -13,7 +13,7 @@ public class FaultedWorkflow extends Flow {
 
     @Override
     public Workflow descriptor() {
-        return workflow("faulted-workflow", "quarkus.flow").tasks(get("http://localhost:9899")) // there is no server
+        return workflow("faulted-workflow", "quarkus-flow").tasks(get("http://localhost:9899")) // there is no server
                 // running at port 9899
                 .build();
     }

--- a/examples/micrometer-prometheus/src/main/java/org/acme/SimpleWorkflow.java
+++ b/examples/micrometer-prometheus/src/main/java/org/acme/SimpleWorkflow.java
@@ -12,6 +12,6 @@ public class SimpleWorkflow extends Flow {
 
     @Override
     public Workflow descriptor() {
-        return workflow("simple-workflow", "quarkus.flow").tasks(set("{ message: \"Ana Sara\" }")).build();
+        return workflow("simple-workflow", "quarkus-flow").tasks(set("{ message: \"Ana Sara\" }")).build();
     }
 }

--- a/examples/micrometer-prometheus/src/main/resources/flow/emit.yaml
+++ b/examples/micrometer-prometheus/src/main/resources/flow/emit.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha5'
+  dsl: '1.0.0'
   namespace: test
   name: emit-event
   version: '0.1.0'

--- a/examples/suspend-resume-abort/src/main/resources/flow/switch-loop-wait.yaml
+++ b/examples/suspend-resume-abort/src/main/resources/flow/switch-loop-wait.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: 1.0.0-alpha5
+  dsl: 1.0.0
   namespace: example
   name: SwitchLoopWait
   version: 0.1.0

--- a/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/FlowLangChain4jProcessorTest.java
+++ b/langchain4j/deployment/src/test/java/io/quarkiverse/flow/langchain4j/deployment/FlowLangChain4jProcessorTest.java
@@ -34,10 +34,13 @@ public class FlowLangChain4jProcessorTest {
                     .addClasses(Agents.class)
                     .addAsResource(new StringAsset("quarkus.http.test-port=0"), "application.properties"));
 
+    private static WorkflowDefinitionId expectedId(Class<?> agentInterface) {
+        return WorkflowNameUtils.newId(agentInterface.getName());
+    }
+
     @Test
     void shouldRegisterPlaceholderWorkflowForSequenceAgent() {
-        // The generated Flow uses WorkflowNameUtils.newId(iface) to name the workflow
-        WorkflowDefinitionId expectedId = WorkflowNameUtils.newId(Agents.StoryCreatorWithConfigurableStyleEditor.class);
+        WorkflowDefinitionId expectedId = expectedId(Agents.StoryCreatorWithConfigurableStyleEditor.class);
 
         WorkflowApplication app = Arc.container().instance(WorkflowApplication.class).get();
 
@@ -69,7 +72,7 @@ public class FlowLangChain4jProcessorTest {
     @Test
     void shouldRegisterWorkflowForSequenceAgentWithA2AClient() {
         // The generated Flow uses WorkflowNameUtils.newId(iface) to name the workflow
-        WorkflowDefinitionId expectedId = WorkflowNameUtils.newId(Agents.SequenceWithA2AAgent.class);
+        WorkflowDefinitionId expectedId = expectedId(Agents.SequenceWithA2AAgent.class);
 
         WorkflowApplication app = Arc.container().instance(WorkflowApplication.class).get();
 
@@ -109,7 +112,7 @@ public class FlowLangChain4jProcessorTest {
 
     @Test
     void shouldRegisterWorkflowForSequenceAgentWithParallelMapper() {
-        WorkflowDefinitionId expectedId = WorkflowNameUtils.newId(Agents.SequenceWithParallelMapperAgent.class);
+        WorkflowDefinitionId expectedId = expectedId(Agents.SequenceWithParallelMapperAgent.class);
 
         WorkflowApplication app = Arc.container().instance(WorkflowApplication.class).get();
 
@@ -132,7 +135,7 @@ public class FlowLangChain4jProcessorTest {
 
     @Test
     void shouldRegisterWorkflowForSequenceAgentWithSupervisor() {
-        WorkflowDefinitionId expectedId = WorkflowNameUtils.newId(Agents.SequenceWithSupervisorAgent.class);
+        WorkflowDefinitionId expectedId = expectedId(Agents.SequenceWithSupervisorAgent.class);
 
         WorkflowApplication app = Arc.container().instance(WorkflowApplication.class).get();
 
@@ -155,7 +158,7 @@ public class FlowLangChain4jProcessorTest {
 
     @Test
     void shouldRegisterWorkflowForSequenceAgentWithPlanner() {
-        WorkflowDefinitionId expectedId = WorkflowNameUtils.newId(Agents.SequenceWithPlannerAgent.class);
+        WorkflowDefinitionId expectedId = expectedId(Agents.SequenceWithPlannerAgent.class);
 
         WorkflowApplication app = Arc.container().instance(WorkflowApplication.class).get();
 

--- a/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/workflow/flow/ConditionalAgenticFlow.java
+++ b/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/workflow/flow/ConditionalAgenticFlow.java
@@ -43,7 +43,6 @@ public abstract class ConditionalAgenticFlow extends AgenticFlow {
     }
 
     @Override
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     public Workflow descriptor() {
         Map<Integer, Predicate<AgenticScope>> predicates = activationPredicates();
 


### PR DESCRIPTION
## Summary

- Fix namespace validation errors by sanitizing package names with `safeName()` in `WorkflowNameUtils.newId(String)` — covers annotation-based agents (langchain4j, newsletter-drafter)
- Fix hardcoded `"quarkus.flow"` namespaces to `"quarkus-flow"` in auth-oauth2-oidc, micrometer-prometheus examples
- Fix `OpenAPIWithOAuth2Flow` using `workflow()` (no args) which generated a UUID name — now uses explicit name/namespace
- Update `dsl` version from `1.0.0-alpha5` to `1.0.0` in emit.yaml and switch-loop-wait.yaml
- Remove unused `@SuppressWarnings` in `ConditionalAgenticFlow`
- Add missing quarkus-maven-plugin executions in durable-workflows-k8s

### Remaining items tracked elsewhere

- `with.authentication` null serialization → fixed in sdk-java via open-workflow-specification/sdk-java#1570
- `emit.event.with` missing `source` → tracked in open-workflow-specification/sdk-java#1554
- Relative URI pattern (`openapi/petstore.json`, `proto/greeter.proto`) → spec issue open-workflow-specification/specification#1166

Fixes #781