### PR TITLE
Fix #810 - Use String payload for CloudEvent messaging bridge

### DIFF
--- a/docs/modules/ROOT/pages/messaging.adoc
+++ b/docs/modules/ROOT/pages/messaging.adoc
@@ -119,21 +119,52 @@ By default, every event published to `flow-out` will include:
 * `flowinstanceid`: The ULID of the executing `WorkflowInstance`.
 * `flowtaskid`: The JSON Pointer of the specific task that emitted the event (e.g., `do/0/task`).
 
-If you are writing a custom consumer downstream, you can extract these attributes directly from the `CloudEvent`:
+If you are writing a custom consumer downstream, use SmallRye's `CloudEventMetadata` to access attributes and read the payload as a `String`:
 
 [source,java]
 ----
-import io.cloudevents.CloudEvent;
+import java.util.concurrent.CompletionStage;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
 import io.quarkus.logging.Log;
+import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
 
-public void printCorrelation(CloudEvent event) {
-    String instanceId = (String) event.getExtension("flowinstanceid");
-    String taskId = (String) event.getExtension("flowtaskid");
+@ApplicationScoped
+public class FlowOutConsumer {
 
-    Log.infof("Flow Instance ID: %s", instanceId);
-    Log.infof("Flow Task ID: %s", taskId);
+    @Incoming("flow-out-consumer")      // <1>
+    public CompletionStage<Void> consume(Message<String> msg) {
+        CloudEventMetadata<?> ce = msg.getMetadata(CloudEventMetadata.class)
+                .orElseThrow(() -> new IllegalArgumentException("Missing CE metadata"));
+
+        String type = ce.getType();
+        String instanceId = ce.<String>getExtension("flowinstanceid").orElse(null);
+        String taskId = ce.<String>getExtension("flowtaskid").orElse(null);
+        String data = msg.getPayload();     // <2>
+
+        Log.infof("CE type: %s, instance: %s, task: %s", type, instanceId, taskId);
+        Log.infof("Payload: %s", data);
+
+        return msg.ack();
+    }
 }
 ----
+<1> Use a different channel name than `flow-out` (which is the engine's outbound channel). Point it at the same topic/address.
+<2> The payload is the event _data_ only. CE attributes (`type`, `source`, extensions, …) are in the message metadata, not in the payload.
+
+The matching channel configuration:
+
+[source,properties]
+----
+mp.messaging.incoming.flow-out-consumer.connector=smallrye-kafka
+mp.messaging.incoming.flow-out-consumer.topic=flow-out
+----
+
+IMPORTANT: Do *not* use `io.cloudevents.CloudEvent` as the parameter type in an `@Incoming` method. SmallRye Reactive Messaging does not auto-deserialize the payload into a `CloudEvent` object — the CE attributes are carried in transport headers (Kafka `ce_*`, AMQP `cloudEvents:*`) and exposed via `CloudEventMetadata`. Using `CloudEvent` directly will cause a `ClassCastException`.
 
 If you need to rename these keys to match your enterprise naming conventions, or disable them entirely:
 [source,properties]

--- a/docs/modules/ROOT/pages/migration-0.14-to-0.15.adoc
+++ b/docs/modules/ROOT/pages/migration-0.14-to-0.15.adoc
@@ -1,7 +1,7 @@
-= Migration Guide: 0.14.x to 0.15.0
+= Migration Guide: 0.14.x to 0.15.1
 include::includes/attributes.adoc[]
 
-Quarkus Flow 0.15.0 fixes CloudEvent encoding on the messaging bridge.
+Quarkus Flow 0.15.1 fixes CloudEvent encoding on the messaging bridge.
 The `flow-out` producer and `flow-in` consumer now use SmallRye Reactive Messaging's native CloudEvent support instead of manual JSON serialization.
 
 This is a **wire-format breaking change**: the outgoing message payload on `flow-out` is now the event _data_ only — CloudEvent attributes travel via transport headers (Kafka `ce_*`, AMQP `cloudEvents:*`).
@@ -17,7 +17,7 @@ This caused two problems:
 * The approach was Kafka-specific.
   Adding Kafka headers would have broken AMQP and other connectors.
 
-0.15.0 delegates CloudEvent encoding to SmallRye via `OutgoingCloudEventMetadata` (outbound) and `IncomingCloudEventMetadata` (inbound).
+0.15.1 delegates CloudEvent encoding to SmallRye via `OutgoingCloudEventMetadata` (outbound) and `IncomingCloudEventMetadata` (inbound).
 SmallRye maps CE attributes to the appropriate transport mechanism for each connector, keeping the bridge transport-agnostic.
 
 == What changed
@@ -26,7 +26,7 @@ SmallRye maps CE attributes to the appropriate transport mechanism for each conn
 
 [cols="1,1",options="header"]
 |===
-| Before (0.14.x) | After (0.15.0)
+| Before (0.14.x) | After (0.15.1)
 
 | Message body = full CE JSON envelope (`specversion`, `type`, `source`, `data`, …)
 | Message body = CE _data_ payload only
@@ -42,7 +42,7 @@ SmallRye maps CE attributes to the appropriate transport mechanism for each conn
 
 [cols="1,1",options="header"]
 |===
-| Before (0.14.x) | After (0.15.0)
+| Before (0.14.x) | After (0.15.1)
 
 | Only structured CloudEvents (full JSON envelope in body)
 | Structured _and_ binary CloudEvents
@@ -53,7 +53,7 @@ SmallRye maps CE attributes to the appropriate transport mechanism for each conn
 
 === AMQP connector support
 
-0.15.0 adds first-class support for the SmallRye AMQP connector (`quarkus-messaging-amqp`).
+0.15.1 adds first-class support for the SmallRye AMQP connector (`quarkus-messaging-amqp`).
 Both structured and binary CloudEvents work on AMQP out of the box — no additional dependencies or configuration required.
 
 == Step-by-step migration
@@ -63,7 +63,8 @@ Both structured and binary CloudEvents work on AMQP out of the box — no additi
 If you consume from `flow-out` using the CloudEvents SDK deserializer, your code now works correctly — no changes needed.
 This was broken in 0.14.x.
 
-If you consume raw bytes and call `JsonFormat.deserialize(payload)`, you must update to use SmallRye's `CloudEventMetadata`:
+If you consume raw bytes and call `JsonFormat.deserialize(payload)`, you must update to use SmallRye's `CloudEventMetadata`.
+As of 0.15.1, the message payload is a `String` (not `byte[]`):
 
 [source,java]
 ----
@@ -73,11 +74,11 @@ CloudEvent event = CE_JSON.deserialize(payload);
 String type = event.getType();
 byte[] data = event.getData().toBytes();
 
-// After (0.15.0) — CE attributes in metadata, payload is data only
+// After (0.15.1) — CE attributes in metadata, payload is data only
 CloudEventMetadata<?> ceMeta = msg.getMetadata(CloudEventMetadata.class)
     .orElseThrow();
 String type = ceMeta.getType();
-byte[] data = msg.getPayload();
+String data = msg.getPayload();
 ----
 
 Required import:
@@ -88,6 +89,11 @@ import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
 ----
 
 No new dependencies — `CloudEventMetadata` comes from `smallrye-reactive-messaging-api`, which is already on the classpath via the Quarkus Messaging connector.
+
+IMPORTANT: Do *not* use `io.cloudevents.CloudEvent` as the parameter type in an `@Incoming` method.
+SmallRye Reactive Messaging does not auto-deserialize the payload into a `CloudEvent` object — the CE attributes are carried in transport headers and exposed via `CloudEventMetadata`.
+Using `CloudEvent` directly will cause a `ClassCastException`.
+See xref:messaging.adoc#_5_cloudevent_correlation_headers[CloudEvent Correlation Headers] for a complete consumer example.
 
 === 2. Update Kafka consumer configuration (if applicable)
 

--- a/examples/newsletter-drafter/src/main/java/org/acme/newsletter/web/NewsletterAPIResource.java
+++ b/examples/newsletter-drafter/src/main/java/org/acme/newsletter/web/NewsletterAPIResource.java
@@ -32,7 +32,7 @@ public class NewsletterAPIResource {
     // Kafka producer bound to topic `flow-in`
     @Inject
     @Channel("flow-in-outgoing")
-    Emitter<byte[]> flowIn;
+    Emitter<String> flowIn;
 
     /**
      * Starts the workflow to create a new newsletter draft.
@@ -55,7 +55,7 @@ public class NewsletterAPIResource {
     @Path("/newsletter")
     public Response sendReview(HumanReview review, @HeaderParam("X-Flow-Instance-Id") String instanceId)
             throws JsonProcessingException {
-        byte[] body = objectMapper.writeValueAsBytes(review);
+        String body = objectMapper.writeValueAsString(review);
 
         OutgoingCloudEventMetadata<?> ceMeta = OutgoingCloudEventMetadata.builder()
                 .withId(UUID.randomUUID().toString())

--- a/examples/newsletter-drafter/src/main/java/org/acme/newsletter/web/NewsletterOutBridge.java
+++ b/examples/newsletter-drafter/src/main/java/org/acme/newsletter/web/NewsletterOutBridge.java
@@ -2,7 +2,6 @@ package org.acme.newsletter.web;
 
 import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
 import jakarta.enterprise.context.ApplicationScoped;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletionStage;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -22,18 +21,17 @@ public class NewsletterOutBridge {
     private static final String REVIEW_REQUIRED_TYPE = "org.acme.email.review.required";
 
     @Incoming("flow-out-incoming")
-    public CompletionStage<Void> onFlowOut(Message<byte[]> msg) {
+    public CompletionStage<Void> onFlowOut(Message<String> msg) {
         try {
             CloudEventMetadata<?> ceMeta = msg.getMetadata(CloudEventMetadata.class).orElse(null);
             if (ceMeta == null || ceMeta.getType() == null)
                 return msg.ack();
 
             if (REVIEW_REQUIRED_TYPE.equals(ceMeta.getType())) {
-                byte[] data = msg.getPayload();
-                // If there's no data, send a minimal envelope so the UI can handle it.
-                String json = (data == null || data.length == 0)
+                String data = msg.getPayload();
+                String json = (data == null || data.isEmpty())
                         ? "{\"type\":\"" + REVIEW_REQUIRED_TYPE + "\",\"payload\":null}"
-                        : new String(data, StandardCharsets.UTF_8);
+                        : data;
 
                 LOG.info("Received review (workflow instance: {}) required event: {}",
                         ceMeta.getExtension("flowinstanceid"), json);

--- a/examples/newsletter-drafter/src/main/resources/application.properties
+++ b/examples/newsletter-drafter/src/main/resources/application.properties
@@ -17,13 +17,13 @@ quarkus.flow.messaging.defaults-enabled=true
 # Flow Engine Inbound CloudEvents (structured JSON)
 mp.messaging.incoming.flow-in.connector=smallrye-kafka
 mp.messaging.incoming.flow-in.topic=flow-in
-mp.messaging.incoming.flow-in.value.deserializer=org.apache.kafka.common.serialization.ByteArrayDeserializer
+mp.messaging.incoming.flow-in.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.flow-in.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 
 # Flow Engine Outbound CloudEvents (structured JSON)
 mp.messaging.outgoing.flow-out.connector=smallrye-kafka
 mp.messaging.outgoing.flow-out.topic=flow-out
-mp.messaging.outgoing.flow-out.value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer
+mp.messaging.outgoing.flow-out.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.flow-out.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 
 # Flow Engine lifecycle events (useful for telemetry/auditing)
@@ -31,18 +31,18 @@ quarkus.flow.messaging.lifecycle-enabled=true
 mp.messaging.outgoing.flow-lifecycle-out.connector=smallrye-kafka
 mp.messaging.outgoing.flow-lifecycle-out.topic=flow-lifecycle-out
 mp.messaging.outgoing.flow-lifecycle-out.key.serializer=org.apache.kafka.common.serialization.StringSerializer
-mp.messaging.outgoing.flow-lifecycle-out.value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer
+mp.messaging.outgoing.flow-lifecycle-out.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
 # Outgoing channel used by the Newsletter API resource
 mp.messaging.outgoing.flow-in-outgoing.connector=smallrye-kafka
 mp.messaging.outgoing.flow-in-outgoing.topic=flow-in
-mp.messaging.outgoing.flow-in-outgoing.value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer
+mp.messaging.outgoing.flow-in-outgoing.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.flow-in-outgoing.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 
 # --- Kafka consumer for flow-out -> Newsletter WebSocket bridge ---
 mp.messaging.incoming.flow-out-incoming.connector=smallrye-kafka
 mp.messaging.incoming.flow-out-incoming.topic=flow-out
-mp.messaging.incoming.flow-out-incoming.value.deserializer=org.apache.kafka.common.serialization.ByteArrayDeserializer
+mp.messaging.incoming.flow-out-incoming.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.flow-out-incoming.auto.offset.reset=earliest
 
 

--- a/examples/newsletter-drafter/src/test/java/org/acme/newsletter/NewsletterWorkflowIT.java
+++ b/examples/newsletter-drafter/src/test/java/org/acme/newsletter/NewsletterWorkflowIT.java
@@ -43,7 +43,7 @@ public class NewsletterWorkflowIT {
 
     @Inject
     @Channel("flow-out-incoming")
-    io.smallrye.mutiny.Multi<Message<byte[]>> flowOutEvents;
+    io.smallrye.mutiny.Multi<Message<String>> flowOutEvents;
 
     @InjectMock
     MailService mailService;
@@ -138,9 +138,9 @@ public class NewsletterWorkflowIT {
                 .contentType("application/json").body(review).when().put("/api/newsletter").then().statusCode(202);
     }
 
-    private NewsletterDraft parseNewsletterDraft(byte[] data) {
+    private NewsletterDraft parseNewsletterDraft(String data) {
         try {
-            if (data == null || data.length == 0)
+            if (data == null || data.isEmpty())
                 return null;
             return JsonUtils.mapper().readValue(data, NewsletterDraft.class);
         } catch (Exception e) {

--- a/examples/resilient-task-orchestrator/src/main/resources/application.properties
+++ b/examples/resilient-task-orchestrator/src/main/resources/application.properties
@@ -12,7 +12,7 @@ quarkus.flow.tracing.enabled=true
 # Flow Engine Inbound CloudEvents (where workflows listen)
 mp.messaging.incoming.flow-in.connector=smallrye-kafka
 mp.messaging.incoming.flow-in.topic=flow-in
-mp.messaging.incoming.flow-in.value.deserializer=org.apache.kafka.common.serialization.ByteArrayDeserializer
+mp.messaging.incoming.flow-in.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.flow-in.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.flow-in.auto.offset.reset=earliest
 
@@ -20,13 +20,13 @@ mp.messaging.incoming.flow-in.auto.offset.reset=earliest
 # For event choreography, publish to flow-in so other workflows can consume
 mp.messaging.outgoing.flow-out.connector=smallrye-kafka
 mp.messaging.outgoing.flow-out.topic=flow-in
-mp.messaging.outgoing.flow-out.value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer
+mp.messaging.outgoing.flow-out.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.flow-out.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 
 # Outgoing channel for tests/API to send events to workflows
 mp.messaging.outgoing.flow-in-outgoing.connector=smallrye-kafka
 mp.messaging.outgoing.flow-in-outgoing.topic=flow-in
-mp.messaging.outgoing.flow-in-outgoing.value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer
+mp.messaging.outgoing.flow-in-outgoing.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.flow-in-outgoing.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 
 # Dev mode

--- a/examples/resilient-task-orchestrator/src/test/java/org/acme/orchestrator/BuildPipelineIT.java
+++ b/examples/resilient-task-orchestrator/src/test/java/org/acme/orchestrator/BuildPipelineIT.java
@@ -54,7 +54,7 @@ class BuildPipelineIT {
 
     @Inject
     @Channel("flow-in")
-    io.smallrye.mutiny.Multi<Message<byte[]>> flowInEvents;
+    io.smallrye.mutiny.Multi<Message<String>> flowInEvents;
 
     // Track emitted events across tests
     private Set<String> emittedTaskIds;
@@ -69,7 +69,7 @@ class BuildPipelineIT {
             try {
                 CloudEventMetadata<?> ceMeta = msg.getMetadata(CloudEventMetadata.class).orElse(null);
                 if (ceMeta != null && "org.acme.build.task.started".equals(ceMeta.getType())) {
-                    BuildTask task = objectMapper.readValue(msg.getPayload(), BuildTask.class);
+                    BuildTask task = objectMapper.readValue(msg.getPayload().getBytes(), BuildTask.class);
                     emittedTaskIds.add(task.id());
                     LOG.info("Task started event captured: {}", task.id());
                 }

--- a/examples/resilient-task-orchestrator/src/test/java/org/acme/orchestrator/CoordinatorWorkflowIT.java
+++ b/examples/resilient-task-orchestrator/src/test/java/org/acme/orchestrator/CoordinatorWorkflowIT.java
@@ -55,7 +55,7 @@ class CoordinatorWorkflowIT {
     // Subscribe to flow-in to capture emitted events
     @Inject
     @Channel("flow-in")
-    Multi<Message<byte[]>> flowInEvents;
+    Multi<Message<String>> flowInEvents;
 
     private List<BuildTask> capturedTasks;
 
@@ -70,7 +70,7 @@ class CoordinatorWorkflowIT {
 
                 // Filter for task.started events
                 if (ceMeta != null && "org.acme.build.task.started".equals(ceMeta.getType())) {
-                    BuildTask task = objectMapper.readValue(msg.getPayload(), BuildTask.class);
+                    BuildTask task = objectMapper.readValue(msg.getPayload().getBytes(), BuildTask.class);
                     capturedTasks.add(task);
                     LOG.debug("Captured emitted task: {} ({})", task.name(), task.id());
                 }

--- a/examples/resilient-task-orchestrator/src/test/java/org/acme/orchestrator/TaskWorkflowIT.java
+++ b/examples/resilient-task-orchestrator/src/test/java/org/acme/orchestrator/TaskWorkflowIT.java
@@ -48,7 +48,7 @@ class TaskWorkflowIT {
     // Kafka/messaging emitter for flow-in channel
     @Inject
     @Channel("flow-in-outgoing")
-    Emitter<byte[]> flowIn;
+    Emitter<String> flowIn;
 
     @BeforeEach
     void setUp() {
@@ -272,7 +272,7 @@ class TaskWorkflowIT {
     }
 
     private void emitTaskStartedEvent(BuildTask task) throws Exception {
-        byte[] taskData = objectMapper.writeValueAsBytes(task);
+        String taskData = objectMapper.writeValueAsString(task);
 
         OutgoingCloudEventMetadata<?> ceMeta = OutgoingCloudEventMetadata.builder()
                 .withId(UUID.randomUUID().toString())

--- a/messaging/integration-tests-amqp/src/test/java/io/quarkiverse/flow/messaging/amqp/it/HelloMessagingFlowAmqpTest.java
+++ b/messaging/integration-tests-amqp/src/test/java/io/quarkiverse/flow/messaging/amqp/it/HelloMessagingFlowAmqpTest.java
@@ -183,7 +183,7 @@ public class HelloMessagingFlowAmqpTest {
 
     private void assertResponseMessage(AmqpMessage msg, String name) {
         assertThat(msg).as("Response message was not received").isNotNull();
-        String body = msg.bodyAsBinary().toString(StandardCharsets.UTF_8);
+        String body = msg.bodyAsString();
         assertThat(body).contains("\"Hello " + name + "!\"");
     }
 

--- a/messaging/integration-tests/pom.xml
+++ b/messaging/integration-tests/pom.xml
@@ -51,6 +51,11 @@
             <version>${io.cloudevents.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-reactive-messaging-in-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Forcing dependency for parallel -->
         <dependency>

--- a/messaging/integration-tests/src/main/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlow.java
+++ b/messaging/integration-tests/src/main/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlow.java
@@ -34,7 +34,7 @@ public class HelloMessagingFlow extends Flow {
      */
     @Override
     public Workflow descriptor() {
-        return FlowWorkflowBuilder.workflow()
+        return FlowWorkflowBuilder.workflow("hello-messaging-flow")
                 // We are listening to one and only one event coming to our broker with the type "io.quarkiverse.flow.messaging.hello.request"
                 // Each event produced by the broker with this type will kick a new workflow instance.
                 // To learn more see the base specification: https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#listen

--- a/messaging/integration-tests/src/main/resources/application.properties
+++ b/messaging/integration-tests/src/main/resources/application.properties
@@ -11,18 +11,16 @@ quarkus.flow.messaging.lifecycle-enabled=true
 mp.messaging.incoming.flow-in.connector=smallrye-kafka
 mp.messaging.incoming.flow-in.topic=flow-in
 mp.messaging.incoming.flow-in.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
-mp.messaging.incoming.flow-in.value.deserializer=org.apache.kafka.common.serialization.ByteArrayDeserializer
+mp.messaging.incoming.flow-in.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 
 mp.messaging.outgoing.flow-out.connector=smallrye-kafka
 mp.messaging.outgoing.flow-out.topic=flow-out
-mp.messaging.outgoing.flow-out.key.serializer=org.apache.kafka.common.serialization.StringSerializer
-mp.messaging.outgoing.flow-out.value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer
+mp.messaging.outgoing.flow-out.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
 # Specific configuration for lifecycle
 mp.messaging.outgoing.flow-lifecycle-out.connector=smallrye-kafka
 mp.messaging.outgoing.flow-lifecycle-out.topic=flow-lifecycle-out
-mp.messaging.outgoing.flow-lifecycle-out.key.serializer=org.apache.kafka.common.serialization.StringSerializer
-mp.messaging.outgoing.flow-lifecycle-out.value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer
+mp.messaging.outgoing.flow-lifecycle-out.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
 # This way you see all the events being consumed or produced.
 # quarkus.log.category."io.quarkiverse.flow".level=DEBUG

--- a/messaging/integration-tests/src/test/java/io/quarkiverse/flow/messaging/it/FlowMessagingDefaultConfigOverrideTest.java
+++ b/messaging/integration-tests/src/test/java/io/quarkiverse/flow/messaging/it/FlowMessagingDefaultConfigOverrideTest.java
@@ -46,10 +46,10 @@ public class FlowMessagingDefaultConfigOverrideTest {
 
     @Test
     void userDefinedDeserializerShouldOverrideDefault() {
-        // Verify that the user-defined deserializer overrides the default ByteArrayDeserializer
+        // Verify that the user-defined deserializer overrides the default StringDeserializer
         String valueDeserializer = config.getValue("mp.messaging.incoming.flow-in.value.deserializer", String.class);
         assertEquals(CUSTOM_VALUE_DESERIALIZER, valueDeserializer,
-                "User-defined value.deserializer should override the default ByteArrayDeserializer");
+                "User-defined value.deserializer should override the default StringDeserializer");
     }
 
     @Test
@@ -80,7 +80,7 @@ public class FlowMessagingDefaultConfigOverrideTest {
                     // Override topic names
                     "mp.messaging.incoming.flow-in.topic", CUSTOM_FLOW_IN_TOPIC,
                     "mp.messaging.outgoing.flow-out.topic", CUSTOM_FLOW_OUT_TOPIC,
-                    // Override value deserializer (default is ByteArrayDeserializer)
+                    // Override value deserializer (default is StringDeserializer)
                     "mp.messaging.incoming.flow-in.value.deserializer", CUSTOM_VALUE_DESERIALIZER);
         }
     }

--- a/messaging/integration-tests/src/test/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlowInMemoryTest.java
+++ b/messaging/integration-tests/src/test/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlowInMemoryTest.java
@@ -16,6 +16,8 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
@@ -39,6 +41,7 @@ import io.smallrye.reactive.messaging.memory.InMemorySource;
  *
  * @see <a href="https://github.com/quarkiverse/quarkus-flow/issues/810">Issue #810</a>
  */
+@DisabledOnOs(OS.WINDOWS)
 @QuarkusTest
 @TestProfile(HelloMessagingFlowInMemoryTest.InMemoryProfile.class)
 public class HelloMessagingFlowInMemoryTest {
@@ -143,7 +146,8 @@ public class HelloMessagingFlowInMemoryTest {
             return Map.of(
                     "mp.messaging.incoming.flow-in.connector", "smallrye-in-memory",
                     "mp.messaging.outgoing.flow-out.connector", "smallrye-in-memory",
-                    "mp.messaging.outgoing.flow-lifecycle-out.connector", "smallrye-in-memory");
+                    "mp.messaging.outgoing.flow-lifecycle-out.connector", "smallrye-in-memory",
+                    "quarkus.kafka.devservices.enabled", "false");
         }
     }
 }

