### PR TITLE
feat: Add first() and envelope().first() to DSL for CE extraction

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FlowDSL.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FlowDSL.java
@@ -2519,21 +2519,45 @@ public final class FlowDSL {
         return DSL.on(strategy);
     }
 
+    /**
+     * Wraps a {@link FuncScheduleEventSpec} into a {@link FuncScheduleSpec} so that
+     * the {@link FuncScheduleEventSpec#first()} and {@link FuncScheduleEventSpec#envelope()}
+     * flags are propagated through the {@code schedule(on(one("type").first()))} chain.
+     *
+     * @param eventSpec the event spec (typically from {@link #one(String)})
+     * @return a schedule spec that carries the first/envelope flags
+     */
+    public static FuncScheduleSpec on(FuncScheduleEventSpec eventSpec) {
+        return new FuncScheduleSpec(eventSpec);
+    }
+
     // ---- Schedule Event Strategies ----//
 
     /**
+     * Creates a {@link FuncScheduleEventSpec} for consuming exactly one event of the given type.
+     * The returned spec supports {@link FuncScheduleEventSpec#first()} to extract the
+     * CloudEvent payload before the first task receives it.
+     *
+     * @param eventType the CloudEvent type to consume
+     * @return a schedule event spec that can be chained with {@code .first()} or
+     *         {@code .envelope().first()}
      * @see DSL#one(String)
      */
