### PR TITLE
Add Hibernate ORM naming strategy property note to docs

### DIFF
--- a/docs/modules/ROOT/pages/persistence.adoc
+++ b/docs/modules/ROOT/pages/persistence.adoc
@@ -187,6 +187,7 @@ Enable migration at startup and disable Hibernate ORM schema generation in your 
 [source,properties]
 ----
 quarkus.hibernate-orm.database.generation=none
+quarkus.hibernate-orm.physical-naming-strategy=org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
 quarkus.flyway.enabled=true
 quarkus.flyway.migrate-at-start=true
 ----


### PR DESCRIPTION
I have added this properties in yaml configuration: quarkus.hibernate-orm.physical-naming-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy because with out it, I wa getting this exception: workflows: org.hibernate.exception.SQLGrammarException: JDBC exception executing SQL [ERROR: relation "workflowinstanceentity" does not exist
  Position: 151] [select wie1_0.applicationId,wie1_0.instanceId,wie1_0.startedAt,wie1_0.status,wie1_0.workflowName,wie1_0.workflowNamespace,wie1_0.workflowVersion from WorkflowInstanceEntity wie1_0 where wie1_0.applicationId=? and wie1_0.workflowNamespace=? and wie1_0.workflowName=? and wie1_0.workflowVersion=?]

mi enviroment it is Quarkus + postgresql

## Description

add a configuration for start up application

Fixes #<!-- issue number -->

## Changes

<!-- List the main changes in this PR -->

I have added this properties in yaml configuration: quarkus.hibernate-orm.physical-naming-strategy: 

## Testing

there is not a testing 

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