--- a/messaging/integration-tests/src/test/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlowInMemoryTest.java
+++ b/messaging/integration-tests/src/test/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlowInMemoryTest.java
@@ -1,0 +1,149 @@
+package io.quarkiverse.flow.messaging.it;
+
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
+import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadata;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import io.smallrye.reactive.messaging.memory.InMemorySink;
+import io.smallrye.reactive.messaging.memory.InMemorySource;
+
+/**
+ * Tests CloudEvent emission using the in-memory connector, resembling
+ * the pattern used in end-user tests (e.g. TripPlannerFlowTest from issue #810).
+ * <p>
+ * Validates that:
+ * <ul>
+ * <li>{@code InMemorySink<String>} receives String payloads (not byte[])</li>
+ * <li>CloudEvent metadata is accessible via {@link CloudEventMetadata}</li>
+ * <li>The payload can be deserialized as a structured CloudEvent JSON</li>
+ * </ul>
+ *
+ * @see <a href="https://github.com/quarkiverse/quarkus-flow/issues/810">Issue #810</a>
+ */
+@QuarkusTest
+@TestProfile(HelloMessagingFlowInMemoryTest.InMemoryProfile.class)
+public class HelloMessagingFlowInMemoryTest {
+
+    @Inject
+    @Any
+    InMemoryConnector connector;
+
+    @Inject
+    HelloMessagingFlow workflow;
+
+    @BeforeEach
+    void setUp() {
+        connector.sink("flow-out").clear();
+        workflow.instance(Map.of()).start();
+    }
+
+    @Test
+    @DisplayName("greet_roundtrip_with_in_memory_connector_produces_string_payload")
+    void greet_roundtrip_in_memory() {
+        InMemorySink<String> sink = connector.sink("flow-out");
+        InMemorySource<Message<?>> source = connector.source("flow-in");
+
+        OutgoingCloudEventMetadata<?> ceMeta = OutgoingCloudEventMetadata.builder()
+                .withId(UUID.randomUUID().toString())
+                .withSource(URI.create("test:/in-memory"))
+                .withType("io.quarkiverse.flow.messaging.hello.request")
+                .withDataContentType("application/json")
+                .build();
+
+        source.send(Message.of("{\"name\":\"InMemory\"}".getBytes()).addMetadata(ceMeta));
+
+        await().atMost(ofSeconds(10)).untilAsserted(() -> {
+            List<? extends Message<String>> messages = sink.received();
+            assertThat(messages)
+                    .as("Should receive at least one event on flow-out")
+                    .isNotEmpty();
+
+            Message<String> msg = messages.stream()
+                    .filter(m -> {
+                        CloudEventMetadata<?> ce = m.getMetadata(CloudEventMetadata.class).orElse(null);
+                        return ce != null && "io.quarkiverse.flow.messaging.hello.response".equals(ce.getType());
+                    })
+                    .findFirst()
+                    .orElse(null);
+
+            assertThat(msg).as("Should find a response CloudEvent").isNotNull();
+
+            CloudEventMetadata<?> responseMeta = msg.getMetadata(CloudEventMetadata.class).orElseThrow();
+            assertThat(responseMeta.getType()).isEqualTo("io.quarkiverse.flow.messaging.hello.response");
+
+            String payload = msg.getPayload();
+            assertThat(payload)
+                    .as("Payload should be a String (not byte[]) containing the greeting")
+                    .isInstanceOf(String.class)
+                    .contains("\"Hello InMemory!\"");
+        });
+    }
+
+    @Test
+    @DisplayName("in_memory_payload_is_valid_json")
+    void in_memory_payload_is_valid_json() {
+        InMemorySink<String> sink = connector.sink("flow-out");
+        InMemorySource<Message<?>> source = connector.source("flow-in");
+
+        OutgoingCloudEventMetadata<?> ceMeta = OutgoingCloudEventMetadata.builder()
+                .withId(UUID.randomUUID().toString())
+                .withSource(URI.create("test:/in-memory"))
+                .withType("io.quarkiverse.flow.messaging.hello.request")
+                .withDataContentType("application/json")
+                .build();
+
+        source.send(Message.of("{\"name\":\"JsonCheck\"}".getBytes()).addMetadata(ceMeta));
+
+        await().atMost(ofSeconds(10)).untilAsserted(() -> {
+            List<? extends Message<String>> messages = sink.received();
+            assertThat(messages).isNotEmpty();
+
+            Message<String> msg = messages.stream()
+                    .filter(m -> {
+                        CloudEventMetadata<?> ce = m.getMetadata(CloudEventMetadata.class).orElse(null);
+                        return ce != null && "io.quarkiverse.flow.messaging.hello.response".equals(ce.getType());
+                    })
+                    .findFirst()
+                    .orElse(null);
+
+            assertThat(msg).isNotNull();
+
+            String payload = msg.getPayload();
+            assertThat(payload).startsWith("{").endsWith("}");
+            assertThat(payload).contains("\"Hello JsonCheck!\"");
+        });
+    }
+
+    public static class InMemoryProfile implements QuarkusTestProfile {
+
+        public InMemoryProfile() {
+        }
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "mp.messaging.incoming.flow-in.connector", "smallrye-in-memory",
+                    "mp.messaging.outgoing.flow-out.connector", "smallrye-in-memory",
+                    "mp.messaging.outgoing.flow-lifecycle-out.connector", "smallrye-in-memory");
+        }
+    }
+}