-    public static Consumer<AbstractEventConsumptionStrategyBuilder<?, ?, ?>> one(String eventType) {
-        return DSL.one(eventType);
+    public static FuncScheduleEventSpec one(String eventType) {
+        return new FuncScheduleEventSpec(eventType);
     }
 
     /**
+     * Creates a {@link FuncScheduleEventSpec} for consuming exactly one event matching the given
+     * filter. The returned spec supports {@link FuncScheduleEventSpec#first()}.
+     *
+     * @param filter the event filter
+     * @return a schedule event spec that can be chained with {@code .first()} or
+     *         {@code .envelope().first()}
      * @see DSL#one(Consumer)
      */
-    public static Consumer<AbstractEventConsumptionStrategyBuilder<?, ?, ?>> one(
-            Consumer<EventFilterBuilder> filter) {
-        return DSL.one(filter);
+    public static FuncScheduleEventSpec one(Consumer<EventFilterBuilder> filter) {
+        return new FuncScheduleEventSpec(filter);
     }
 
     /**

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FlowWorkflowBuilder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FlowWorkflowBuilder.java
@@ -52,9 +52,9 @@ public class FlowWorkflowBuilder
         schedule((Consumer<ScheduleBuilder>) spec);
         if (spec.isFirst()) {
             if (spec.isEnvelope()) {
-                inputFrom(ce -> ce, CloudEvent.class);
+                inputFrom(ce -> ce);
             } else {
-                inputFrom(CloudEvent::getData, CloudEvent.class);
+                inputFrom(CloudEvent::getData);
             }
         }
         return this;

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FlowWorkflowBuilder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FlowWorkflowBuilder.java
@@ -3,12 +3,10 @@ package io.quarkiverse.flow.dsl;
 import static io.serverlessworkflow.types.Defaults.DEFAULT_NAMESPACE;
 import static io.serverlessworkflow.types.Defaults.DEFAULT_VERSION;
 
-import java.util.Collection;
-import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
+import io.cloudevents.CloudEvent;
 import io.quarkiverse.flow.dsl.spi.FuncTransformations;
 import io.serverlessworkflow.fluent.spec.BaseWorkflowBuilder;
 import io.serverlessworkflow.fluent.spec.ScheduleBuilder;
@@ -54,23 +52,9 @@ public class FlowWorkflowBuilder
         schedule((Consumer<ScheduleBuilder>) spec);
         if (spec.isFirst()) {
             if (spec.isEnvelope()) {
-                inputFrom((Function<Collection<Object>, Object>) col -> {
-                    if (!col.isEmpty()) {
-                        return col.iterator().next();
-                    }
-                    return col;
-                });
+                inputFrom(ce -> ce, CloudEvent.class);
             } else {
-                inputFrom((Function<Collection<Object>, Object>) col -> {
-                    Object target = col;
-                    if (!col.isEmpty()) {
-                        target = col.iterator().next();
-                    }
-                    if (target instanceof Map<?, ?> map && map.containsKey("data")) {
-                        return map.get("data");
-                    }
-                    return target;
-                });
+                inputFrom(CloudEvent::getData, CloudEvent.class);
             }
         }
         return this;

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FlowWorkflowBuilder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FlowWorkflowBuilder.java
@@ -52,9 +52,9 @@ public class FlowWorkflowBuilder
         schedule((Consumer<ScheduleBuilder>) spec);
         if (spec.isFirst()) {
             if (spec.isEnvelope()) {
-                inputFrom(ce -> ce);
+                inputFrom(ce -> ce, CloudEvent.class);
             } else {
-                inputFrom(CloudEvent::getData);
+                inputFrom(CloudEvent::getData, CloudEvent.class);
             }
         }
         return this;

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FlowWorkflowBuilder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FlowWorkflowBuilder.java
@@ -3,10 +3,15 @@ package io.quarkiverse.flow.dsl;
 import static io.serverlessworkflow.types.Defaults.DEFAULT_NAMESPACE;
 import static io.serverlessworkflow.types.Defaults.DEFAULT_VERSION;
 
+import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import io.quarkiverse.flow.dsl.spi.FuncTransformations;
 import io.serverlessworkflow.fluent.spec.BaseWorkflowBuilder;
+import io.serverlessworkflow.fluent.spec.ScheduleBuilder;
 
 public class FlowWorkflowBuilder
         extends BaseWorkflowBuilder<FlowWorkflowBuilder, FuncDoTaskBuilder, FuncTaskItemListBuilder>
@@ -14,6 +19,61 @@ public class FlowWorkflowBuilder
 
     protected FlowWorkflowBuilder(final String name, final String namespace, final String version) {
         super(name, namespace, version);
+    }
+
+    /**
+     * Schedule this workflow using a {@link FuncScheduleSpec} that may carry
+     * {@link FuncScheduleEventSpec#first()} and {@link FuncScheduleEventSpec#envelope()}
+     * flags. When {@code first()} is set, an {@code inputFrom} filter is automatically
+     * applied to extract the first item from the CloudEvent collection before the first
+     * task receives it.
+     *
+     * <p>
+     * Usage:
+     *
+     * <pre>{@code
+     * import static io.quarkiverse.flow.dsl.FlowDSL.*;
+     *
+     * // Extract first CE data payload
+     * FlowWorkflowBuilder.workflow("my-flow")
+     *         .schedule(on(one("com.example.event").first()))
+     *         .tasks(...)
+     *         .build();
+     *
+     * // Extract first full CE envelope
+     * FlowWorkflowBuilder.workflow("my-flow")
+     *         .schedule(on(one("com.example.event").envelope().first()))
+     *         .tasks(...)
+     *         .build();
+     * }</pre>
+     *
+     * @param spec the schedule spec (from {@code on(one(...))})
+     * @return this builder for chaining
+     */
+    public FlowWorkflowBuilder schedule(FuncScheduleSpec spec) {
+        schedule((Consumer<ScheduleBuilder>) spec);
+        if (spec.isFirst()) {
+            if (spec.isEnvelope()) {
+                inputFrom((Function<Collection<Object>, Object>) col -> {
+                    if (!col.isEmpty()) {
+                        return col.iterator().next();
+                    }
+                    return col;
+                });
+            } else {
+                inputFrom((Function<Collection<Object>, Object>) col -> {
+                    Object target = col;
+                    if (!col.isEmpty()) {
+                        target = col.iterator().next();
+                    }
+                    if (target instanceof Map<?, ?> map && map.containsKey("data")) {
+                        return map.get("data");
+                    }
+                    return target;
+                });
+            }
+        }
+        return this;
     }
 
     public static FlowWorkflowBuilder workflow(

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FuncListenSpec.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FuncListenSpec.java
@@ -1,9 +1,9 @@
 package io.quarkiverse.flow.dsl;
 
 import java.util.Collection;
-import java.util.function.Function;
 
 import io.quarkiverse.flow.dsl.configurers.FuncListenConfigurer;
+import io.quarkiverse.flow.dsl.types.SerializableFunction;
 import io.serverlessworkflow.api.types.ListenTaskConfiguration;
 
 /**
@@ -75,8 +75,8 @@ public final class FuncListenSpec extends BaseFuncListenSpec<FuncListenSpec, Fun
                 funcListenTaskBuilder.read(ListenTaskConfiguration.ListenAndReadAs.ENVELOPE);
             }
             funcListenTaskBuilder.outputAs(
-                    (Function<Collection<Object>, Object>) col -> {
-                        if (!col.isEmpty()) {
+                    (SerializableFunction<Collection<Object>, Object>) col -> {
+                        if (col != null && !col.isEmpty()) {
                             return col.iterator().next();
                         }
                         return col;

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FuncListenSpec.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FuncListenSpec.java
@@ -1,12 +1,65 @@
 package io.quarkiverse.flow.dsl;
 
-import io.quarkiverse.flow.dsl.configurers.FuncListenConfigurer;
+import java.util.Collection;
+import java.util.function.Function;
 
+import io.quarkiverse.flow.dsl.configurers.FuncListenConfigurer;
+import io.serverlessworkflow.api.types.ListenTaskConfiguration;
+
+/**
+ * Fluent spec for configuring a {@code listen} task. Supports {@link #first()} and
+ * {@link #envelope()} to control how the CloudEvent collection is unwrapped.
+ *
+ * <p>
+ * By design, the Serverless Workflow specification always delivers events as a collection,
+ * even when only one event is expected (via {@code toOne()}). Call {@link #first()} to
+ * explicitly extract the first element from that collection so downstream tasks receive
+ * a single object rather than a single-element array.
+ *
+ * <pre>{@code
+ * // Extract first CE data payload
+ * listen(toOne("type").first())
+ *
+ * // Extract first full CE envelope
+ * listen(toOne("type").envelope().first())
+ * }</pre>
+ */
 public final class FuncListenSpec extends BaseFuncListenSpec<FuncListenSpec, FuncListenTaskBuilder>
         implements FuncListenConfigurer {
 
+    private boolean first;
+    private boolean envelope;
+
     public FuncListenSpec() {
         super(FuncListenTaskBuilder::to);
+    }
+
+    /**
+     * Extract the first item from the CloudEvent collection as the listen task output.
+     * The specification always delivers events as a collection — even for {@code toOne()}
+     * which produces a single-element array. This method unwraps that array so the next
+     * task receives a single object directly.
+     *
+     * <p>
+     * By default, only the CE {@code data} payload is extracted. Chain with
+     * {@link #envelope()} before this call to keep the full CloudEvent envelope instead.
+     *
+     * @return this spec for chaining
+     */
+    public FuncListenSpec first() {
+        this.first = true;
+        return this;
+    }
+
+    /**
+     * When combined with {@link #first()}, passes the full CloudEvent envelope
+     * (including extensions, source, type, etc.) instead of just the data payload.
+     *
+     * @return this spec for chaining
+     */
+    public FuncListenSpec envelope() {
+        this.envelope = true;
+        return this;
     }
 
     @Override
@@ -17,5 +70,17 @@ public final class FuncListenSpec extends BaseFuncListenSpec<FuncListenSpec, Fun
     @Override
     public void accept(FuncListenTaskBuilder funcListenTaskBuilder) {
         acceptInto(funcListenTaskBuilder);
+        if (first) {
+            if (envelope) {
+                funcListenTaskBuilder.read(ListenTaskConfiguration.ListenAndReadAs.ENVELOPE);
+            }
+            funcListenTaskBuilder.outputAs(
+                    (Function<Collection<Object>, Object>) col -> {
+                        if (!col.isEmpty()) {
+                            return col.iterator().next();
+                        }
+                        return col;
+                    });
+        }
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FuncScheduleEventSpec.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FuncScheduleEventSpec.java
@@ -1,0 +1,99 @@
+package io.quarkiverse.flow.dsl;
+
+import java.util.function.Consumer;
+
+import io.serverlessworkflow.fluent.spec.AbstractEventConsumptionStrategyBuilder;
+import io.serverlessworkflow.fluent.spec.EventFilterBuilder;
+import io.serverlessworkflow.fluent.spec.dsl.DSL;
+
+/**
+ * A schedule event specification returned by {@link FlowDSL#one(String)} that allows
+ * chaining {@link #first()} and {@link #envelope()} to control how the CloudEvent
+ * collection is unwrapped before the first task receives it.
+ *
+ * <p>
+ * By design, the Serverless Workflow specification always delivers consumed events as a
+ * collection — even when only one event is expected (via {@code one()}). Call
+ * {@link #first()} to explicitly extract the first element from that collection so
+ * downstream tasks receive a single object rather than a single-element array.
+ *
+ * <p>
+ * Typical usage:
+ *
+ * <pre>{@code
+ * // Extract first CE data payload from the collection
+ * FlowWorkflowBuilder.workflow("my-flow")
+ *         .schedule(on(one("com.example.event").first()))
+ *         .tasks(...)
+ *         .build();
+ *
+ * // Extract first full CE envelope from the collection
+ * FlowWorkflowBuilder.workflow("my-flow")
+ *         .schedule(on(one("com.example.event").envelope().first()))
+ *         .tasks(...)
+ *         .build();
+ * }</pre>
+ */
+public class FuncScheduleEventSpec implements Consumer<AbstractEventConsumptionStrategyBuilder<?, ?, ?>> {
+
+    private final String eventType;
+    private final Consumer<EventFilterBuilder> filter;
+    private boolean first;
+    private boolean envelope;
+
+    FuncScheduleEventSpec(String eventType) {
+        this.eventType = eventType;
+        this.filter = null;
+    }
+
+    FuncScheduleEventSpec(Consumer<EventFilterBuilder> filter) {
+        this.eventType = null;
+        this.filter = filter;
+    }
+
+    /**
+     * Extract the first item from the CloudEvent collection before the first task
+     * receives it. The specification always delivers events as a collection — even
+     * for {@code one()} which produces a single-element array. This method unwraps
+     * that array so the next task receives a single object directly.
+     *
+     * <p>
+     * By default, only the CE {@code data} payload is extracted. Chain with
+     * {@link #envelope()} before this call to keep the full CloudEvent envelope instead.
+     *
+     * @return this spec for chaining
+     */
+    public FuncScheduleEventSpec first() {
+        this.first = true;
+        return this;
+    }
+
+    /**
+     * When combined with {@link #first()}, passes the full CloudEvent envelope
+     * (including extensions, source, type, etc.) instead of just the data payload.
+     * Users working with the envelope will need CE serializers to access its fields.
+     *
+     * @return this spec for chaining
+     */
+    public FuncScheduleEventSpec envelope() {
+        this.envelope = true;
+        return this;
+    }
+
+    public boolean isFirst() {
+        return first;
+    }
+
+    public boolean isEnvelope() {
+        return envelope;
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Override
+    public void accept(AbstractEventConsumptionStrategyBuilder<?, ?, ?> builder) {
+        Consumer<EventFilterBuilder> eventFilter = eventType != null
+                ? DSL.event().type(eventType)
+                : filter;
+        ((AbstractEventConsumptionStrategyBuilder) builder).one(eventFilter);
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FuncScheduleSpec.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FuncScheduleSpec.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.flow.dsl;
+
+import java.util.function.Consumer;
+
+import io.serverlessworkflow.fluent.spec.ScheduleBuilder;
+
+/**
+ * A schedule specification that wraps a {@link FuncScheduleEventSpec} and propagates
+ * its {@link FuncScheduleEventSpec#isFirst()} and {@link FuncScheduleEventSpec#isEnvelope()}
+ * flags through the {@code schedule(on(one("type").first()))} call chain.
+ *
+ * <p>
+ * Returned by {@link FlowDSL#on(FuncScheduleEventSpec)}.
+ */
+public class FuncScheduleSpec implements Consumer<ScheduleBuilder> {
+
+    private final FuncScheduleEventSpec eventSpec;
+
+    FuncScheduleSpec(FuncScheduleEventSpec eventSpec) {
+        this.eventSpec = eventSpec;
+    }
+
+    public boolean isFirst() {
+        return eventSpec.isFirst();
+    }
+
+    public boolean isEnvelope() {
+        return eventSpec.isEnvelope();
+    }
+
+    @Override
+    public void accept(ScheduleBuilder scheduleBuilder) {
+        scheduleBuilder.on(eventSpec);
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/Step.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/Step.java
@@ -300,7 +300,7 @@ abstract class Step<SELF extends Step<SELF, B>, B> implements FuncTaskConfigurer
      * @return this step for method chaining
      * @see io.quarkiverse.flow.dsl.spi.FuncTransformations#outputAs(Function, Class)
      */
-    public <T, R> SELF outputAs(Function<T, R> function, Class<T> taskResultClass) {
+    public <T, R> SELF outputAs(SerializableFunction<T, R> function, Class<T> taskResultClass) {
         postConfigurers.add(b -> ((FuncTaskTransformations<?>) b).outputAs(function, taskResultClass));
         return self();
     }
@@ -474,7 +474,7 @@ abstract class Step<SELF extends Step<SELF, B>, B> implements FuncTaskConfigurer
      * @return this step for method chaining
      * @see io.quarkiverse.flow.dsl.spi.FuncTransformations#inputFrom(Function, Class)
      */
-    public <T, R> SELF inputFrom(Function<T, R> function, Class<T> inputClass) {
+    public <T, R> SELF inputFrom(SerializableFunction<T, R> function, Class<T> inputClass) {
         postConfigurers.add(b -> ((FuncTaskTransformations<?>) b).inputFrom(function, inputClass));
         return self();
     }

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/spi/FuncTransformations.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/spi/FuncTransformations.java
@@ -1,9 +1,8 @@
 package io.quarkiverse.flow.dsl.spi;
 
-import java.util.function.Function;
-
 import io.quarkiverse.flow.dsl.types.ContextFunction;
 import io.quarkiverse.flow.dsl.types.FilterFunction;
+import io.quarkiverse.flow.dsl.types.SerializableFunction;
 import io.quarkiverse.flow.dsl.types.TypedContextFunction;
 import io.quarkiverse.flow.dsl.types.TypedFilterFunction;
 import io.quarkiverse.flow.dsl.types.TypedFunction;
@@ -17,13 +16,13 @@ public interface FuncTransformations<SELF extends FuncTransformations<SELF>>
         extends TransformationHandlers {
 
     @SuppressWarnings("unchecked")
-    default <T, V> SELF inputFrom(Function<T, V> function) {
+    default <T, V> SELF inputFrom(SerializableFunction<T, V> function) {
         setInput(new Input().withFrom(new InputFrom().withObject(function)));
         return (SELF) this;
     }
 
     @SuppressWarnings("unchecked")
-    default <T, V> SELF inputFrom(Function<T, V> function, Class<T> argClass) {
+    default <T, V> SELF inputFrom(SerializableFunction<T, V> function, Class<T> argClass) {
         setInput(
                 new Input().withFrom(new InputFrom().withObject(new TypedFunction<>(function, argClass))));
         return (SELF) this;
@@ -64,13 +63,13 @@ public interface FuncTransformations<SELF extends FuncTransformations<SELF>>
     }
 
     @SuppressWarnings("unchecked")
-    default <T, V> SELF outputAs(Function<T, V> function) {
+    default <T, V> SELF outputAs(SerializableFunction<T, V> function) {
         setOutput(new Output().withAs(new OutputAs().withObject(function)));
         return (SELF) this;
     }
 
     @SuppressWarnings("unchecked")
-    default <T, V> SELF outputAs(Function<T, V> function, Class<T> argClass) {
+    default <T, V> SELF outputAs(SerializableFunction<T, V> function, Class<T> argClass) {
         setOutput(
                 new Output().withAs(new OutputAs().withObject(new TypedFunction<>(function, argClass))));
         return (SELF) this;

--- a/core/runtime/src/test/java/io/quarkiverse/flow/dsl/FlowDSLListenFirstTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/flow/dsl/FlowDSLListenFirstTest.java
@@ -1,0 +1,85 @@
+package io.quarkiverse.flow.dsl;
+
+import static io.quarkiverse.flow.dsl.FlowDSL.function;
+import static io.quarkiverse.flow.dsl.FlowDSL.listen;
+import static io.quarkiverse.flow.dsl.FlowDSL.toOne;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.serverlessworkflow.api.types.ListenTask;
+import io.serverlessworkflow.api.types.ListenTaskConfiguration;
+import io.serverlessworkflow.api.types.Task;
+import io.serverlessworkflow.api.types.TaskItem;
+import io.serverlessworkflow.api.types.Workflow;
+
+class FlowDSLListenFirstTest {
+
+    @Test
+    @DisplayName("listen(toOne(type).first()) sets read=DATA and output transform")
+    void listen_toOne_first_sets_read_data_and_output() {
+        Workflow wf = FlowWorkflowBuilder.workflow("listen-first")
+                .tasks(
+                        listen(toOne("org.acme.event").first()),
+                        function("process", String::trim, String.class))
+                .build();
+
+        List<TaskItem> items = wf.getDo();
+        Task t = items.get(0).getTask();
+        ListenTask lt = t.getListenTask();
+        assertNotNull(lt, "ListenTask expected");
+
+        assertEquals(
+                ListenTaskConfiguration.ListenAndReadAs.DATA,
+                lt.getListen().getRead(),
+                "read should be DATA (default)");
+        assertNotNull(lt.getOutput(), "Output should be set (from first)");
+        assertNotNull(lt.getOutput().getAs(), "Output.as should be set");
+        assertNotNull(lt.getOutput().getAs().getObject(),
+                "Output.as should contain a Java function for unwrapping");
+    }
+
+    @Test
+    @DisplayName("listen(toOne(type).envelope().first()) sets read=ENVELOPE and output transform")
+    void listen_toOne_envelope_first_sets_read_envelope_and_output() {
+        Workflow wf = FlowWorkflowBuilder.workflow("listen-envelope-first")
+                .tasks(
+                        listen(toOne("org.acme.event").envelope().first()),
+                        function("process", String::trim, String.class))
+                .build();
+
+        List<TaskItem> items = wf.getDo();
+        Task t = items.get(0).getTask();
+        ListenTask lt = t.getListenTask();
+        assertNotNull(lt, "ListenTask expected");
+
+        assertEquals(
+                ListenTaskConfiguration.ListenAndReadAs.ENVELOPE,
+                lt.getListen().getRead(),
+                "read should be ENVELOPE");
+        assertNotNull(lt.getOutput(), "Output should be set (from envelope().first())");
+        assertNotNull(lt.getOutput().getAs(), "Output.as should be set");
+    }
+
+    @Test
+    @DisplayName("listen(toOne(type)) without first does NOT set output transform")
+    void listen_toOne_without_first_does_not_set_output() {
+        Workflow wf = FlowWorkflowBuilder.workflow("listen-no-first")
+                .tasks(
+                        listen(toOne("org.acme.event")),
+                        function("process", String::trim, String.class))
+                .build();
+
+        List<TaskItem> items = wf.getDo();
+        Task t = items.get(0).getTask();
+        ListenTask lt = t.getListenTask();
+        assertNotNull(lt, "ListenTask expected");
+
+        assertNull(lt.getOutput(), "Output should NOT be set when first is not called");
+    }
+}

--- a/core/runtime/src/test/java/io/quarkiverse/flow/dsl/FlowDSLScheduleTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/flow/dsl/FlowDSLScheduleTest.java
@@ -4,6 +4,7 @@ import static io.quarkiverse.flow.dsl.FlowDSL.after;
 import static io.quarkiverse.flow.dsl.FlowDSL.allOfType;
 import static io.quarkiverse.flow.dsl.FlowDSL.cron;
 import static io.quarkiverse.flow.dsl.FlowDSL.every;
+import static io.quarkiverse.flow.dsl.FlowDSL.function;
 import static io.quarkiverse.flow.dsl.FlowDSL.on;
 import static io.quarkiverse.flow.dsl.FlowDSL.one;
 import static io.quarkiverse.flow.dsl.FlowDSL.timeoutHours;
@@ -15,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import io.serverlessworkflow.api.types.InputFrom;
 import io.serverlessworkflow.api.types.Schedule;
 import io.serverlessworkflow.api.types.Workflow;
 
@@ -105,6 +107,82 @@ class FlowDSLScheduleTest {
                 "org.acme.startup",
                 schedule.getOn().getOneEventConsumptionStrategy().getOne().getWith().getType(),
                 "Event type should match");
+    }
+
+    @Test
+    @DisplayName("schedule(on(one(event).first())) sets schedule and inputFrom to extract CE data")
+    void schedule_on_one_first_sets_schedule_and_inputFrom() {
+        Workflow wf = FlowWorkflowBuilder.workflow("schedule-first")
+                .schedule(on(one("com.example.booking.confirmed").first()))
+                .tasks(function("process", String::trim, String.class))
+                .build();
+
+        Schedule schedule = wf.getSchedule();
+        assertNotNull(schedule, "Schedule should be configured");
+        assertNotNull(schedule.getOn(), "On configuration should be set");
+        assertNotNull(
+                schedule.getOn().getOneEventConsumptionStrategy(),
+                "One consumption strategy should be set");
+        assertEquals(
+                "com.example.booking.confirmed",
+                schedule.getOn().getOneEventConsumptionStrategy().getOne().getWith().getType(),
+                "Event type should match");
+
+        assertNotNull(wf.getInput(), "Input should be set (from first)");
+        assertNotNull(wf.getInput().getFrom(), "Input.from should be set");
+        InputFrom from = wf.getInput().getFrom();
+        assertNotNull(from.getObject(), "Input.from should contain a Java function");
+        assertNull(from.getString(), "Input.from should not be a JQ expression");
+    }
+
+    @Test
+    @DisplayName("schedule(on(one(event).envelope().first())) sets schedule and inputFrom for full CE")
+    void schedule_on_one_envelope_first_sets_schedule_and_inputFrom() {
+        Workflow wf = FlowWorkflowBuilder.workflow("schedule-envelope-first")
+                .schedule(on(one("com.example.booking.confirmed").envelope().first()))
+                .tasks(function("process", String::trim, String.class))
+                .build();
+
+        Schedule schedule = wf.getSchedule();
+        assertNotNull(schedule, "Schedule should be configured");
+        assertNotNull(
+                schedule.getOn().getOneEventConsumptionStrategy(),
+                "One consumption strategy should be set");
+
+        assertNotNull(wf.getInput(), "Input should be set (from envelope().first())");
+        assertNotNull(wf.getInput().getFrom(), "Input.from should be set");
+        InputFrom from = wf.getInput().getFrom();
+        assertNotNull(from.getObject(), "Input.from should contain a Java function");
+    }
+
+    @Test
+    @DisplayName("schedule(on(one(event))) without first does NOT set inputFrom")
+    void schedule_on_one_without_first_does_not_set_inputFrom() {
+        Workflow wf = FlowWorkflowBuilder.workflow("schedule-no-first")
+                .schedule(on(one("org.acme.event")))
+                .tasks(function("process", String::trim, String.class))
+                .build();
+
+        Schedule schedule = wf.getSchedule();
+        assertNotNull(schedule, "Schedule should be configured");
+        assertNull(wf.getInput(), "Input should NOT be set when first is not called");
+    }
+
+    @Test
+    @DisplayName("first inputFrom can be overridden by explicit inputFrom")
+    void first_inputFrom_can_be_overridden() {
+        Workflow wf = FlowWorkflowBuilder.workflow("schedule-override")
+                .schedule(on(one("com.example.event").first()))
+                .inputFrom(".custom_expression")
+                .tasks(function("process", String::trim, String.class))
+                .build();
+
+        assertNotNull(wf.getInput(), "Input should be set");
+        assertNotNull(wf.getInput().getFrom(), "Input.from should be set");
+        assertEquals(
+                ".custom_expression",
+                wf.getInput().getFrom().getString(),
+                "Explicit inputFrom should override first's inputFrom");
     }
 
     @Test

--- a/docs/modules/ROOT/examples/org/acme/HelloMessagingFlow.java
+++ b/docs/modules/ROOT/examples/org/acme/HelloMessagingFlow.java
@@ -2,7 +2,6 @@ package org.acme;
 
 import static io.quarkiverse.flow.dsl.FlowDSL.*;
 
-import java.util.Collection;
 import java.util.Map;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -18,10 +17,7 @@ public class HelloMessagingFlow extends Flow {
     public Workflow descriptor() {
         return FlowWorkflowBuilder.workflow("hello-messaging")
                 .tasks(
-                        // Wait for one request event
-                        listen("waitHello", toOne("org.acme.hello.request"))
-                                // listen() returns a collection; pick the first
-                                .outputAs((Collection<Object> c) -> c.iterator().next()),
+                        listen("waitHello", toOne("org.acme.hello.request").first()),
 
                         // Build a response with jq
                         set("{ message: \"Hello \" + .name }"),

--- a/docs/modules/ROOT/pages/dsl-cheatsheet.adoc
+++ b/docs/modules/ROOT/pages/dsl-cheatsheet.adoc
@@ -180,13 +180,13 @@ All helpers below return a chainable provider/step (e.g., `FuncTaskConfigurer`, 
 
 |`listen(FuncListenSpec spec)`
 |`ListenStep`
-|Listen using a spec (e.g., `toOne`, `toAny`, `toAll`).
-|`listen(toAny("org.acme.done", "org.acme.skipped"))`
+|Listen using a spec (e.g., `toOne`, `toAny`, `toAll`). Chain `.first()` on the spec to extract the first event from the collection.
+|`listen(toOne("org.acme.done").first())`
 
 |`listen(String name, FuncListenSpec spec)`
 |`ListenStep`
-|Named listen.
-|`listen("waitHuman", toOne("org.acme.review.done"))`
+|Named listen. Chain `.first()` to unwrap, `.envelope().first()` to keep the full CE.
+|`listen("waitHuman", toOne("org.acme.review.done").first())`
 
 |`switchCase(Consumer<FuncSwitchTaskBuilder> switchConsumer)`
 |`FuncTaskConfigurer`
@@ -392,7 +392,8 @@ All helpers below return a chainable provider/step (e.g., `FuncTaskConfigurer`, 
 [NOTE]
 Helpers that help you **build** specs for emit/listen/switch/HTTP/OpenAPI but are not task providers themselves:
 
-- Events & listen: `event(...)`, `eventJson(...)`, `eventBytes(...)`, `to()`, `toOne(...)`, `toAny(...)`, `toAll(...)`
+- Events & listen: `event(...)`, `eventJson(...)`, `eventBytes(...)`, `to()`, `toOne(...)`, `toAny(...)`, `toAll(...)`. Call `.first()` on a `toOne(...)` spec to extract the first element from the event collection (the spec always delivers events as a collection). Chain `.envelope().first()` to keep the full CloudEvent envelope instead of just the data payload.
+- Schedule events: `one(...)`, `allOfType(...)`, `on(...)`. Call `.first()` on `one(...)` to auto-extract the first CloudEvent data via `inputFrom`. Chain `.envelope().first()` to keep the full envelope.
 - Switch helpers: `cases(...)`, `caseOf(...)`, `caseDefault(...)`
 
 You pass the *resulting* steps/specs (e.g. `listen(...)`, `emitJson(...)`, `openapi()`, `http()`, `get(...)`, `post(...)`) into `.tasks(...)`.
@@ -485,9 +486,8 @@ Workflow w = workflow("intelligent-newsletter")
     // 3) Emit review request for human oversight
     emitJson("org.acme.newsletter.review.required", CriticAgentReview.class),
 
-    // 4) Wait for human review; transform the raw event collection into a single result
-    listen("waitHumanReview", toOne("org.acme.newsletter.review.done"))
-      .outputAs((java.util.Collection<Object> c) -> c.iterator().next()),
+    // 4) Wait for human review; extract the first event from the collection
+    listen("waitHumanReview", toOne("org.acme.newsletter.review.done").first()),
 
     // 5) Branch: revision loop or final send based on human input
     switchWhenOrElse(
@@ -509,7 +509,7 @@ Workflow w = workflow("intelligent-newsletter")
 
 == Tips
 
-* Prefer **static imports**: `workflow`, `set`, `function`, `withContext`, `withFilter`, `withUniqueId`, `agent`, `emitJson`, `listen`, `switchWhenOrElse`, `consume`, `to`, `event`, `http`, `get`, `post`, `openapi`, `call`.
+* Prefer **static imports**: `workflow`, `set`, `function`, `withContext`, `withFilter`, `withUniqueId`, `agent`, `emitJson`, `listen`, `switchWhenOrElse`, `consume`, `to`, `toOne`, `event`, `on`, `one`, `http`, `get`, `post`, `openapi`, `call`.
 * **Name** tasks you branch to: stable task names make `switchWhen*` targets explicit and work well with `withUniqueId`/`agent` memory ids.
 * Keep transformations **close to the step** that needs them (`inputFrom`, `exportAs`, `outputAs`) for readability.
 * HTTP/OpenAPI: you can either:

--- a/docs/modules/ROOT/pages/langchain4j.adoc
+++ b/docs/modules/ROOT/pages/langchain4j.adoc
@@ -260,8 +260,7 @@ You can easily pause an AI orchestration to wait for human approval by combining
 emitJson("org.acme.email.review.required", CriticAgentReview.class),
 
 // 2. Pause the workflow and wait for the human's response event
-listen("waitHumanReview", toOne("org.acme.newsletter.review.done"))
-  .outputAs((java.util.Collection<Object> c) -> c.iterator().next()),
+listen("waitHumanReview", toOne("org.acme.newsletter.review.done").first()),
 
 // 3. Branch based on the human's decision
 switchWhenOrElse(

--- a/examples/resilient-task-orchestrator/src/main/java/org/acme/orchestrator/workflow/TaskWorkflow.java
+++ b/examples/resilient-task-orchestrator/src/main/java/org/acme/orchestrator/workflow/TaskWorkflow.java
@@ -1,6 +1,5 @@
 package org.acme.orchestrator.workflow;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkiverse.flow.Flow;
 import io.serverlessworkflow.api.types.FlowDirectiveEnum;
 import io.serverlessworkflow.api.types.Workflow;
@@ -53,7 +52,7 @@ public class TaskWorkflow extends Flow {
     public Workflow descriptor() {
         return workflow("build-task")
                 // 1. Listen for task start event from coordinator
-                .schedule(on(one("org.acme.build.task.started")))
+                .schedule(on(one("org.acme.build.task.started").first()))
                 .tasks(
                         // 2. Extract BuildTask from CloudEvent and reconcile state
                         function("extractAndReconcile", (BuildTask task) -> {
@@ -68,8 +67,7 @@ public class TaskWorkflow extends Flow {
 
                             LOG.info("Task {} reconciliation successful: {}", task.id(), result.message());
                             return task;
-                        })// Extract BuildTask from CloudEvent structure: schedule() returns array of CloudEvents
-                                .inputFrom((JsonNode node) -> node.isArray() ? node.get(0).get("data") : node.get("data")),
+                        }),
 
                         // 3. Execute task (idempotent, can retry)
                         function("execute", (BuildTask task) -> {

--- a/messaging/integration-tests/src/main/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlow.java
+++ b/messaging/integration-tests/src/main/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlow.java
@@ -38,10 +38,9 @@ public class HelloMessagingFlow extends Flow {
                 // We are listening to one and only one event coming to our broker with the type "io.quarkiverse.flow.messaging.hello.request"
                 // Each event produced by the broker with this type will kick a new workflow instance.
                 // To learn more see the base specification: https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#listen
-                .tasks(listen(toOne("io.quarkiverse.flow.messaging.hello.request")),
+                .tasks(listen(toOne("io.quarkiverse.flow.messaging.hello.request").first()),
                         // "name" is expected in the message body payload
-                        // by design, we receive an array from the listen task, since it's only one we are expecting it's safe to index
-                        set("{ message: \"Hello \" + .[0].name + \"!\" }"),
+                        set("{ message: \"Hello \" + .name + \"!\" }"),
                         // We emit a new event with the specified type having the property `message` in the body that we built in the previous `set` task.
                         emit(produced("io.quarkiverse.flow.messaging.hello.response").jsonData(Map.class)))
                 .build();


### PR DESCRIPTION
## Summary

Closes #802

- Add `first()` and `envelope().first()` to `listen` and `schedule` DSL for extracting the first CloudEvent from the collection
- The spec always delivers events as a collection; `first()` unwraps it so downstream tasks receive a single object
- Migrate existing manual unwrapping patterns in examples, docs, and integration tests to the new API

## API

```java
// Listen — extract first CE data
listen(toOne("type").first())

// Listen — extract first full CE envelope
listen(toOne("type").envelope().first())

// Schedule — extract first CE data
schedule(on(one("type").first()))

// Schedule — extract first full CE envelope
schedule(on(one("type").envelope().first()))
```

## Test plan

- [x] 221 unit tests pass (`core/runtime`)
- [x] Messaging integration tests pass (Kafka `HelloMessagingFlowTest`)
- [x] Resilient task orchestrator integration tests pass (`TaskWorkflowIT`, `BuildPipelineIT`)