### PR TITLE
Fix #799 - Use SmallRye CloudEvent metadata for messaging bridge

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -46,6 +46,7 @@
 ** xref:idempotency-correlation.adoc[Idempotency and Correlation]
 
 * Migration Guides
+** xref:migration-0.14-to-0.15.adoc[0.14.x to 0.15.0]
 ** xref:migration-0.13-to-0.14.adoc[0.13.x to 0.14.0]
 
 * Reference

--- a/docs/modules/ROOT/pages/idempotency-correlation.adoc
+++ b/docs/modules/ROOT/pages/idempotency-correlation.adoc
@@ -325,12 +325,15 @@ public Response sendReview(HumanReview review, @HeaderParam("X-Flow-Instance-Id"
     throws JsonProcessingException {
   byte[] body = objectMapper.writeValueAsBytes(review);
 
-  CloudEvent ce = CloudEventBuilder.v1().withId(UUID.randomUUID().toString())
+  OutgoingCloudEventMetadata<?> ceMeta = OutgoingCloudEventMetadata.builder()
+    .withId(UUID.randomUUID().toString())
+    .withSource(URI.create("api:/newsletter"))
+    .withType("org.acme.newsletter.review.done")
+    .withDataContentType("application/json")
     .withExtension("flowinstanceid", instanceId)
-    .withSource(URI.create("api:/newsletter")).withType("org.acme.newsletter.review.done")
-    .withDataContentType("application/json").withData(body).build();
+    .build();
 
-  flowIn.send(CE_JSON.serialize(ce));
+  flowIn.send(Message.of(body).addMetadata(ceMeta));
   return Response.accepted().build();
 }
 ----

--- a/docs/modules/ROOT/pages/messaging.adoc
+++ b/docs/modules/ROOT/pages/messaging.adoc
@@ -42,32 +42,32 @@ quarkus.flow.messaging.defaults-enabled=true
 
 Once enabled, the engine creates two default channels:
 
-* `flow-in` (Inbound): Consumes structured CloudEvents JSON to start or wake up workflows.
-* `flow-out` (Outbound): Publishes structured CloudEvents JSON emitted by workflows.
+* `flow-in` (Inbound): Consumes CloudEvents (structured or binary) to start or wake up workflows.
+* `flow-out` (Outbound): Publishes CloudEvents emitted by workflows via SmallRye's `OutgoingCloudEventMetadata`.
 
 == 2. Map channels to Kafka topics
 
 Configure MicroProfile Reactive Messaging to connect the default Flow channels to your Kafka topics.
 
-Notice that Quarkus Flow uses `byte[]` for the payload on the wire; the engine handles the serialization and deserialization of the CloudEvent JSON envelope automatically.
+CloudEvent encoding is handled automatically by SmallRye Reactive Messaging.
+The message payload carries the event _data_, while CE attributes (`specversion`, `type`, `source`, …) travel via transport headers — Kafka `ce_*` headers or AMQP `cloudEvents:*` application properties.
+You do not need to configure custom serializers or deserializers.
 
 [source,properties]
 ----
 # Inbound (Listens for events to start or resume workflows)
 mp.messaging.incoming.flow-in.connector=smallrye-kafka
 mp.messaging.incoming.flow-in.topic=flow-in
-mp.messaging.incoming.flow-in.value.deserializer=org.apache.kafka.common.serialization.ByteArrayDeserializer
-mp.messaging.incoming.flow-in.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 
 # Outbound (Publishes events emitted by the workflow)
 mp.messaging.outgoing.flow-out.connector=smallrye-kafka
 mp.messaging.outgoing.flow-out.topic=flow-out
-mp.messaging.outgoing.flow-out.value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer
-mp.messaging.outgoing.flow-out.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 
 # Optional if Dev Services is off:
 # kafka.bootstrap.servers=localhost:9092
 ----
+
+TIP: The same channels work with the AMQP connector — just replace `smallrye-kafka` with `smallrye-amqp` and `topic` with `address`.
 
 == 3. Emit and Listen in the Java DSL
 
@@ -92,7 +92,7 @@ With this in place:
 
 == 4. Enable lifecycle events (Optional)
 
-You can configure the engine to publish its internal state changes (e.g., when a workflow starts, suspends, or faults) to a dedicated Kafka topic. This is highly useful for building observability dashboards or audit logs.
+You can configure the engine to publish its internal state changes (e.g., when a workflow starts, suspends, or faults) to a dedicated topic. This is highly useful for building observability dashboards or audit logs.
 
 [source,properties]
 ----
@@ -100,8 +100,6 @@ quarkus.flow.messaging.lifecycle-enabled=true
 
 mp.messaging.outgoing.flow-lifecycle-out.connector=smallrye-kafka
 mp.messaging.outgoing.flow-lifecycle-out.topic=flow-lifecycle-out
-mp.messaging.outgoing.flow-lifecycle-out.key.serializer=org.apache.kafka.common.serialization.StringSerializer
-mp.messaging.outgoing.flow-lifecycle-out.value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer
 ----
 
 Common lifecycle event types published to this topic include:

--- a/docs/modules/ROOT/pages/migration-0.14-to-0.15.adoc
+++ b/docs/modules/ROOT/pages/migration-0.14-to-0.15.adoc
@@ -1,0 +1,142 @@
+= Migration Guide: 0.14.x to 0.15.0
+include::includes/attributes.adoc[]
+
+Quarkus Flow 0.15.0 fixes CloudEvent encoding on the messaging bridge.
+The `flow-out` producer and `flow-in` consumer now use SmallRye Reactive Messaging's native CloudEvent support instead of manual JSON serialization.
+
+This is a **wire-format breaking change**: the outgoing message payload on `flow-out` is now the event _data_ only — CloudEvent attributes travel via transport headers (Kafka `ce_*`, AMQP `cloudEvents:*`).
+Code that reads raw bytes from `flow-out` and calls `JsonFormat.deserialize()` must be updated.
+
+== Why the change?
+
+In 0.14.x the publisher serialized the full CloudEvent JSON envelope into the message body via `JsonFormat.serialize()` and sent it as opaque `byte[]`.
+No transport-level headers were set.
+This caused two problems:
+
+* Consumers using the standard `CloudEventDeserializer` from the CloudEvents Kafka SDK failed with `CloudEventRWException: Unknown encoding` because neither the `content-type` header (structured mode) nor the `ce_specversion` header (binary mode) was present.
+* The approach was Kafka-specific.
+  Adding Kafka headers would have broken AMQP and other connectors.
+
+0.15.0 delegates CloudEvent encoding to SmallRye via `OutgoingCloudEventMetadata` (outbound) and `IncomingCloudEventMetadata` (inbound).
+SmallRye maps CE attributes to the appropriate transport mechanism for each connector, keeping the bridge transport-agnostic.
+
+== What changed
+
+=== Outbound (`flow-out`)
+
+[cols="1,1",options="header"]
+|===
+| Before (0.14.x) | After (0.15.0)
+
+| Message body = full CE JSON envelope (`specversion`, `type`, `source`, `data`, …)
+| Message body = CE _data_ payload only
+
+| No transport headers
+| CE attributes in transport headers (Kafka `ce_*`, AMQP `cloudEvents:*`)
+
+| Manual `JsonFormat.serialize()`
+| SmallRye `OutgoingCloudEventMetadata`
+|===
+
+=== Inbound (`flow-in`)
+
+[cols="1,1",options="header"]
+|===
+| Before (0.14.x) | After (0.15.0)
+
+| Only structured CloudEvents (full JSON envelope in body)
+| Structured _and_ binary CloudEvents
+
+| `Message<byte[]>` — rejects non-byte payloads
+| `Message<?>` — handles `byte[]`, `String`, and `JsonObject` payloads (AMQP support)
+|===
+
+=== AMQP connector support
+
+0.15.0 adds first-class support for the SmallRye AMQP connector (`quarkus-messaging-amqp`).
+Both structured and binary CloudEvents work on AMQP out of the box — no additional dependencies or configuration required.
+
+== Step-by-step migration
+
+=== 1. Update consumers reading from `flow-out`
+
+If you consume from `flow-out` using the CloudEvents SDK deserializer, your code now works correctly — no changes needed.
+This was broken in 0.14.x.
+
+If you consume raw bytes and call `JsonFormat.deserialize(payload)`, you must update to use SmallRye's `CloudEventMetadata`:
+
+[source,java]
+----
+// Before (0.14.x) — payload was the full CE JSON envelope
+byte[] payload = msg.getPayload();
+CloudEvent event = CE_JSON.deserialize(payload);
+String type = event.getType();
+byte[] data = event.getData().toBytes();
+
+// After (0.15.0) — CE attributes in metadata, payload is data only
+CloudEventMetadata<?> ceMeta = msg.getMetadata(CloudEventMetadata.class)
+    .orElseThrow();
+String type = ceMeta.getType();
+byte[] data = msg.getPayload();
+----
+
+Required import:
+
+[source,java]
+----
+import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
+----
+
+No new dependencies — `CloudEventMetadata` comes from `smallrye-reactive-messaging-api`, which is already on the classpath via the Quarkus Messaging connector.
+
+=== 2. Update Kafka consumer configuration (if applicable)
+
+If you configured an external Kafka consumer (outside SmallRye) with `CloudEventDeserializer`, it now works without changes — the transport headers are correctly set.
+
+If you previously worked around the missing headers by using `ByteArrayDeserializer` and manual parsing, you can simplify to:
+
+[source,properties]
+----
+mp.messaging.incoming.my-channel.value.deserializer=io.cloudevents.kafka.CloudEventDeserializer
+----
+
+=== 3. Verify
+
+Rebuild your project and run your messaging integration tests:
+
+[source,bash]
+----
+mvn clean verify
+----
+
+== New capabilities
+
+=== Binary CloudEvents on `flow-in`
+
+Producers can now send binary-mode CloudEvents to `flow-in`.
+The consumer auto-detects the encoding:
+
+* **Kafka**: CE attributes in `ce_*` record headers, data in the value.
+* **AMQP**: CE attributes in `cloudEvents:*` application properties, data in the body.
+
+No configuration is needed — detection is automatic via SmallRye.
+
+=== AMQP connector
+
+You can now use the AMQP connector as a drop-in replacement for Kafka:
+
+[source,properties]
+----
+mp.messaging.incoming.flow-in.connector=smallrye-amqp
+mp.messaging.incoming.flow-in.address=flow-in
+
+mp.messaging.outgoing.flow-out.connector=smallrye-amqp
+mp.messaging.outgoing.flow-out.address=flow-out
+----
+
+No additional serializer/deserializer configuration is required for AMQP.
+
+== No other behavioral changes
+
+Workflow execution semantics, the Java DSL, lifecycle events, and correlation metadata (`flowinstanceid`, `flowtaskid`) are unchanged.
+The correlation attributes are now carried as CloudEvent extension attributes in the transport headers rather than embedded in the JSON body.

--- a/docs/modules/ROOT/pages/wk-lab-3-events-yaml.adoc
+++ b/docs/modules/ROOT/pages/wk-lab-3-events-yaml.adoc
@@ -85,22 +85,20 @@ Now, connect the engine's internal channels to actual Kafka topics. Add these st
 # Inbound (Listen for 'demo.message.incoming')
 mp.messaging.incoming.flow-in.connector=smallrye-kafka
 mp.messaging.incoming.flow-in.topic=flow-in
-mp.messaging.incoming.flow-in.value.deserializer=org.apache.kafka.common.serialization.ByteArrayDeserializer
-mp.messaging.incoming.flow-in.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 
 # Outbound (Emit 'demo.message.uppercased')
 mp.messaging.outgoing.flow-out.connector=smallrye-kafka
 mp.messaging.outgoing.flow-out.topic=flow-out
-mp.messaging.outgoing.flow-out.value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer
-mp.messaging.outgoing.flow-out.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 ----
+
+NOTE: You don't need to configure serializers or deserializers. SmallRye handles CloudEvent encoding automatically via transport headers.
 
 == 4. Drive the workflow
 
 Run your application in dev mode: `./mvnw quarkus:dev`. You can now trigger the workflow in two different ways.
 
 === 4.1 Trigger via an Event (Asynchronous)
-If you have a Kafka producer, you can send a structured CloudEvent to the `flow-in` topic.
+If you have a Kafka producer, you can send a CloudEvent to the `flow-in` topic. You can use either structured mode (full JSON envelope) or binary mode (CE attributes in Kafka headers, data in the value).
 
 TIP: You can use the **Kafka Dev UI** in the Quarkus Dev UI to produce a message directly to the topic.
 

--- a/examples/newsletter-drafter/src/main/java/org/acme/newsletter/web/NewsletterAPIResource.java
+++ b/examples/newsletter-drafter/src/main/java/org/acme/newsletter/web/NewsletterAPIResource.java
@@ -2,11 +2,8 @@ package org.acme.newsletter.web;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.cloudevents.CloudEvent;
-import io.cloudevents.core.builder.CloudEventBuilder;
-import io.cloudevents.core.provider.EventFormatProvider;
-import io.cloudevents.jackson.JsonFormat;
 import io.serverlessworkflow.impl.WorkflowInstance;
+import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadata;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
@@ -16,18 +13,15 @@ import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import org.acme.newsletter.NewsletterWorkflow;
 import org.acme.newsletter.domain.HumanReview;
 import org.acme.newsletter.domain.NewsletterRequest;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
 
 @Path("/api")
 public class NewsletterAPIResource {
-
-    private static final JsonFormat CE_JSON = (JsonFormat) EventFormatProvider.getInstance()
-            .resolveFormat(JsonFormat.CONTENT_TYPE);
 
     @Inject
     NewsletterWorkflow newsletterWorkflow;
@@ -63,13 +57,15 @@ public class NewsletterAPIResource {
             throws JsonProcessingException {
         byte[] body = objectMapper.writeValueAsBytes(review);
 
-        CloudEvent ce = CloudEventBuilder.v1().withId(UUID.randomUUID().toString())
+        OutgoingCloudEventMetadata<?> ceMeta = OutgoingCloudEventMetadata.builder()
+                .withId(UUID.randomUUID().toString())
+                .withSource(URI.create("api:/newsletter"))
+                .withType("org.acme.newsletter.review.done")
+                .withDataContentType("application/json")
                 .withExtension("flowinstanceid", instanceId)
-                .withSource(URI.create("api:/newsletter")).withType("org.acme.newsletter.review.done")
-                .withDataContentType("application/json").withData(body).build();
+                .build();
 
-        byte[] ceBytes = CE_JSON.serialize(ce);
-        flowIn.send(ceBytes);
+        flowIn.send(Message.of(body).addMetadata(ceMeta));
 
         return Response.accepted().build();
     }

--- a/examples/newsletter-drafter/src/main/java/org/acme/newsletter/web/NewsletterOutBridge.java
+++ b/examples/newsletter-drafter/src/main/java/org/acme/newsletter/web/NewsletterOutBridge.java
@@ -1,11 +1,11 @@
 package org.acme.newsletter.web;
 
-import io.cloudevents.CloudEvent;
-import io.cloudevents.core.provider.EventFormatProvider;
-import io.cloudevents.jackson.JsonFormat;
+import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletionStage;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,34 +16,33 @@ import org.slf4j.LoggerFactory;
 @ApplicationScoped
 public class NewsletterOutBridge {
 
-    private static final JsonFormat CE_JSON = (JsonFormat) EventFormatProvider.getInstance()
-            .resolveFormat(JsonFormat.CONTENT_TYPE);
     private static final Logger LOG = LoggerFactory.getLogger(NewsletterOutBridge.class);
 
     // match the type emitted by our workflow: "org.acme.email.review.required"
     private static final String REVIEW_REQUIRED_TYPE = "org.acme.email.review.required";
 
     @Incoming("flow-out-incoming")
-    public void onFlowOut(byte[] record) {
+    public CompletionStage<Void> onFlowOut(Message<byte[]> msg) {
         try {
-            CloudEvent ce = CE_JSON.deserialize(record);
-            if (ce == null || ce.getType() == null)
-                return;
+            CloudEventMetadata<?> ceMeta = msg.getMetadata(CloudEventMetadata.class).orElse(null);
+            if (ceMeta == null || ceMeta.getType() == null)
+                return msg.ack();
 
-            if (REVIEW_REQUIRED_TYPE.equals(ce.getType())) {
-                byte[] data = ce.getData() != null ? ce.getData().toBytes() : null;
+            if (REVIEW_REQUIRED_TYPE.equals(ceMeta.getType())) {
+                byte[] data = msg.getPayload();
                 // If there's no data, send a minimal envelope so the UI can handle it.
                 String json = (data == null || data.length == 0)
                         ? "{\"type\":\"" + REVIEW_REQUIRED_TYPE + "\",\"payload\":null}"
                         : new String(data, StandardCharsets.UTF_8);
 
                 LOG.info("Received review (workflow instance: {}) required event: {}",
-                        ce.getExtension("flowinstanceid"), json);
+                        ceMeta.getExtension("flowinstanceid"), json);
 
                 NewsletterUpdatesSocket.broadcast(json);
             }
         } catch (Exception ex) {
-            LOG.error("Failed to consume event {}", new String(record), ex);
+            LOG.error("Failed to consume event", ex);
         }
+        return msg.ack();
     }
 }

--- a/examples/newsletter-drafter/src/test/java/org/acme/newsletter/NewsletterWorkflowIT.java
+++ b/examples/newsletter-drafter/src/test/java/org/acme/newsletter/NewsletterWorkflowIT.java
@@ -11,19 +11,16 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.cloudevents.CloudEvent;
-import io.cloudevents.core.provider.EventFormatProvider;
-import io.cloudevents.jackson.JsonFormat;
 import io.quarkus.test.InjectMock;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.kafka.InjectKafkaCompanion;
-import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 import io.serverlessworkflow.impl.jackson.JsonUtils;
-import io.smallrye.reactive.messaging.kafka.companion.ConsumerTask;
-import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
+import jakarta.inject.Inject;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import org.acme.newsletter.agents.AutoDraftCriticAgent;
 import org.acme.newsletter.agents.HumanEditorAgent;
@@ -31,8 +28,8 @@ import org.acme.newsletter.domain.HumanReview;
 import org.acme.newsletter.domain.NewsletterDraft;
 import org.acme.newsletter.domain.NewsletterRequest;
 import org.acme.newsletter.services.MailService;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -41,14 +38,12 @@ import org.mockito.ArgumentCaptor;
 
 @DisabledOnOs(OS.WINDOWS)
 @QuarkusTest
-@QuarkusTestResource(KafkaCompanionResource.class)
+@TestProfile(NewsletterWorkflowIT.BroadcastProfile.class)
 public class NewsletterWorkflowIT {
 
-    private static final JsonFormat CE_JSON = (JsonFormat) EventFormatProvider.getInstance()
-            .resolveFormat(JsonFormat.CONTENT_TYPE);
-
-    @InjectKafkaCompanion
-    KafkaCompanion companion;
+    @Inject
+    @Channel("flow-out-incoming")
+    io.smallrye.mutiny.Multi<Message<byte[]>> flowOutEvents;
 
     @InjectMock
     MailService mailService;
@@ -74,17 +69,29 @@ public class NewsletterWorkflowIT {
 
     @Test
     void agent_chain_human_review_two_rounds_via_rest() {
-        // Start consuming BEFORE triggering the workflow
-        ConsumerTask<Object, Object> out = companion
-                .consumeWithDeserializers(StringDeserializer.class, ByteArrayDeserializer.class).fromTopics("flow-out");
-
         final String expectedType = "org.acme.email.review.required";
-        final AtomicReference<NewsletterDraft> draft1 = new AtomicReference<>();
-        final AtomicReference<NewsletterDraft> draft2 = new AtomicReference<>();
-        final AtomicLong firstReviewOffset = new AtomicLong(-1L);
-
-        // Store the correlation ID
+        final List<NewsletterDraft> capturedDrafts = new CopyOnWriteArrayList<>();
         final AtomicReference<String> instanceIdRef = new AtomicReference<>();
+
+        // Subscribe to flow-out events to capture review-required events
+        flowOutEvents.subscribe().with(msg -> {
+            try {
+                CloudEventMetadata<?> ceMeta = msg.getMetadata(CloudEventMetadata.class).orElse(null);
+                if (ceMeta != null && expectedType.equals(ceMeta.getType())) {
+                    NewsletterDraft draft = parseNewsletterDraft(msg.getPayload());
+                    if (draft != null) {
+                        capturedDrafts.add(draft);
+                        String flowInstanceId = ceMeta.getExtension("flowinstanceid")
+                                .orElseThrow(() -> new IllegalStateException("flowinstanceid not presented in the event"))
+                                .toString();
+                        instanceIdRef.compareAndSet(null, flowInstanceId);
+                    }
+                }
+                msg.ack();
+            } catch (Exception e) {
+                // ignore non-matching events
+            }
+        });
 
         final NewsletterRequest request = new NewsletterRequest(NewsletterRequest.MarketMood.BULLISH,
                 List.of("IBM:-13%", "GOOGL:+5%"), "Fed is about to cut taxes, software companies to move up",
@@ -93,51 +100,27 @@ public class NewsletterWorkflowIT {
         // 1) start via REST
         given().contentType("application/json").body(request).when().post("/api/newsletter").then().statusCode(202);
 
-        // 2) ROUND #1 — wait first review-required and capture its offset AND instanceId
+        // 2) ROUND #1 — wait first review-required
         await().atMost(ofSeconds(10)).untilAsserted(() -> {
-            boolean found = out.stream().anyMatch(rec -> {
-                CloudEvent ce = CE_JSON.deserialize((byte[]) rec.value());
-                if (expectedType.equals(ce.getType())) {
-                    draft1.set(parseNewsletterDraft(ce));
-                    firstReviewOffset.set(rec.offset());
-
-                    // TODO: to actually filter it once the SDK fixes the event filtering DSL
-                    // Extract the flowinstanceid extension added by Quarkus Flow
-                    Object flowInstanceId = ce.getExtension("flowinstanceid");
-                    assertThat(flowInstanceId).isNotNull();
-                    instanceIdRef.set(flowInstanceId.toString());
-
-                    return true;
-                }
-                return false;
-            });
-            assertThat(found).isTrue();
+            assertThat(capturedDrafts).as("Should receive first review-required event").isNotEmpty();
         });
-        assertThat(draft1.get()).isNotNull();
+        assertThat(capturedDrafts.get(0)).isNotNull();
         assertThat(instanceIdRef.get()).isNotEmpty();
 
         // 3) needs_revision -> loop back to drafter, passing the correlation ID
         sendHumanReview(instanceIdRef.get(),
-                new HumanReview(draft1.get(), "Please tone down the hype", HumanReview.ReviewStatus.NEEDS_REVISION));
+                new HumanReview(capturedDrafts.get(0), "Please tone down the hype",
+                        HumanReview.ReviewStatus.NEEDS_REVISION));
 
-        // 4) ROUND #2 — wait NEXT review-required (offset strictly greater)
+        // 4) ROUND #2 — wait NEXT review-required
         await().atMost(ofSeconds(10)).untilAsserted(() -> {
-            boolean found = out.stream().anyMatch(rec -> {
-                if (rec.offset() <= firstReviewOffset.get())
-                    return false;
-                CloudEvent ce = CE_JSON.deserialize((byte[]) rec.value());
-                if (expectedType.equals(ce.getType())) {
-                    draft2.set(parseNewsletterDraft(ce));
-                    return true;
-                }
-                return false;
-            });
-            assertThat(found).isTrue();
+            assertThat(capturedDrafts).as("Should receive second review-required event")
+                    .hasSizeGreaterThanOrEqualTo(2);
         });
-        assertThat(draft2.get()).isNotNull();
+        assertThat(capturedDrafts.get(1)).isNotNull();
 
         // 5) done -> workflow proceeds to sendNewsletter
-        sendHumanReview(instanceIdRef.get(), new HumanReview(draft2.get(), "", HumanReview.ReviewStatus.DONE));
+        sendHumanReview(instanceIdRef.get(), new HumanReview(capturedDrafts.get(1), "", HumanReview.ReviewStatus.DONE));
 
         // 6) verify MailService was called with some non-empty body
         await().atMost(ofSeconds(10)).untilAsserted(() -> {
@@ -145,8 +128,6 @@ public class NewsletterWorkflowIT {
             verify(mailService, atLeastOnce()).send(eq("subscribers@acme.finance.org"), bodyCaptor.capture());
             assertThat(bodyCaptor.getValue()).isNotNull();
         });
-
-        out.close();
     }
 
     private void sendHumanReview(String instanceId, HumanReview review) {
@@ -157,14 +138,20 @@ public class NewsletterWorkflowIT {
                 .contentType("application/json").body(review).when().put("/api/newsletter").then().statusCode(202);
     }
 
-    private NewsletterDraft parseNewsletterDraft(CloudEvent ce) {
+    private NewsletterDraft parseNewsletterDraft(byte[] data) {
         try {
-            byte[] data = ce.getData() == null ? null : ce.getData().toBytes();
-            if (data == null)
+            if (data == null || data.length == 0)
                 return null;
             return JsonUtils.mapper().readValue(data, NewsletterDraft.class);
         } catch (Exception e) {
-            throw new IllegalStateException("Failed to parse NewsletterDraft from CloudEvent data", e);
+            throw new IllegalStateException("Failed to parse NewsletterDraft from event data", e);
+        }
+    }
+
+    public static class BroadcastProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("mp.messaging.incoming.flow-out-incoming.broadcast", "true");
         }
     }
 }

--- a/examples/resilient-task-orchestrator/src/test/java/org/acme/orchestrator/BuildPipelineIT.java
+++ b/examples/resilient-task-orchestrator/src/test/java/org/acme/orchestrator/BuildPipelineIT.java
@@ -1,7 +1,6 @@
 package org.acme.orchestrator;
 
-import io.cloudevents.CloudEvent;
-import io.cloudevents.jackson.JsonFormat;
+import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -13,6 +12,7 @@ import org.acme.orchestrator.model.TaskState;
 import org.acme.orchestrator.model.TaskStatus;
 import org.acme.orchestrator.service.TaskStateStore;
 import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,14 +48,13 @@ class BuildPipelineIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(BuildPipelineIT.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final JsonFormat CE_JSON = new JsonFormat();
 
     @Inject
     TaskStateStore stateStore;
 
     @Inject
     @Channel("flow-in")
-    io.smallrye.mutiny.Multi<byte[]> flowInEvents;
+    io.smallrye.mutiny.Multi<Message<byte[]>> flowInEvents;
 
     // Track emitted events across tests
     private Set<String> emittedTaskIds;
@@ -66,14 +65,15 @@ class BuildPipelineIT {
         emittedTaskIds = ConcurrentHashMap.newKeySet();
 
         // Subscribe to flow-in events to track which tasks were actually emitted
-        flowInEvents.subscribe().with(eventBytes -> {
+        flowInEvents.subscribe().with(msg -> {
             try {
-                CloudEvent ce = CE_JSON.deserialize(eventBytes);
-                if (ce.getType().equals("org.acme.build.task.started")) {
-                    BuildTask task = objectMapper.readValue(ce.getData().toBytes(), BuildTask.class);
+                CloudEventMetadata<?> ceMeta = msg.getMetadata(CloudEventMetadata.class).orElse(null);
+                if (ceMeta != null && "org.acme.build.task.started".equals(ceMeta.getType())) {
+                    BuildTask task = objectMapper.readValue(msg.getPayload(), BuildTask.class);
                     emittedTaskIds.add(task.id());
                     LOG.info("Task started event captured: {}", task.id());
                 }
+                msg.ack();
             } catch (Exception e) {
                 LOG.error("Failed to process event", e);
             }

--- a/examples/resilient-task-orchestrator/src/test/java/org/acme/orchestrator/CoordinatorWorkflowIT.java
+++ b/examples/resilient-task-orchestrator/src/test/java/org/acme/orchestrator/CoordinatorWorkflowIT.java
@@ -2,7 +2,6 @@ package org.acme.orchestrator;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
@@ -10,6 +9,7 @@ import org.acme.orchestrator.model.BuildSpec;
 import org.acme.orchestrator.model.BuildTask;
 import org.acme.orchestrator.workflow.CoordinatorWorkflow;
 import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,9 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.cloudevents.CloudEvent;
-import io.cloudevents.core.provider.EventFormatProvider;
-import io.cloudevents.jackson.JsonFormat;
+import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -48,9 +46,6 @@ class CoordinatorWorkflowIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(CoordinatorWorkflowIT.class);
 
-    private static final JsonFormat CE_JSON = (JsonFormat) EventFormatProvider.getInstance()
-            .resolveFormat(JsonFormat.CONTENT_TYPE);
-
     @Inject
     CoordinatorWorkflow coordinatorWorkflow;
 
@@ -60,7 +55,7 @@ class CoordinatorWorkflowIT {
     // Subscribe to flow-in to capture emitted events
     @Inject
     @Channel("flow-in")
-    Multi<byte[]> flowInEvents;
+    Multi<Message<byte[]>> flowInEvents;
 
     private List<BuildTask> capturedTasks;
 
@@ -69,16 +64,17 @@ class CoordinatorWorkflowIT {
         capturedTasks = new CopyOnWriteArrayList<>();
 
         // Subscribe to incoming events and parse BuildTask CloudEvents
-        flowInEvents.subscribe().with(eventBytes -> {
+        flowInEvents.subscribe().with(msg -> {
             try {
-                CloudEvent ce = CE_JSON.deserialize(eventBytes);
+                CloudEventMetadata<?> ceMeta = msg.getMetadata(CloudEventMetadata.class).orElse(null);
 
                 // Filter for task.started events
-                if (ce.getType().equals("org.acme.build.task.started")) {
-                    BuildTask task = objectMapper.readValue(Objects.requireNonNull(ce.getData()).toBytes(), BuildTask.class);
+                if (ceMeta != null && "org.acme.build.task.started".equals(ceMeta.getType())) {
+                    BuildTask task = objectMapper.readValue(msg.getPayload(), BuildTask.class);
                     capturedTasks.add(task);
                     LOG.debug("Captured emitted task: {} ({})", task.name(), task.id());
                 }
+                msg.ack();
             } catch (Exception e) {
                 LOG.error("Failed to parse CloudEvent", e);
             }

--- a/examples/resilient-task-orchestrator/src/test/java/org/acme/orchestrator/TaskWorkflowIT.java
+++ b/examples/resilient-task-orchestrator/src/test/java/org/acme/orchestrator/TaskWorkflowIT.java
@@ -1,10 +1,7 @@
 package org.acme.orchestrator;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.cloudevents.CloudEvent;
-import io.cloudevents.core.builder.CloudEventBuilder;
-import io.cloudevents.core.provider.EventFormatProvider;
-import io.cloudevents.jackson.JsonFormat;
+import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadata;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.acme.orchestrator.model.BuildTask;
@@ -13,6 +10,7 @@ import org.acme.orchestrator.model.TaskStatus;
 import org.acme.orchestrator.service.TaskStateStore;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,9 +38,6 @@ import static org.awaitility.Awaitility.await;
 class TaskWorkflowIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(TaskWorkflowIT.class);
-
-    private static final JsonFormat CE_JSON = (JsonFormat) EventFormatProvider.getInstance()
-            .resolveFormat(JsonFormat.CONTENT_TYPE);
 
     @Inject
     ObjectMapper objectMapper;
@@ -276,22 +271,17 @@ class TaskWorkflowIT {
         }
     }
 
-    /**
-     * Helper method to emit a task.started CloudEvent.
-     */
     private void emitTaskStartedEvent(BuildTask task) throws Exception {
         byte[] taskData = objectMapper.writeValueAsBytes(task);
 
-        CloudEvent ce = CloudEventBuilder.v1()
+        OutgoingCloudEventMetadata<?> ceMeta = OutgoingCloudEventMetadata.builder()
                 .withId(UUID.randomUUID().toString())
                 .withSource(URI.create("test:/task-workflow"))
                 .withType("org.acme.build.task.started")
                 .withDataContentType("application/json")
-                .withData(taskData)
                 .build();
 
-        byte[] ceBytes = CE_JSON.serialize(ce);
-        flowIn.send(ceBytes);
+        flowIn.send(Message.of(taskData).addMetadata(ceMeta));
 
         LOG.info("Emitted task.started event for task: {} ({})",
                 task.id(), task.name());

--- a/messaging/integration-tests-amqp/pom.xml
+++ b/messaging/integration-tests-amqp/pom.xml
@@ -10,8 +10,8 @@
         <skipITs>true</skipITs>
     </properties>
 
-    <artifactId>quarkus-flow-messaging-integration-tests</artifactId>
-    <name>Quarkus Flow :: Messaging :: Integration Tests</name>
+    <artifactId>quarkus-flow-messaging-integration-tests-amqp</artifactId>
+    <name>Quarkus Flow :: Messaging :: Integration Tests :: AMQP</name>
 
     <dependencies>
         <dependency>
@@ -19,10 +19,10 @@
             <artifactId>quarkus-flow</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- Since we are using Kafka, we use its connector - but can be any SmallRye connector -->
+        <!-- AMQP connector (SmallRye Reactive Messaging) -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-messaging-kafka</artifactId>
+            <artifactId>quarkus-messaging-amqp</artifactId>
         </dependency>
 
         <dependency>
@@ -31,8 +31,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-kafka-companion</artifactId>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-amqp-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>io.cloudevents</groupId>
-            <artifactId>cloudevents-kafka</artifactId>
+            <artifactId>cloudevents-json-jackson</artifactId>
             <version>${io.cloudevents.version}</version>
             <scope>test</scope>
         </dependency>
@@ -93,16 +93,6 @@
                         <maven.home>${maven.home}</maven.home>
                     </systemPropertyVariables>
                 </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/messaging/integration-tests-amqp/src/main/java/io/quarkiverse/flow/messaging/amqp/it/HelloMessagingFlow.java
+++ b/messaging/integration-tests-amqp/src/main/java/io/quarkiverse/flow/messaging/amqp/it/HelloMessagingFlow.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.flow.messaging.amqp.it;
+
+import static io.quarkiverse.flow.dsl.FlowDSL.emit;
+import static io.quarkiverse.flow.dsl.FlowDSL.listen;
+import static io.quarkiverse.flow.dsl.FlowDSL.produced;
+import static io.quarkiverse.flow.dsl.FlowDSL.set;
+import static io.quarkiverse.flow.dsl.FlowDSL.toOne;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkiverse.flow.Flow;
+import io.quarkiverse.flow.dsl.FlowWorkflowBuilder;
+import io.serverlessworkflow.api.types.Workflow;
+
+@ApplicationScoped
+public class HelloMessagingFlow extends Flow {
+    /**
+     * This example illustrates how we consume a CloudEvent filtering it by "type".<br/>
+     * By the end of the workflow, we emit the event adding to the payload the attribute `message` we built via JQ in the `set`
+     * task.
+     * <p/>
+     * The infrastructure burden is handled internally by Kafka/SmallRye/Workflow runtime.<br/>
+     * As you may notice, this workflow is not tied to an event infrastructure whatsoever. Any connector supported by SmallRye
+     * would work just fine.
+     * <p/>
+     * To know more about the infrastructure configuration, please see the application.properties and the tests in this module.
+     *
+     * @see <a href="https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#listen">DSL Reference:
+     *      Listen</a>
+     * @see <a href="https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#emit">DSL Reference:
+     *      Emit</a>
+     */
+    @Override
+    public Workflow descriptor() {
+        return FlowWorkflowBuilder.workflow()
+                // We are listening to one and only one event coming to our broker with the type "io.quarkiverse.flow.messaging.hello.request"
+                // Each event produced by the broker with this type will kick a new workflow instance.
+                // To learn more see the base specification: https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#listen
+                .tasks(listen(toOne("io.quarkiverse.flow.messaging.hello.request")),
+                        // "name" is expected in the message body payload
+                        // by design, we receive an array from the listen task, since it's only one we are expecting it's safe to index
+                        // on more a more robust scenario, you should use `forEach`.
+                        set("{ message: \"Hello \" + .[0].name + \"!\" }"),
+                        // We emit a new event with the specified type having the property `message` in the body that we built in the previous `set` task.
+                        emit(produced("io.quarkiverse.flow.messaging.hello.response").jsonData(Map.class)))
+                .build();
+    }
+}

--- a/messaging/integration-tests-amqp/src/main/java/io/quarkiverse/flow/messaging/amqp/it/HelloMessagingFlow.java
+++ b/messaging/integration-tests-amqp/src/main/java/io/quarkiverse/flow/messaging/amqp/it/HelloMessagingFlow.java
@@ -41,7 +41,6 @@ public class HelloMessagingFlow extends Flow {
                 .tasks(listen(toOne("io.quarkiverse.flow.messaging.hello.request")),
                         // "name" is expected in the message body payload
                         // by design, we receive an array from the listen task, since it's only one we are expecting it's safe to index
-                        // on more a more robust scenario, you should use `forEach`.
                         set("{ message: \"Hello \" + .[0].name + \"!\" }"),
                         // We emit a new event with the specified type having the property `message` in the body that we built in the previous `set` task.
                         emit(produced("io.quarkiverse.flow.messaging.hello.response").jsonData(Map.class)))

--- a/messaging/integration-tests-amqp/src/main/resources/application.properties
+++ b/messaging/integration-tests-amqp/src/main/resources/application.properties
@@ -1,0 +1,13 @@
+# Enable quarkus-flow-messaging default consumer and publisher beans
+quarkus.flow.messaging.defaults-enabled=true
+quarkus.flow.messaging.lifecycle-enabled=true
+
+# Configure channels with AMQP connector
+mp.messaging.incoming.flow-in.connector=smallrye-amqp
+mp.messaging.incoming.flow-in.address=flow-in
+
+mp.messaging.outgoing.flow-out.connector=smallrye-amqp
+mp.messaging.outgoing.flow-out.address=flow-out
+
+mp.messaging.outgoing.flow-lifecycle-out.connector=smallrye-amqp
+mp.messaging.outgoing.flow-lifecycle-out.address=flow-lifecycle-out

--- a/messaging/integration-tests-amqp/src/test/java/io/quarkiverse/flow/messaging/amqp/it/HelloMessagingFlowAmqpTest.java
+++ b/messaging/integration-tests-amqp/src/test/java/io/quarkiverse/flow/messaging/amqp/it/HelloMessagingFlowAmqpTest.java
@@ -14,6 +14,9 @@ import java.util.concurrent.TimeUnit;
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,10 +31,10 @@ import io.cloudevents.jackson.JsonFormat;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadata;
 import io.vertx.amqp.AmqpClient;
 import io.vertx.amqp.AmqpClientOptions;
 import io.vertx.amqp.AmqpMessage;
-import io.vertx.amqp.AmqpMessageBuilder;
 import io.vertx.amqp.AmqpReceiver;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -47,6 +50,10 @@ public class HelloMessagingFlowAmqpTest {
 
     @Inject
     HelloMessagingFlow workflow;
+
+    @Inject
+    @Channel("flow-in-outgoing")
+    Emitter<byte[]> flowIn;
 
     @ConfigProperty(name = "amqp-host")
     String amqpHost;
@@ -109,18 +116,14 @@ public class HelloMessagingFlowAmqpTest {
         CompletableFuture<AmqpMessage> responseFuture = listenOnFlowOut();
 
         byte[] data = "{\"name\":\"Elisa\"}".getBytes();
-        AmqpMessageBuilder msgBuilder = AmqpMessage.create()
-                .withBufferAsBody(Buffer.buffer(data))
-                .contentType("application/json");
+        OutgoingCloudEventMetadata<?> ceMeta = OutgoingCloudEventMetadata.builder()
+                .withId(UUID.randomUUID().toString())
+                .withSource(URI.create("test:/it"))
+                .withType("io.quarkiverse.flow.messaging.hello.request")
+                .withDataContentType("application/json")
+                .build();
 
-        msgBuilder.applicationProperties(new JsonObject()
-                .put("cloudEvents:specversion", "1.0")
-                .put("cloudEvents:id", UUID.randomUUID().toString())
-                .put("cloudEvents:source", "test:/it")
-                .put("cloudEvents:type", "io.quarkiverse.flow.messaging.hello.request")
-                .put("cloudEvents:datacontenttype", "application/json"));
-
-        sendToFlowIn(msgBuilder.build());
+        flowIn.send(Message.of(data).addMetadata(ceMeta));
 
         AmqpMessage response = responseFuture.get(15, TimeUnit.SECONDS);
         assertResponseMessage(response, "Elisa");
@@ -189,7 +192,9 @@ public class HelloMessagingFlowAmqpTest {
         public Map<String, String> getConfigOverrides() {
             return Map.of(
                     "quarkus.flow.messaging.metadata.instance-id.key", "custominstanceid",
-                    "quarkus.flow.messaging.metadata.task-id.key", "customtaskid");
+                    "quarkus.flow.messaging.metadata.task-id.key", "customtaskid",
+                    "mp.messaging.outgoing.flow-in-outgoing.connector", "smallrye-amqp",
+                    "mp.messaging.outgoing.flow-in-outgoing.address", "flow-in");
         }
     }
 }

--- a/messaging/integration-tests-amqp/src/test/java/io/quarkiverse/flow/messaging/amqp/it/HelloMessagingFlowAmqpTest.java
+++ b/messaging/integration-tests-amqp/src/test/java/io/quarkiverse/flow/messaging/amqp/it/HelloMessagingFlowAmqpTest.java
@@ -1,0 +1,195 @@
+package io.quarkiverse.flow.messaging.amqp.it;
+
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.provider.EventFormatProvider;
+import io.cloudevents.jackson.JsonFormat;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.vertx.amqp.AmqpClient;
+import io.vertx.amqp.AmqpClientOptions;
+import io.vertx.amqp.AmqpMessage;
+import io.vertx.amqp.AmqpMessageBuilder;
+import io.vertx.amqp.AmqpReceiver;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+
+@DisabledOnOs(OS.WINDOWS)
+@QuarkusTest
+@TestProfile(HelloMessagingFlowAmqpTest.AmqpConfigProfile.class)
+public class HelloMessagingFlowAmqpTest {
+
+    private static final JsonFormat CE_JSON = (JsonFormat) EventFormatProvider.getInstance()
+            .resolveFormat(JsonFormat.CONTENT_TYPE);
+
+    @Inject
+    HelloMessagingFlow workflow;
+
+    @ConfigProperty(name = "amqp-host")
+    String amqpHost;
+
+    @ConfigProperty(name = "amqp-port")
+    int amqpPort;
+
+    private Vertx vertx;
+    private AmqpClient client;
+
+    @BeforeEach
+    void setUp() {
+        workflow.instance(Map.of()).start();
+        vertx = Vertx.vertx();
+        client = AmqpClient.create(vertx, new AmqpClientOptions()
+                .setHost(amqpHost)
+                .setPort(amqpPort));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (client != null) {
+            CompletableFuture<Void> close = new CompletableFuture<>();
+            client.close().onComplete(ar -> close.complete(null));
+            close.get(5, TimeUnit.SECONDS);
+        }
+        if (vertx != null) {
+            CompletableFuture<Void> close = new CompletableFuture<>();
+            vertx.close().onComplete(ar -> close.complete(null));
+            close.get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    @DisplayName("greet_roundtrip_with_structured_cloud_event_via_amqp")
+    void greet_roundtrip_structured_amqp() throws Exception {
+        CompletableFuture<AmqpMessage> responseFuture = listenOnFlowOut();
+
+        CloudEvent greet = CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withSource(URI.create("test:/it"))
+                .withType("io.quarkiverse.flow.messaging.hello.request")
+                .withDataContentType("application/json")
+                .withData("{\"name\":\"Elisa\"}".getBytes())
+                .build();
+
+        byte[] ceBytes = CE_JSON.serialize(greet);
+        sendToFlowIn(AmqpMessage.create()
+                .withBufferAsBody(Buffer.buffer(ceBytes))
+                .contentType("application/cloudevents+json")
+                .build());
+
+        AmqpMessage response = responseFuture.get(15, TimeUnit.SECONDS);
+        assertResponseMessage(response, "Elisa");
+    }
+
+    @Test
+    @DisplayName("greet_roundtrip_with_binary_cloud_event_via_amqp")
+    void greet_roundtrip_binary_amqp() throws Exception {
+        CompletableFuture<AmqpMessage> responseFuture = listenOnFlowOut();
+
+        byte[] data = "{\"name\":\"Elisa\"}".getBytes();
+        AmqpMessageBuilder msgBuilder = AmqpMessage.create()
+                .withBufferAsBody(Buffer.buffer(data))
+                .contentType("application/json");
+
+        msgBuilder.applicationProperties(new JsonObject()
+                .put("cloudEvents:specversion", "1.0")
+                .put("cloudEvents:id", UUID.randomUUID().toString())
+                .put("cloudEvents:source", "test:/it")
+                .put("cloudEvents:type", "io.quarkiverse.flow.messaging.hello.request")
+                .put("cloudEvents:datacontenttype", "application/json"));
+
+        sendToFlowIn(msgBuilder.build());
+
+        AmqpMessage response = responseFuture.get(15, TimeUnit.SECONDS);
+        assertResponseMessage(response, "Elisa");
+    }
+
+    private CompletableFuture<AmqpMessage> listenOnFlowOut() {
+        CompletableFuture<AmqpMessage> future = new CompletableFuture<>();
+        String expectedType = "io.quarkiverse.flow.messaging.hello.response";
+
+        CompletableFuture<Void> receiverReady = new CompletableFuture<>();
+
+        client.createReceiver("flow-out").onComplete(ar -> {
+            if (ar.failed()) {
+                future.completeExceptionally(ar.cause());
+                receiverReady.completeExceptionally(ar.cause());
+                return;
+            }
+            AmqpReceiver receiver = ar.result();
+            receiver.handler(msg -> {
+                // Binary mode: check cloudEvents:type in application properties
+                JsonObject appProps = msg.applicationProperties();
+                if (appProps != null) {
+                    String type = appProps.getString("cloudEvents:type");
+                    if (expectedType.equals(type)) {
+                        future.complete(msg);
+                        return;
+                    }
+                }
+                // Structured mode: check body for expected type
+                try {
+                    String body = msg.bodyAsBinary().toString(StandardCharsets.UTF_8);
+                    if (body.contains(expectedType)) {
+                        future.complete(msg);
+                    }
+                } catch (Exception ignored) {
+                }
+            });
+            receiverReady.complete(null);
+        });
+
+        await().atMost(ofSeconds(5)).untilAsserted(() -> assertThat(receiverReady).isDone());
+        return future;
+    }
+
+    private void sendToFlowIn(AmqpMessage message) {
+        CompletableFuture<Void> sent = new CompletableFuture<>();
+        client.createSender("flow-in").onComplete(ar -> {
+            if (ar.failed()) {
+                sent.completeExceptionally(ar.cause());
+                return;
+            }
+            ar.result().send(message);
+            sent.complete(null);
+        });
+        await().atMost(ofSeconds(5)).untilAsserted(() -> assertThat(sent).isDone());
+    }
+
+    private void assertResponseMessage(AmqpMessage msg, String name) {
+        assertThat(msg).as("Response message was not received").isNotNull();
+        String body = msg.bodyAsBinary().toString(StandardCharsets.UTF_8);
+        assertThat(body).contains("\"Hello " + name + "!\"");
+    }
+
+    public static class AmqpConfigProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.flow.messaging.metadata.instance-id.key", "custominstanceid",
+                    "quarkus.flow.messaging.metadata.task-id.key", "customtaskid");
+        }
+    }
+}

--- a/messaging/integration-tests-amqp/src/test/resources/application.properties
+++ b/messaging/integration-tests-amqp/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+# Use random port for parallel test execution
+quarkus.http.test-port=0

--- a/messaging/integration-tests/src/main/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlow.java
+++ b/messaging/integration-tests/src/main/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlow.java
@@ -41,7 +41,6 @@ public class HelloMessagingFlow extends Flow {
                 .tasks(listen(toOne("io.quarkiverse.flow.messaging.hello.request")),
                         // "name" is expected in the message body payload
                         // by design, we receive an array from the listen task, since it's only one we are expecting it's safe to index
-                        // on more a more robust scenario, you should use `forEach`.
                         set("{ message: \"Hello \" + .[0].name + \"!\" }"),
                         // We emit a new event with the specified type having the property `message` in the body that we built in the previous `set` task.
                         emit(produced("io.quarkiverse.flow.messaging.hello.response").jsonData(Map.class)))

--- a/messaging/integration-tests/src/test/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlowTest.java
+++ b/messaging/integration-tests/src/test/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlowTest.java
@@ -11,11 +11,15 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
+import jakarta.inject.Inject;
+
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -32,6 +36,7 @@ import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
 import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadata;
 import io.smallrye.reactive.messaging.kafka.companion.ConsumerTask;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 
@@ -46,6 +51,10 @@ public class HelloMessagingFlowTest {
 
     @InjectKafkaCompanion
     KafkaCompanion companion;
+
+    @Inject
+    @Channel("flow-in-outgoing")
+    Emitter<byte[]> flowIn;
 
     @Test
     @DisplayName("greet_roundtrip_with_structured_cloud_event")
@@ -77,17 +86,15 @@ public class HelloMessagingFlowTest {
                 .consumeWithDeserializers(StringDeserializer.class, CloudEventDeserializer.class)
                 .fromTopics("flow-out");
 
-        // Binary mode: data in Kafka value, CE attributes in ce_* headers
         byte[] data = "{\"name\":\"Elisa\"}".getBytes();
-        RecordHeaders headers = new RecordHeaders();
-        headers.add("ce_specversion", "1.0".getBytes());
-        headers.add("ce_id", UUID.randomUUID().toString().getBytes());
-        headers.add("ce_source", "test:/it".getBytes());
-        headers.add("ce_type", "io.quarkiverse.flow.messaging.hello.request".getBytes());
-        headers.add("ce_datacontenttype", "application/json".getBytes());
+        OutgoingCloudEventMetadata<?> ceMeta = OutgoingCloudEventMetadata.builder()
+                .withId(UUID.randomUUID().toString())
+                .withSource(URI.create("test:/it"))
+                .withType("io.quarkiverse.flow.messaging.hello.request")
+                .withDataContentType("application/json")
+                .build();
 
-        companion.produceWithSerializers(StringSerializer.class, ByteArraySerializer.class)
-                .fromRecords(new ProducerRecord<>("flow-in", null, null, null, data, headers));
+        flowIn.send(Message.of(data).addMetadata(ceMeta));
 
         CloudEvent ce = awaitResponseCE(out);
         assertResponseCE(ce, "Elisa");
@@ -130,7 +137,11 @@ public class HelloMessagingFlowTest {
         public Map<String, String> getConfigOverrides() {
             return Map.of(
                     "quarkus.flow.messaging.metadata.instance-id.key", "custominstanceid",
-                    "quarkus.flow.messaging.metadata.task-id.key", "customtaskid");
+                    "quarkus.flow.messaging.metadata.task-id.key", "customtaskid",
+                    "mp.messaging.outgoing.flow-in-outgoing.connector", "smallrye-kafka",
+                    "mp.messaging.outgoing.flow-in-outgoing.topic", "flow-in",
+                    "mp.messaging.outgoing.flow-in-outgoing.value.serializer",
+                    "org.apache.kafka.common.serialization.ByteArraySerializer");
         }
     }
 }

--- a/messaging/integration-tests/src/test/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlowTest.java
+++ b/messaging/integration-tests/src/test/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlowTest.java
@@ -71,8 +71,12 @@ public class HelloMessagingFlowTest {
                 .withData("{\"name\":\"Elisa\"}".getBytes())
                 .build();
 
+        @SuppressWarnings("unchecked")
+        ProducerRecord<Object, Object> structuredRecord = new ProducerRecord<>("flow-in",
+                (Object) CE_JSON.serialize(greet));
+        structuredRecord.headers().add("content-type", "application/cloudevents+json; charset=UTF-8".getBytes());
         companion.produceWithSerializers(StringSerializer.class, ByteArraySerializer.class)
-                .fromRecords(new ProducerRecord<>("flow-in", CE_JSON.serialize(greet)));
+                .fromRecords(structuredRecord);
 
         CloudEvent ce = awaitResponseCE(out);
         assertResponseCE(ce, "Elisa");

--- a/messaging/integration-tests/src/test/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlowTest.java
+++ b/messaging/integration-tests/src/test/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlowTest.java
@@ -1,10 +1,8 @@
 package io.quarkiverse.flow.messaging.it;
 
 import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.util.List;
@@ -14,10 +12,11 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -26,6 +25,7 @@ import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.jackson.JsonFormat;
+import io.cloudevents.kafka.CloudEventDeserializer;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
@@ -48,13 +48,12 @@ public class HelloMessagingFlowTest {
     KafkaCompanion companion;
 
     @Test
-    void greet_roundtrip() {
-        // Start consuming from 'flow-out' BEFORE producing to avoid missing anything
+    @DisplayName("greet_roundtrip_with_structured_cloud_event")
+    void greet_roundtrip_structured() {
         ConsumerTask<Object, Object> out = companion
-                .consumeWithDeserializers(StringDeserializer.class, ByteArrayDeserializer.class)
+                .consumeWithDeserializers(StringDeserializer.class, CloudEventDeserializer.class)
                 .fromTopics("flow-out");
 
-        // Produce the domain CloudEvent to 'flow-in'
         final CloudEvent greet = CloudEventBuilder.v1()
                 .withId(UUID.randomUUID().toString())
                 .withSource(URI.create("test:/it"))
@@ -63,38 +62,63 @@ public class HelloMessagingFlowTest {
                 .withData("{\"name\":\"Elisa\"}".getBytes())
                 .build();
 
-        final byte[] payload = CE_JSON.serialize(greet);
+        companion.produceWithSerializers(StringSerializer.class, ByteArraySerializer.class)
+                .fromRecords(new ProducerRecord<>("flow-in", CE_JSON.serialize(greet)));
+
+        CloudEvent ce = awaitResponseCE(out);
+        assertResponseCE(ce, "Elisa");
+        out.close();
+    }
+
+    @Test
+    @DisplayName("greet_roundtrip_with_binary_cloud_event")
+    void greet_roundtrip_binary() {
+        ConsumerTask<Object, Object> out = companion
+                .consumeWithDeserializers(StringDeserializer.class, CloudEventDeserializer.class)
+                .fromTopics("flow-out");
+
+        // Binary mode: data in Kafka value, CE attributes in ce_* headers
+        byte[] data = "{\"name\":\"Elisa\"}".getBytes();
+        RecordHeaders headers = new RecordHeaders();
+        headers.add("ce_specversion", "1.0".getBytes());
+        headers.add("ce_id", UUID.randomUUID().toString().getBytes());
+        headers.add("ce_source", "test:/it".getBytes());
+        headers.add("ce_type", "io.quarkiverse.flow.messaging.hello.request".getBytes());
+        headers.add("ce_datacontenttype", "application/json".getBytes());
 
         companion.produceWithSerializers(StringSerializer.class, ByteArraySerializer.class)
-                .fromRecords(new ProducerRecord<>("flow-in", payload));
+                .fromRecords(new ProducerRecord<>("flow-in", null, null, null, data, headers));
 
-        // Await until we see OUR domain response event on 'flow-out'
+        CloudEvent ce = awaitResponseCE(out);
+        assertResponseCE(ce, "Elisa");
+        out.close();
+    }
+
+    private CloudEvent awaitResponseCE(ConsumerTask<Object, Object> out) {
         final String expectedType = "io.quarkiverse.flow.messaging.hello.response";
         final AtomicReference<CloudEvent> responseRef = new AtomicReference<>();
 
         await().atMost(ofSeconds(10)).untilAsserted(() -> {
             boolean found = out.stream()
-                    .map(rec -> CE_JSON.deserialize((byte[]) rec.value()))
+                    .map(rec -> (CloudEvent) rec.value())
+                    .filter(Objects::nonNull)
                     .peek(ce -> {
                         if (expectedType.equals(ce.getType()))
                             responseRef.set(ce);
                     })
                     .anyMatch(ce -> expectedType.equals(ce.getType()));
-            assertTrue(found, "Still waiting for CE type: " + expectedType);
+            assertThat(found).as("Still waiting for CE type: %s", expectedType).isTrue();
         });
 
-        CloudEvent ce = responseRef.get();
-        assertNotNull(ce, "Response CloudEvent was not captured");
-        assertEquals(expectedType, ce.getType());
+        return responseRef.get();
+    }
 
-        // Validate payload content (adjust to your workflow’s behavior)
-        assertTrue(new String(Objects.requireNonNull(ce.getData()).toBytes()).contains("\"Hello Elisa!\""),
-                "Unexpected CE data: " + new String(ce.getData().toBytes()));
-
-        assertTrue(ce.getExtensionNames().containsAll(List.of("custominstanceid", "customtaskid")));
-
-        // Tidy up
-        out.close();
+    private void assertResponseCE(CloudEvent ce, String name) {
+        assertThat(ce).as("Response CloudEvent was not captured").isNotNull();
+        assertThat(ce.getType()).isEqualTo("io.quarkiverse.flow.messaging.hello.response");
+        assertThat(new String(Objects.requireNonNull(ce.getData()).toBytes()))
+                .contains("\"Hello " + name + "!\"");
+        assertThat(ce.getExtensionNames()).containsAll(List.of("custominstanceid", "customtaskid"));
     }
 
     public static class ConfigureMetadata implements QuarkusTestProfile {

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -15,6 +15,7 @@
         <module>runtime</module>
         <module>deployment</module>
         <module>integration-tests</module>
+        <module>integration-tests-amqp</module>
     </modules>
 
 </project>

--- a/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/ContentBasedRouterEventsPublisher.java
+++ b/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/ContentBasedRouterEventsPublisher.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.flow.messaging;
 
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -7,24 +10,25 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.cloudevents.CloudEvent;
-import io.cloudevents.core.format.EventFormat;
-import io.cloudevents.core.provider.EventFormatProvider;
-import io.cloudevents.jackson.JsonFormat;
 import io.serverlessworkflow.impl.events.EventPublisher;
 import io.smallrye.reactive.messaging.MutinyEmitter;
+import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadata;
 
 /**
  * A content-based router {@link EventPublisher}.
+ * <p>
+ * CloudEvent attributes are propagated via {@link OutgoingCloudEventMetadata},
+ * letting SmallRye Reactive Messaging handle transport-specific encoding
+ * (Kafka headers, AMQP properties, etc.) rather than manually serializing
+ * the full CloudEvent envelope.
  *
- * @see <a href="https://www.enterpriseintegrationpatterns.com/patterns/messaging/ContentBasedRouter.html>Messaging Patterns -
+ * @see <a href="https://www.enterpriseintegrationpatterns.com/patterns/messaging/ContentBasedRouter.html">Messaging Patterns -
  *      Content-Based Router</a>
  */
 public abstract class ContentBasedRouterEventsPublisher implements EventPublisher {
 
     private static final String ENGINE_PREFIX = "io.serverlessworkflow";
     private static final Logger LOG = LoggerFactory.getLogger(ContentBasedRouterEventsPublisher.class);
-    private static final EventFormat FORMAT = EventFormatProvider.getInstance()
-            .resolveFormat(JsonFormat.CONTENT_TYPE);
 
     protected boolean isLifecycleEvent(CloudEvent event) {
         final String type = event.getType();
@@ -37,11 +41,43 @@ public abstract class ContentBasedRouterEventsPublisher implements EventPublishe
             return CompletableFuture.completedFuture(null);
 
         try {
-            byte[] structured = FORMAT.serialize(event);
-            if (LOG.isDebugEnabled())
-                LOG.debug("Flow: Publishing on channel {} event={}", channelName(), new String(structured));
+            byte[] data = event.getData() != null ? event.getData().toBytes() : new byte[0];
 
-            return outEmitter().sendMessage(Message.of(structured)).subscribeAsCompletionStage();
+            var builder = OutgoingCloudEventMetadata.builder()
+                    .withId(event.getId())
+                    .withSource(event.getSource())
+                    .withType(event.getType());
+
+            if (event.getDataContentType() != null) {
+                builder.withDataContentType(event.getDataContentType());
+            }
+            if (event.getDataSchema() != null) {
+                builder.withDataSchema(event.getDataSchema());
+            }
+            if (event.getSubject() != null) {
+                builder.withSubject(event.getSubject());
+            }
+            if (event.getTime() != null) {
+                builder.withTimestamp(event.getTime().atZoneSameInstant(ZoneOffset.UTC));
+            }
+
+            if (!event.getExtensionNames().isEmpty()) {
+                Map<String, Object> extensions = new HashMap<>();
+                for (String name : event.getExtensionNames()) {
+                    extensions.put(name, event.getExtension(name));
+                }
+                builder.withExtensions(extensions);
+            }
+
+            OutgoingCloudEventMetadata<?> ceMetadata = builder.build();
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Flow: Publishing on channel {} CE id={} type={} source={}",
+                        channelName(), event.getId(), event.getType(), event.getSource());
+            }
+
+            return outEmitter().sendMessage(Message.of(data).addMetadata(ceMetadata))
+                    .subscribeAsCompletionStage();
         } catch (Exception e) {
             final CompletableFuture<Void> cf = new CompletableFuture<>();
             cf.completeExceptionally(e);

--- a/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/FlowMessagingConsumer.java
+++ b/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/FlowMessagingConsumer.java
@@ -3,7 +3,6 @@ package io.quarkiverse.flow.messaging;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -22,8 +21,6 @@ import org.slf4j.LoggerFactory;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.data.BytesCloudEventData;
-import io.cloudevents.core.provider.EventFormatProvider;
-import io.cloudevents.jackson.JsonFormat;
 import io.serverlessworkflow.impl.events.AbstractTypeConsumer;
 import io.smallrye.reactive.messaging.ce.IncomingCloudEventMetadata;
 
@@ -32,53 +29,19 @@ public class FlowMessagingConsumer
         extends AbstractTypeConsumer {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlowMessagingConsumer.class);
-    private static final JsonFormat FORMAT = (JsonFormat) EventFormatProvider.getInstance()
-            .resolveFormat(JsonFormat.CONTENT_TYPE);
     private final Map<String, Consumer<CloudEvent>> topicMap = new ConcurrentHashMap<>();
     private final AtomicReference<Consumer<CloudEvent>> allConsumerRef = new AtomicReference<>();
+
     @Inject
     ManagedExecutor executor;
 
-    private static CloudEvent parseStructuredCE(byte[] json) {
-        if (FORMAT == null)
-            throw new IllegalStateException("CloudEvents JSON format not available");
-        return FORMAT.deserialize(json);
-    }
-
-    private static byte[] toBytes(Object raw) {
-        if (raw instanceof byte[] b) {
-            return b;
-        }
-        if (raw instanceof String s) {
-            return s.getBytes(StandardCharsets.UTF_8);
-        }
-        if (raw != null) {
-            return raw.toString().getBytes(StandardCharsets.UTF_8);
-        }
-        return new byte[0];
-    }
-
     private static CloudEvent resolveCloudEvent(Message<?> msg) {
-        byte[] payload = toBytes(msg.getPayload());
-        if (payload.length > 0) {
-            try {
-                return parseStructuredCE(payload);
-            } catch (Exception structuredEx) {
-                LOG.debug("Flow: Structured CE parse failed, trying binary mode", structuredEx);
-            }
-        }
-
-        // Binary mode: CE attributes in transport headers via SmallRye metadata
-        Optional<IncomingCloudEventMetadata<?>> ceMeta = msg
+        IncomingCloudEventMetadata<?> meta = (IncomingCloudEventMetadata<?>) msg
                 .getMetadata(IncomingCloudEventMetadata.class)
-                .map(m -> (IncomingCloudEventMetadata<?>) m);
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Message does not carry CloudEvent metadata. "
+                                + "Ensure the channel has cloud-events enabled (the default)."));
 
-        if (ceMeta.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "Message is neither a structured CloudEvent nor carries binary CE metadata");
-        }
-
-        IncomingCloudEventMetadata<?> meta = ceMeta.get();
         CloudEventBuilder builder = CloudEventBuilder.v1()
                 .withId(meta.getId())
                 .withSource(meta.getSource())
@@ -104,8 +67,11 @@ public class FlowMessagingConsumer
             }
         }
 
-        if (payload.length > 0) {
-            builder.withData(BytesCloudEventData.wrap(payload));
+        Object data = meta.getData();
+        if (data instanceof byte[] bytes) {
+            builder.withData(BytesCloudEventData.wrap(bytes));
+        } else if (data != null) {
+            builder.withData(BytesCloudEventData.wrap(data.toString().getBytes(StandardCharsets.UTF_8)));
         }
 
         return builder.build();

--- a/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/FlowMessagingConsumer.java
+++ b/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/FlowMessagingConsumer.java
@@ -1,6 +1,9 @@
 package io.quarkiverse.flow.messaging;
 
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -17,9 +20,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.data.BytesCloudEventData;
 import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.jackson.JsonFormat;
 import io.serverlessworkflow.impl.events.AbstractTypeConsumer;
+import io.smallrye.reactive.messaging.ce.IncomingCloudEventMetadata;
 
 @ApplicationScoped
 public class FlowMessagingConsumer
@@ -39,12 +45,78 @@ public class FlowMessagingConsumer
         return FORMAT.deserialize(json);
     }
 
+    private static byte[] toBytes(Object raw) {
+        if (raw instanceof byte[] b) {
+            return b;
+        }
+        if (raw instanceof String s) {
+            return s.getBytes(StandardCharsets.UTF_8);
+        }
+        if (raw != null) {
+            return raw.toString().getBytes(StandardCharsets.UTF_8);
+        }
+        return new byte[0];
+    }
+
+    private static CloudEvent resolveCloudEvent(Message<?> msg) {
+        byte[] payload = toBytes(msg.getPayload());
+        if (payload.length > 0) {
+            try {
+                return parseStructuredCE(payload);
+            } catch (Exception structuredEx) {
+                LOG.debug("Flow: Structured CE parse failed, trying binary mode", structuredEx);
+            }
+        }
+
+        // Binary mode: CE attributes in transport headers via SmallRye metadata
+        Optional<IncomingCloudEventMetadata<?>> ceMeta = msg
+                .getMetadata(IncomingCloudEventMetadata.class)
+                .map(m -> (IncomingCloudEventMetadata<?>) m);
+
+        if (ceMeta.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Message is neither a structured CloudEvent nor carries binary CE metadata");
+        }
+
+        IncomingCloudEventMetadata<?> meta = ceMeta.get();
+        CloudEventBuilder builder = CloudEventBuilder.v1()
+                .withId(meta.getId())
+                .withSource(meta.getSource())
+                .withType(meta.getType());
+
+        meta.getDataContentType().ifPresent(builder::withDataContentType);
+        meta.getDataSchema().ifPresent(builder::withDataSchema);
+        meta.getSubject().ifPresent(builder::withSubject);
+        meta.getTimeStamp()
+                .map(ZonedDateTime::toOffsetDateTime)
+                .ifPresent(builder::withTime);
+
+        for (Map.Entry<String, Object> ext : meta.getExtensions().entrySet()) {
+            Object val = ext.getValue();
+            if (val instanceof String s) {
+                builder.withExtension(ext.getKey(), s);
+            } else if (val instanceof Number n) {
+                builder.withExtension(ext.getKey(), n);
+            } else if (val instanceof Boolean b) {
+                builder.withExtension(ext.getKey(), b);
+            } else if (val != null) {
+                builder.withExtension(ext.getKey(), val.toString());
+            }
+        }
+
+        if (payload.length > 0) {
+            builder.withData(BytesCloudEventData.wrap(payload));
+        }
+
+        return builder.build();
+    }
+
     @Incoming("flow-in")
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
-    public CompletionStage<Void> onIncoming(Message<byte[]> msg) {
+    public CompletionStage<Void> onIncoming(Message<?> msg) {
         final CloudEvent ce;
         try {
-            ce = parseStructuredCE(msg.getPayload());
+            ce = resolveCloudEvent(msg);
             LOG.debug("Flow: Received event: {}", ce);
         } catch (Exception e) {
             LOG.error("Flow: CE parse failure", e);

--- a/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/FlowMessagingConsumer.java
+++ b/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/FlowMessagingConsumer.java
@@ -19,10 +19,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.data.BytesCloudEventData;
 import io.serverlessworkflow.impl.events.AbstractTypeConsumer;
 import io.smallrye.reactive.messaging.ce.IncomingCloudEventMetadata;
+import io.vertx.core.json.JsonObject;
 
 @ApplicationScoped
 public class FlowMessagingConsumer
@@ -69,7 +71,13 @@ public class FlowMessagingConsumer
 
         Object data = meta.getData();
         if (data instanceof byte[] bytes) {
-            builder.withData(BytesCloudEventData.wrap(bytes));
+            builder.withData(bytes);
+        } else if (data instanceof CloudEventData cloudEventData) {
+            builder.withData(cloudEventData);
+        } else if (data instanceof String text) {
+            builder.withData(text.getBytes(StandardCharsets.UTF_8));
+        } else if (data instanceof JsonObject jsonObject) {
+            builder.withData(jsonObject.encode().getBytes(StandardCharsets.UTF_8));
         } else if (data != null) {
             builder.withData(BytesCloudEventData.wrap(data.toString().getBytes(StandardCharsets.UTF_8)));
         }

--- a/runner/app/src/test/java/io/quarkiverse/flow/runner/app/EmitEventWorkflowTest.java
+++ b/runner/app/src/test/java/io/quarkiverse/flow/runner/app/EmitEventWorkflowTest.java
@@ -7,7 +7,6 @@ import static org.awaitility.Awaitility.await;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import jakarta.enterprise.inject.Any;
 import jakarta.inject.Inject;
@@ -17,14 +16,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.cloudevents.CloudEvent;
-import io.cloudevents.core.provider.EventFormatProvider;
-import io.cloudevents.jackson.JsonFormat;
 import io.quarkiverse.flow.runner.model.ExecutionResponse;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import io.serverlessworkflow.impl.WorkflowStatus;
+import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
 import io.smallrye.reactive.messaging.memory.InMemoryConnector;
 import io.smallrye.reactive.messaging.memory.InMemorySink;
 
@@ -34,9 +31,6 @@ import io.smallrye.reactive.messaging.memory.InMemorySink;
 @QuarkusTest
 @TestProfile(EmitEventWorkflowTest.MessagingProfile.class)
 class EmitEventWorkflowTest {
-
-    private static final JsonFormat CE_JSON = (JsonFormat) EventFormatProvider.getInstance()
-            .resolveFormat(JsonFormat.CONTENT_TYPE);
 
     @Inject
     @Any
@@ -74,23 +68,18 @@ class EmitEventWorkflowTest {
         await().atMost(ofSeconds(5)).untilAsserted(() -> {
             InMemorySink<byte[]> sink = connector.sink("flow-out");
 
-            // Deserialize CloudEvent payloads from byte arrays
-            List<CloudEvent> events = sink.received().stream()
-                    .map(Message::getPayload)
-                    .map(CE_JSON::deserialize)
-                    .collect(Collectors.toList());
-
-            assertThat(events)
+            List<? extends Message<byte[]>> messages = sink.received();
+            assertThat(messages)
                     .as("Events should have been emitted to flow-out channel")
                     .isNotEmpty();
 
-            CloudEvent event = events.get(0);
-            assertThat(event.getType()).isEqualTo("org.quarkiverse.flow.runner.app.response");
-            assertThat(event.getSource().toString()).isEqualTo("uri://org.quarkiverse.flow.runner.app.test");
+            Message<byte[]> msg = messages.get(0);
+            CloudEventMetadata<?> ceMeta = msg.getMetadata(CloudEventMetadata.class).orElse(null);
+            assertThat(ceMeta).as("Message should carry CloudEvent metadata").isNotNull();
+            assertThat(ceMeta.getType()).isEqualTo("org.quarkiverse.flow.runner.app.response");
+            assertThat(ceMeta.getSource().toString()).isEqualTo("uri://org.quarkiverse.flow.runner.app.test");
 
-            // Verify the event data contains the transformed input
-            assertThat(event.getData()).isNotNull();
-            String eventData = new String(event.getData().toBytes());
+            String eventData = new String(msg.getPayload());
             assertThat(eventData).contains("Test User");
         });
     }


### PR DESCRIPTION
## Summary

- Refactor `flow-out` producer to use `OutgoingCloudEventMetadata` instead of manual `JsonFormat.serialize()`
- Refactor `flow-in` consumer to accept `Message<?>` with `IncomingCloudEventMetadata`, supporting both structured and binary CloudEvents
- Add AMQP integration tests (`integration-tests-amqp` module)
- Update all examples to use SmallRye's `CloudEventMetadata` API instead of CloudEvents SDK serialization
- Add migration guide (0.14→0.15) and update messaging docs

## Breaking change

`flow-out` payload is now data-only — CE attributes travel via transport headers (`ce_*` for Kafka, `cloudEvents:*` for AMQP). Consumers using `JsonFormat.deserialize()` must switch to `CloudEventMetadata` from message metadata.

## Test plan

- [x] Kafka integration tests (structured + binary CE roundtrip)
- [x] AMQP integration tests (structured + binary CE roundtrip)
- [x] Runner EmitEventWorkflowTest
- [x] Newsletter-drafter example tests
- [x] Resilient-task-orchestrator example tests

Fixes #799