--- a/messaging/integration-tests/src/test/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlowStructuredIT.java
+++ b/messaging/integration-tests/src/test/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlowStructuredIT.java
@@ -1,0 +1,173 @@
+package io.quarkiverse.flow.messaging.it;
+
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.inject.Inject;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.provider.EventFormatProvider;
+import io.cloudevents.jackson.JsonFormat;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadata;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerTask;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests that CloudEvents work correctly in <strong>structured</strong> mode,
+ * where the entire CE envelope (attributes + data) is serialized as a single
+ * JSON value, as opposed to binary mode where attributes go in Kafka headers.
+ *
+ * @see <a href="https://github.com/quarkiverse/quarkus-flow/issues/810">Issue #810</a>
+ */
+@DisabledOnOs(OS.WINDOWS)
+@QuarkusTest
+@QuarkusTestResource(KafkaCompanionResource.class)
+@TestProfile(HelloMessagingFlowStructuredIT.StructuredCEProfile.class)
+public class HelloMessagingFlowStructuredIT {
+
+    private static final JsonFormat CE_JSON = (JsonFormat) EventFormatProvider.getInstance()
+            .resolveFormat(JsonFormat.CONTENT_TYPE);
+
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
+
+    @Inject
+    @Channel("flow-in-outgoing")
+    Emitter<String> flowIn;
+
+    @Inject
+    HelloMessagingFlow workflow;
+
+    @BeforeEach
+    void setUp() {
+        workflow.instance(java.util.Map.of()).start();
+    }
+
+    @Test
+    @DisplayName("greet_roundtrip_structured_mode_with_structured_input")
+    void greet_roundtrip_structured_input() {
+        ConsumerTask<Object, Object> out = companion
+                .consumeWithDeserializers(StringDeserializer.class, StringDeserializer.class)
+                .fromTopics("flow-out");
+
+        final CloudEvent greet = CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withSource(URI.create("test:/it-structured"))
+                .withType("io.quarkiverse.flow.messaging.hello.request")
+                .withDataContentType("application/json")
+                .withData("{\"name\":\"Structured\"}".getBytes())
+                .build();
+
+        ProducerRecord<Object, Object> structuredRecord = new ProducerRecord<>("flow-in",
+                new String(CE_JSON.serialize(greet), StandardCharsets.UTF_8));
+        structuredRecord.headers().add("content-type", "application/cloudevents+json; charset=UTF-8".getBytes());
+        companion.produceWithSerializers(StringSerializer.class, StringSerializer.class)
+                .fromRecords(structuredRecord);
+
+        String ceJson = awaitResponseJson(out, "Structured");
+        assertStructuredCeResponse(ceJson, "Structured");
+    }
+
+    @Test
+    @DisplayName("greet_roundtrip_structured_mode_with_binary_input")
+    void greet_roundtrip_binary_input() {
+        ConsumerTask<Object, Object> out = companion
+                .consumeWithDeserializers(StringDeserializer.class, StringDeserializer.class)
+                .fromTopics("flow-out");
+
+        String data = "{\"name\":\"Binary\"}";
+        OutgoingCloudEventMetadata<?> ceMeta = OutgoingCloudEventMetadata.builder()
+                .withId(UUID.randomUUID().toString())
+                .withSource(URI.create("test:/it-structured"))
+                .withType("io.quarkiverse.flow.messaging.hello.request")
+                .withDataContentType("application/json")
+                .build();
+
+        flowIn.send(Message.of(data).addMetadata(ceMeta));
+
+        String ceJson = awaitResponseJson(out, "Binary");
+        assertStructuredCeResponse(ceJson, "Binary");
+    }
+
+    private void assertStructuredCeResponse(String ceJson, String name) {
+        JsonObject envelope = new JsonObject(ceJson);
+        assertThat(envelope.getString("type"))
+                .as("CE type attribute")
+                .isEqualTo("io.quarkiverse.flow.messaging.hello.response");
+
+        Object rawData = envelope.getValue("data");
+        String dataJson = rawData instanceof String ? (String) rawData : rawData.toString();
+        assertThat(dataJson)
+                .as("CE data should contain the greeting for %s", name)
+                .contains("Hello " + name + "!");
+    }
+
+    private String awaitResponseJson(ConsumerTask<Object, Object> out, String expectedName) {
+        final String expectedType = "io.quarkiverse.flow.messaging.hello.response";
+        final String expectedGreeting = "Hello " + expectedName + "!";
+        final AtomicReference<String> responseRef = new AtomicReference<>();
+
+        await().atMost(ofSeconds(10)).untilAsserted(() -> {
+            boolean found = out.stream()
+                    .map(rec -> (String) rec.value())
+                    .filter(Objects::nonNull)
+                    .peek(json -> {
+                        if (json.contains(expectedType) && json.contains(expectedGreeting))
+                            responseRef.set(json);
+                    })
+                    .anyMatch(json -> json.contains(expectedType) && json.contains(expectedGreeting));
+            assertThat(found).as("Still waiting for structured CE with greeting: %s", expectedGreeting).isTrue();
+        });
+
+        return responseRef.get();
+    }
+
+    public static class StructuredCEProfile implements QuarkusTestProfile {
+
+        public StructuredCEProfile() {
+        }
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "mp.messaging.outgoing.flow-out.cloud-events-mode", "structured",
+                    "mp.messaging.outgoing.flow-out.value.serializer",
+                    "org.apache.kafka.common.serialization.StringSerializer",
+                    "mp.messaging.outgoing.flow-lifecycle-out.cloud-events-mode", "structured",
+                    "mp.messaging.outgoing.flow-lifecycle-out.value.serializer",
+                    "org.apache.kafka.common.serialization.StringSerializer",
+                    "mp.messaging.outgoing.flow-in-outgoing.connector", "smallrye-kafka",
+                    "mp.messaging.outgoing.flow-in-outgoing.topic", "flow-in",
+                    "mp.messaging.outgoing.flow-in-outgoing.value.serializer",
+                    "org.apache.kafka.common.serialization.StringSerializer");
+        }
+    }
+}

