### PR TITLE
Fix for diagram editor rendering issue

### DIFF
--- a/core/deployment/src/main/resources/dev-ui/qwc-flow-workflows.js
+++ b/core/deployment/src/main/resources/dev-ui/qwc-flow-workflows.js
@@ -115,7 +115,8 @@ export class QwcFlow extends observeState(QwcHotReloadElement) {
 
     _visualizeDiagramEditor(workflow) {
         this._diagramEditorDialogOpened = true;
-        this._currentDiagramEditorWorkflow = workflow;
+        // Force new object to trigger re-render and not use stale workflow reference
+        this._currentDiagramEditorWorkflow = {...workflow};
     }
 
     _diagramEditorDialog() {


### PR DESCRIPTION
## Description

Fixes an intermittent Dev UI issue where the workflow diagram rendered stale after reopening resulting in a small visual issue with start and end nodes. Root cause: the diagram element only re-mounts when its workflow property reference changes; `_visualizeDiagramEditor` now passes a fresh reference each open - verified manually.

Fixes https://github.com/quarkiverse/quarkus-flow/issues/775

## Changes

Spreading `workflow` into a fresh object guarantees a new workflow reference each open, making sure it re-renders instead of reusing a stale reference.


## Testing

Manually tested.  The symptom is a visual issue and not reliably reproducible in an automated test, so none is added; the change is low-risk and isolated to the Dev UI host.

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] Tested manually (describe below if applicable)

### Manual Testing

Repeatedly open/close/reopen the diagram

**Before fix (notice the console logs are not triggered meaning the `updated` function is not called on a bad render, when you switch views it is rerendered)**

https://github.com/user-attachments/assets/417b5747-204a-4d5f-9385-78a1e59c3434

**After fix (notice the console logs verifying the `updated` function is being called)**

https://github.com/user-attachments/assets/be674a75-24c7-4bdb-8f89-4ff9daf4f814

**More before and after testing**
Before:

https://github.com/user-attachments/assets/218990a1-ed49-4a27-abce-c59297d424d3

After

https://github.com/user-attachments/assets/5c2f15f7-772a-4bc3-87cd-5d3a034ea737


## Checklist

Before submitting this PR, please ensure:

- [x] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [x] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [x] Commit messages are clear and follow conventional commits style
- [x] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
