### PR TITLE
feat: Update @openworkflowspec/diagram-editor to 1.0.0 and align SDK exclusions

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <esbuild-maven-plugin.version>2.0.0</esbuild-maven-plugin.version>
-        <react.version>19.2.7</react.version>
+        <react.version>19.2.8</react.version>
         <scheduler.version>0.27.0</scheduler.version>
         <openworkflowspec.diagram-editor.version>1.0.0</openworkflowspec.diagram-editor.version>
         <use-sync-external-store.version>1.6.0</use-sync-external-store.version>
@@ -177,9 +177,9 @@
                         <artifactId>diagram-editor</artifactId>
                         <version>${openworkflowspec.diagram-editor.version}</version>
                         <exclusions>
-                            <!-- Required because @serverlessworkflow/sdk is an npm dependency, not available on mvnpm as alpha version, but is already bundled in @serverlessworkflow/diagram-editor's dist. -->
+                            <!-- Required because @openworkflowspec/sdk is an npm dependency, not available on mvnpm as alpha version, but is already bundled in @openworkflowspec/diagram-editor's dist. -->
                             <exclusion>
-                                <groupId>org.mvnpm.at.serverlessworkflow</groupId>
+                                <groupId>org.mvnpm.at.openworkflowspec</groupId>
                                 <artifactId>sdk</artifactId>
                             </exclusion>
                             <!-- D3 is already bundled in @openworkflowspec/diagram-editor, avoid version conflicts for transitive D3 dependencies. -->

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -14,7 +14,7 @@
         <esbuild-maven-plugin.version>2.0.0</esbuild-maven-plugin.version>
         <react.version>19.2.7</react.version>
         <scheduler.version>0.27.0</scheduler.version>
-        <openworkflowspec.diagram-editor.version>0.2.0</openworkflowspec.diagram-editor.version>
+        <openworkflowspec.diagram-editor.version>1.0.0</openworkflowspec.diagram-editor.version>
         <use-sync-external-store.version>1.6.0</use-sync-external-store.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,9 +42,9 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.log.level>OFF</quarkus.log.level>
 
-        <quarkus.version>3.33.2.1</quarkus.version>
+        <quarkus.version>3.33.3</quarkus.version>
         <jandex.version>3.6.0</jandex.version>
-        <io.serverlessworkflow.version>7.26.0.Final</io.serverlessworkflow.version>
+        <io.serverlessworkflow.version>7.26.1.Final</io.serverlessworkflow.version>
         <io.cloudevents.version>5.0.0</io.cloudevents.version>
 
         <io.quarkiverse.jackson-jq.version>2.5.2</io.quarkiverse.jackson-jq.version>


### PR DESCRIPTION
Closes https://github.com/quarkiverse/quarkus-flow/issues/796

### Description:                                                                                                                                
                                                                                                                                            
This PR upgrades @openworkflowspec/diagram-editor to `1.0.0` release and align `@serverlessworkflow/sdk` with the new name `@openworkflowspec/sdk`

### Alternatives considered

_No response_

### Area(s)

- [x] Runtime / Engine
- [ ] DSL / API
- [x] Dev UI / Mermaid
- [ ] Persistence
- [ ] Messaging / CloudEvents
- [ ] Observability (Micrometer / OTEL)
- [ ] Docs & examples
- [ ] Agentic AI

### Impact & scope

_No response_


### How to test:
- from Quarkus Flow:
  - `mvn clean install -DskipTests`

- Run an example:
```
cd examples/suspend-resume-abort
#or this one to have multiple WFs
#cd examples/micrometer-prometheus
mvn clean quarkus:dev
```


## Preview:
https://github.com/user-attachments/assets/5803df66-96ee-48ba-9742-e65f7898d881