--- a/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/ContentBasedRouterEventsPublisher.java
+++ b/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/ContentBasedRouterEventsPublisher.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.flow.messaging;
 
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
@@ -41,7 +42,7 @@ public abstract class ContentBasedRouterEventsPublisher implements EventPublishe
             return CompletableFuture.completedFuture(null);
 
         try {
-            byte[] data = event.getData() != null ? event.getData().toBytes() : new byte[0];
+            final String data = event.getData() != null ? new String(event.getData().toBytes(), StandardCharsets.UTF_8) : null;
 
             var builder = OutgoingCloudEventMetadata.builder()
                     .withId(event.getId())
@@ -90,7 +91,7 @@ public abstract class ContentBasedRouterEventsPublisher implements EventPublishe
         // no-op;
     }
 
-    protected abstract MutinyEmitter<byte[]> outEmitter();
+    protected abstract MutinyEmitter<String> outEmitter();
 
     /**
      * Whether we should accept the event based on child's class criteria

--- a/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/FlowDomainEventsPublisher.java
+++ b/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/FlowDomainEventsPublisher.java
@@ -13,10 +13,10 @@ public class FlowDomainEventsPublisher extends ContentBasedRouterEventsPublisher
 
     @Inject
     @Channel(CHANNEL_NAME)
-    MutinyEmitter<byte[]> out;
+    MutinyEmitter<String> out;
 
     @Override
-    protected MutinyEmitter<byte[]> outEmitter() {
+    protected MutinyEmitter<String> outEmitter() {
         return out;
     }
 

--- a/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/FlowLifecycleEventsPublisher.java
+++ b/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/FlowLifecycleEventsPublisher.java
@@ -15,10 +15,10 @@ public class FlowLifecycleEventsPublisher extends ContentBasedRouterEventsPublis
 
     @Inject
     @Channel(CHANNEL_NAME)
-    MutinyEmitter<byte[]> out;
+    MutinyEmitter<String> out;
 
     @Override
-    protected MutinyEmitter<byte[]> outEmitter() {
+    protected MutinyEmitter<String> outEmitter() {
         return out;
     }
 

--- a/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/FlowMessagingConsumer.java
+++ b/messaging/runtime/src/main/java/io/quarkiverse/flow/messaging/FlowMessagingConsumer.java
@@ -23,7 +23,7 @@ import io.cloudevents.CloudEventData;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.data.BytesCloudEventData;
 import io.serverlessworkflow.impl.events.AbstractTypeConsumer;
-import io.smallrye.reactive.messaging.ce.IncomingCloudEventMetadata;
+import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
 import io.vertx.core.json.JsonObject;
 
 @ApplicationScoped
@@ -38,8 +38,8 @@ public class FlowMessagingConsumer
     ManagedExecutor executor;
 
     private static CloudEvent resolveCloudEvent(Message<?> msg) {
-        IncomingCloudEventMetadata<?> meta = (IncomingCloudEventMetadata<?>) msg
-                .getMetadata(IncomingCloudEventMetadata.class)
+        CloudEventMetadata<?> meta = (CloudEventMetadata<?>) msg
+                .getMetadata(CloudEventMetadata.class)
                 .orElseThrow(() -> new IllegalArgumentException(
                         "Message does not carry CloudEvent metadata. "
                                 + "Ensure the channel has cloud-events enabled (the default)."));
@@ -70,6 +70,9 @@ public class FlowMessagingConsumer
         }
 
         Object data = meta.getData();
+        if (data == null) {
+            data = msg.getPayload();
+        }
         if (data instanceof byte[] bytes) {
             builder.withData(bytes);
         } else if (data instanceof CloudEventData cloudEventData) {

--- a/runner/app/src/main/resources/application-messaging.properties
+++ b/runner/app/src/main/resources/application-messaging.properties
@@ -28,7 +28,7 @@ quarkus.flow.messaging.defaults-enabled=true
 mp.messaging.incoming.flow-in.connector=smallrye-kafka
 mp.messaging.incoming.flow-in.topic=flow-in
 mp.messaging.incoming.flow-in.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
-mp.messaging.incoming.flow-in.value.deserializer=org.apache.kafka.common.serialization.ByteArrayDeserializer
+mp.messaging.incoming.flow-in.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 
 # ----------------------------------------------------------------------------
 # Kafka Producer - Outgoing Workflow Execution Results
@@ -39,7 +39,7 @@ mp.messaging.incoming.flow-in.value.deserializer=org.apache.kafka.common.seriali
 mp.messaging.outgoing.flow-out.connector=smallrye-kafka
 mp.messaging.outgoing.flow-out.topic=flow-out
 mp.messaging.outgoing.flow-out.key.serializer=org.apache.kafka.common.serialization.StringSerializer
-mp.messaging.outgoing.flow-out.value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer
+mp.messaging.outgoing.flow-out.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
 # ----------------------------------------------------------------------------
 # Kafka Connection (Required at Runtime)

--- a/runner/app/src/test/java/io/quarkiverse/flow/runner/app/EmitEventWorkflowTest.java
+++ b/runner/app/src/test/java/io/quarkiverse/flow/runner/app/EmitEventWorkflowTest.java
@@ -66,21 +66,20 @@ class EmitEventWorkflowTest {
 
         // And - Verify event was emitted to flow-out channel
         await().atMost(ofSeconds(5)).untilAsserted(() -> {
-            InMemorySink<byte[]> sink = connector.sink("flow-out");
+            InMemorySink<String> sink = connector.sink("flow-out");
 
-            List<? extends Message<byte[]>> messages = sink.received();
+            List<? extends Message<String>> messages = sink.received();
             assertThat(messages)
                     .as("Events should have been emitted to flow-out channel")
                     .isNotEmpty();
 
-            Message<byte[]> msg = messages.get(0);
+            Message<String> msg = messages.get(0);
             CloudEventMetadata<?> ceMeta = msg.getMetadata(CloudEventMetadata.class).orElse(null);
             assertThat(ceMeta).as("Message should carry CloudEvent metadata").isNotNull();
             assertThat(ceMeta.getType()).isEqualTo("org.quarkiverse.flow.runner.app.response");
             assertThat(ceMeta.getSource().toString()).isEqualTo("uri://org.quarkiverse.flow.runner.app.test");
 
-            String eventData = new String(msg.getPayload());
-            assertThat(eventData).contains("Test User");
+            assertThat(msg.getPayload()).contains("Test User");
         });
     }
 


### PR DESCRIPTION
## Summary

- Change `MutinyEmitter<byte[]>` to `MutinyEmitter<String>` in `ContentBasedRouterEventsPublisher`, `FlowDomainEventsPublisher`, and `FlowLifecycleEventsPublisher` so the messaging bridge works with `StringSerializer` and `cloud-events-mode=structured`
- Update `FlowMessagingConsumer` to use `CloudEventMetadata` (parent interface) instead of `IncomingCloudEventMetadata`, and fall back to `msg.getPayload()` when `meta.getData()` is null — enables in-memory connector support
- Update all examples (`newsletter-drafter`, `resilient-task-orchestrator`) and runner configs to use `StringSerializer`/`StringDeserializer`
- Add integration tests for Kafka structured CE mode and in-memory connector
- Update `messaging.adoc` with a complete `@Incoming` consumer example using `Message<String>` + `CloudEventMetadata`
- Update migration guide to 0.15.1 reflecting `String` payload and `CloudEventMetadata` usage

## Test plan

- [ ] `messaging/integration-tests` — Kafka binary, structured, in-memory, and config override tests
- [ ] `messaging/integration-tests-amqp` — AMQP binary mode test
- [ ] `examples/newsletter-drafter` — IT passes with `StringSerializer`
- [ ] `examples/resilient-task-orchestrator` — ITs pass with `StringSerializer`
- [ ] `runner/app` — emit event test with `InMemorySink<String>`

Closes #810