### PR TITLE
Fail fast when AgenticAwareModelFactory is not registered

### DIFF
--- a/langchain4j/integration-tests/src/main/java/io/quarkiverse/flow/langchain4j/it/Agents.java
+++ b/langchain4j/integration-tests/src/main/java/io/quarkiverse/flow/langchain4j/it/Agents.java
@@ -221,6 +221,26 @@ public class Agents {
         ResultWithAgenticScope<String> ask(@V("request") String request);
     }
 
+    public interface CreativeWriterWithLimit {
+        @UserMessage("""
+                You are a creative writer.
+                Generate a draft of a story of exactly {{maxSentences}} sentences around the given topic.
+                Return only the story and nothing else.
+                The topic is {{topic}}.
+                """)
+        @Agent(description = "Generate a story with a sentence limit", outputKey = "story")
+        String generateStory(@V("topic") String topic, @V("maxSentences") Integer maxSentences);
+    }
+
+    public interface StoryCreatorWithMaxSentences {
+        @SequenceAgent(outputKey = "story", subAgents = {
+                CreativeWriterWithLimit.class, AudienceEditor.class, StyleEditor.class
+        })
+        @Agent(description = "write with sentence limit", outputKey = "story")
+        String write(@V("topic") String topic, @V("style") String style, @V("audience") String audience,
+                @V("maxSentences") Integer maxSentences);
+    }
+
     public interface DumbAgent {
         @Agent(description = "A dumb agent to workaround a dumb check", outputKey = "loopCounter")
         int dumb(@V("request") String request);
@@ -239,6 +259,9 @@ public class Agents {
 
         @Agent(description = "A dumb agent to workaround a dumb check", outputKey = "mood")
         String dumb4();
+
+        @Agent(description = "A dumb agent to workaround a dumb check", outputKey = "maxSentences")
+        Integer dumb5();
 
     }
 

--- a/langchain4j/integration-tests/src/main/java/io/quarkiverse/flow/langchain4j/it/CreativeWriterAdapter.java
+++ b/langchain4j/integration-tests/src/main/java/io/quarkiverse/flow/langchain4j/it/CreativeWriterAdapter.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.flow.langchain4j.it;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class CreativeWriterAdapter {
+
+    @Inject
+    Agents.StoryCreatorWithMaxSentences storyAgent;
+
+    public String writeStory(CreativeWriterRequest req) {
+        return storyAgent.write(req.topic(), req.style(), req.audience(), req.maxSentences());
+    }
+
+}

--- a/langchain4j/integration-tests/src/main/java/io/quarkiverse/flow/langchain4j/it/CreativeWriterFlow.java
+++ b/langchain4j/integration-tests/src/main/java/io/quarkiverse/flow/langchain4j/it/CreativeWriterFlow.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.flow.langchain4j.it;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkiverse.flow.Flow;
+import io.quarkiverse.flow.dsl.FlowDSL;
+import io.quarkiverse.flow.dsl.FlowWorkflowBuilder;
+import io.serverlessworkflow.api.types.Workflow;
+
+@ApplicationScoped
+public class CreativeWriterFlow extends Flow {
+
+    @Inject
+    CreativeWriterAdapter creativeWriter;
+
+    @Override
+    public Workflow descriptor() {
+        return FlowWorkflowBuilder.workflow("creative-writer")
+                .tasks(FlowDSL.function("writeStory",
+                        (CreativeWriterRequest req) -> creativeWriter.writeStory(req)))
+                .build();
+    }
+}

--- a/langchain4j/integration-tests/src/main/java/io/quarkiverse/flow/langchain4j/it/CreativeWriterRequest.java
+++ b/langchain4j/integration-tests/src/main/java/io/quarkiverse/flow/langchain4j/it/CreativeWriterRequest.java
@@ -1,0 +1,4 @@
+package io.quarkiverse.flow.langchain4j.it;
+
+public record CreativeWriterRequest(String topic, String style, String audience, Integer maxSentences) {
+}

--- a/langchain4j/integration-tests/src/test/java/io/quarkiverse/flow/langchain4j/it/CreativeWriterFlowIT.java
+++ b/langchain4j/integration-tests/src/test/java/io/quarkiverse/flow/langchain4j/it/CreativeWriterFlowIT.java
@@ -1,0 +1,121 @@
+package io.quarkiverse.flow.langchain4j.it;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static io.quarkiverse.flow.langchain4j.it.WiremockOllamaUtils.ollamaResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.junit.QuarkusTest;
+import io.serverlessworkflow.impl.WorkflowModel;
+
+/**
+ * Tests the Flow-to-agent code path where a {@link CreativeWriterFlow} invokes a
+ * {@link CreativeWriterAdapter} that calls a {@code @SequenceAgent}. This exercises the
+ * scope serialization/deserialization between the parent workflow and the child agentic
+ * workflow — the path where parameter values can be lost (Strings become null,
+ * Integers become 0).
+ *
+ * <p>
+ * The WireMock stubs intentionally match on the <b>actual parameter values</b> (e.g.
+ * "dungeons and dragons", "nerds", "fantasy", "5") rather than generic keywords. If
+ * parameters are lost during scope serialization the stubs will not match, WireMock
+ * returns 404, and the test fails.
+ *
+ * @see <a href="https://github.com/quarkusio/quarkus-workshop-langchain4j/pull/376#issuecomment-5091522868">Bug report</a>
+ */
+@QuarkusTest
+@QuarkusTestResource(value = CreativeWriterFlowIT.StrictParameterOllamaMock.class, restrictToAnnotatedClass = true)
+public class CreativeWriterFlowIT {
+
+    @Inject
+    CreativeWriterFlow creativeWriterFlow;
+
+    @Test
+    @DisplayName("test_flow_calling_sequence_agent_preserves_string_and_integer_parameters")
+    void test_flow_calling_sequence_agent_preserves_string_and_integer_parameters() {
+        CreativeWriterRequest request = new CreativeWriterRequest("dungeons and dragons", "fantasy", "nerds", 5);
+
+        WorkflowModel result = creativeWriterFlow.startInstance(request).await().indefinitely();
+
+        assertThat(result).isNotNull();
+        assertThat(result.isNull()).isFalse();
+        String story = result.asText().orElse(null);
+        assertThat(story)
+                .as("The sequence agent (CreativeWriterWithLimit -> AudienceEditor -> StyleEditor) should return a story")
+                .isNotBlank();
+    }
+
+    /**
+     * WireMock stubs that match on actual parameter values injected into LLM prompts.
+     * Each agent's stub requires the corresponding input parameter value to be present
+     * in the request body — proving it survived the Flow-to-agent scope serialization.
+     */
+    public static class StrictParameterOllamaMock implements QuarkusTestResourceLifecycleManager {
+
+        private WireMockServer wireMock;
+
+        @Override
+        public Map<String, String> start() {
+            wireMock = new WireMockServer(options()
+                    .dynamicPort()
+                    .notifier(new ConsoleNotifier(true)));
+            wireMock.start();
+
+            // CreativeWriterWithLimit: prompt uses {{topic}} and {{maxSentences}}
+            // — match on both the topic String value AND the Integer value
+            wireMock.stubFor(post(urlEqualTo("/api/chat"))
+                    .withRequestBody(containing("creative"))
+                    .withRequestBody(containing("dungeons and dragons"))
+                    .withRequestBody(containing("5 sentences"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(ollamaResponse("A brave party ventured into the dungeon."))));
+
+            // AudienceEditor: prompt uses {{audience}} — match on actual audience value
+            wireMock.stubFor(post(urlEqualTo("/api/chat"))
+                    .withRequestBody(containing("audience"))
+                    .withRequestBody(containing("nerds"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(ollamaResponse(
+                                    "A brave party of level-20 adventurers ventured into the dungeon."))));
+
+            // StyleEditor: prompt uses {{style}} — match on actual style value
+            wireMock.stubFor(post(urlEqualTo("/api/chat"))
+                    .withRequestBody(containing("style"))
+                    .withRequestBody(containing("fantasy"))
+                    .atPriority(5)
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(ollamaResponse(
+                                    "In the enchanted realm, a brave party of level-20 adventurers ventured into the dungeon."))));
+
+            return Map.of("quarkus.langchain4j.ollama.base-url", wireMock.baseUrl());
+        }
+
+        @Override
+        public void stop() {
+            if (wireMock != null) {
+                wireMock.stop();
+            }
+        }
+    }
+}

--- a/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/workflow/service/FlowPlanner.java
+++ b/langchain4j/runtime/src/main/java/io/quarkiverse/flow/langchain4j/workflow/service/FlowPlanner.java
@@ -19,6 +19,7 @@ import dev.langchain4j.agentic.planner.AgenticSystemTopology;
 import dev.langchain4j.agentic.planner.InitPlanningContext;
 import dev.langchain4j.agentic.planner.Planner;
 import dev.langchain4j.agentic.planner.PlanningContext;
+import io.quarkiverse.flow.langchain4j.spec.AgenticAwareModelFactory;
 import io.quarkiverse.flow.langchain4j.workflow.flow.*;
 import io.quarkiverse.flow.langchain4j.workflow.runtime.*;
 import io.serverlessworkflow.impl.WorkflowDefinition;
@@ -57,6 +58,13 @@ public class FlowPlanner implements Planner {
 
     @Override
     public Action firstAction(PlanningContext planningContext) {
+        if (!(definition.application().modelFactory() instanceof AgenticAwareModelFactory)) {
+            throw new IllegalStateException(
+                    "AgenticAwareModelFactory is not registered as the workflow model factory. "
+                            + "AgenticScope parameters will be silently lost during workflow execution. "
+                            + "Actual factory: " + definition.application().modelFactory().getClass().getName());
+        }
+
         final WorkflowInstance instance = definition.instance(planningContext.agenticScope());
         planningContext.agenticScope().writeExecutionContext(instance.id(), this);
 


### PR DESCRIPTION
## Summary

- Adds a guard in `FlowPlanner.firstAction()` that throws `IllegalStateException` if the workflow model factory is not `AgenticAwareModelFactory`. Without this factory, `AgenticScope` parameters are silently lost during serialization — Strings become null and Integers become 0, causing `MissingArgumentException` in sub-agents.
- Adds `CreativeWriterFlowIT` integration test that exercises the nested Flow → adapter → `@SequenceAgent` scope serialization path with WireMock stubs matching on actual parameter values (including `Integer maxSentences=5`).

## Context

Reported in https://github.com/quarkusio/quarkus-workshop-langchain4j/pull/376#issuecomment-5091522868. Investigation showed the mechanism works correctly when `AgenticAwareModelFactory` is registered, but if it ever fails to register, `JacksonModelFactory.fromOther()` silently creates a new empty scope with no warning. The guard makes this failure mode explicit.

## Test plan

- [x] `CreativeWriterFlowIT` passes — verifies String and Integer params survive scope serialization
- [x] All existing integration tests pass