### PR TITLE
feat: Enhance workflow discovery and conflict resolution from dependencies

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/DiscoveredWorkflowBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/DiscoveredWorkflowBuildItem.java
@@ -19,13 +19,14 @@ import io.serverlessworkflow.impl.WorkflowDefinitionId;
 public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
 
     private final From from;
+    private final boolean fromRootArchive;
     private String definitionResourcePath;
     private WorkflowDefinitionId workflowDefinitionId;
     private Workflow workflowFromSpec;
     private String specIdentifier;
     private String className;
 
-    private DiscoveredWorkflowBuildItem(String definitionResourcePath, Workflow workflow) {
+    private DiscoveredWorkflowBuildItem(String definitionResourcePath, Workflow workflow, boolean fromRootArchive) {
         this.definitionResourcePath = definitionResourcePath;
         this.workflowDefinitionId = WorkflowDefinitionId.of(workflow);
         this.specIdentifier = WorkflowNameUtils.yamlDescriptorIdentifier(
@@ -34,22 +35,37 @@ public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
                 workflowDefinitionId.version());
         this.workflowFromSpec = workflow;
         this.from = From.SPEC;
+        this.fromRootArchive = fromRootArchive;
     }
 
     private DiscoveredWorkflowBuildItem(String className) {
         this.className = className;
         this.from = From.SOURCE;
+        this.fromRootArchive = true;
     }
 
     /**
-     * Creates a build item for a workflow discovered from a specification file.
+     * Creates a build item for a workflow discovered from a specification file
+     * in the application's own resources (root archive).
      *
      * @param definitionResourcePath the classpath workflow definition resource path
      * @param workflow the parsed workflow model
      * @return a new {@link DiscoveredWorkflowBuildItem}
      */
     public static DiscoveredWorkflowBuildItem fromSpec(String definitionResourcePath, Workflow workflow) {
-        return new DiscoveredWorkflowBuildItem(definitionResourcePath, workflow);
+        return new DiscoveredWorkflowBuildItem(definitionResourcePath, workflow, true);
+    }
+
+    /**
+     * Creates a build item for a workflow discovered from a specification file
+     * inside a dependency JAR.
+     *
+     * @param definitionResourcePath the classpath workflow definition resource path
+     * @param workflow the parsed workflow model
+     * @return a new {@link DiscoveredWorkflowBuildItem}
+     */
+    public static DiscoveredWorkflowBuildItem fromDependencySpec(String definitionResourcePath, Workflow workflow) {
+        return new DiscoveredWorkflowBuildItem(definitionResourcePath, workflow, false);
     }
 
     /**
@@ -103,6 +119,14 @@ public final class DiscoveredWorkflowBuildItem extends MultiBuildItem {
      */
     public boolean fromSpec() {
         return From.SPEC == this.from;
+    }
+
+    /**
+     * @return {@code true} if the workflow originates from the application's root archive
+     *         (its own sources/resources), {@code false} if it was contributed by a dependency JAR
+     */
+    public boolean fromRootArchive() {
+        return fromRootArchive;
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowProcessor.java
@@ -7,6 +7,7 @@ import static io.quarkus.arc.processor.DotNames.SINGLETON;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -349,9 +350,12 @@ class FlowProcessor {
 
         // Watch workflow resource files for changes in dev mode
         // Since workflows are now loaded from classpath resources, we watch the resource paths
+        // Dependency-provided paths are a no-op for packaged JARs, but enable live reload when
+        // the dependency is a local module in a multi-module dev mode workspace
         List<String> resourcePaths = workflows.stream()
-                .filter(DiscoveredWorkflowBuildItem::fromSpec)
+                .filter(workflow -> workflow.fromSpec() || workflow.fromRootArchive())
                 .map(DiscoveredWorkflowBuildItem::definitionResourcePath)
+                .filter(Objects::nonNull)
                 .toList();
 
         for (String resourcePath : resourcePaths) {

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowResourceCollectorProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowResourceCollectorProcessor.java
@@ -2,21 +2,27 @@ package io.quarkiverse.flow.deployment;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.quarkiverse.flow.config.FlowDefinitionsConfig;
 import io.quarkiverse.flow.internal.WorkflowNameUtils;
+import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.ResolvedDependency;
 import io.serverlessworkflow.api.WorkflowReader;
 import io.serverlessworkflow.api.types.Workflow;
 
@@ -28,53 +34,67 @@ public class FlowResourceCollectorProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(FlowResourceCollectorProcessor.class);
 
     /**
+     * Marks any dependency JAR containing the configured flow directory as an application archive,
+     * so its workflow files become visible to {@link #collectWorkflowFiles}. This allows plain
+     * resources-only JARs (no Jandex index or beans.xml) to contribute workflow definitions.
+     */
+    @BuildStep
+    public void flowDirectoryArchiveMarker(
+            FlowDefinitionsConfig flowDefinitionsConfig,
+            BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> markers) {
+        if (flowDefinitionsConfig.scanDependencies()) {
+            markers.produce(new AdditionalApplicationArchiveMarkerBuildItem(
+                    flowDefinitionsConfig.dir().orElse(FlowDefinitionsConfig.DEFAULT_FLOW_DIR)));
+        }
+    }
+
+    /**
      * Collect all workflow files from application archives and produce
      * build items for each unique workflow.
      * <p>
      * Quarkus ApplicationArchivesBuildItem provides access to all application resources,
      * with test resources automatically taking precedence over main resources.
+     * When {@code quarkus.flow.definitions.scan-dependencies} is enabled (default),
+     * JARs of the application's <em>direct</em> dependencies containing the flow directory are
+     * scanned as well; transitive dependencies are ignored. The application's own workflows
+     * take precedence over dependency-provided ones with the same identifier.
      */
     @BuildStep
     public void collectWorkflowFiles(
             ApplicationArchivesBuildItem archives,
+            CurateOutcomeBuildItem curateOutcome,
             FlowDefinitionsConfig flowDefinitionsConfig,
             BuildProducer<DiscoveredWorkflowBuildItem> workflows,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResources) {
 
         final String flowResourcePath = flowDefinitionsConfig.dir().orElse(FlowDefinitionsConfig.DEFAULT_FLOW_DIR);
         Map<String, DiscoveredWorkflowBuildItem> workflowsMap = new HashMap<>();
+        Map<String, String> workflowOrigins = new HashMap<>();
 
-        // Scan only the root archive (application's own resources)
+        // Scan the root archive first (application's own resources)
         // In test mode, the root archive contains merged src/main/resources + src/test/resources
         // with test resources taking precedence
-        archives.getRootArchive().accept(tree -> tree.walk(visit -> {
-            String relativePath = visit.getRelativePath("/");
+        scanArchive(archives.getRootArchive(), true, flowResourcePath, workflowsMap, workflowOrigins);
 
-            // Only process files in the configured flow directory
-            if (relativePath.startsWith(flowResourcePath + "/") &&
-                    WorkflowNameUtils.SUPPORTED_WORKFLOW_FILE_EXTENSIONS.stream()
-                            .anyMatch(relativePath::endsWith)
-                    &&
-                    (!Files.isSymbolicLink(visit.getPath()) || flowDefinitionsConfig.followSymlinks())) {
+        // Then scan dependency archives; JARs containing the flow directory are application
+        // archives thanks to the marker produced by flowDirectoryArchiveMarker.
+        // Only direct dependencies contribute workflows: transitive ones are skipped to keep
+        // the build predictable and its cost bounded by what the application declares itself
+        if (flowDefinitionsConfig.scanDependencies()) {
+            Set<ArtifactKey> transitiveDependencies = curateOutcome.getApplicationModel().getDependencies().stream()
+                    .filter(dependency -> !dependency.isDirect())
+                    .map(ResolvedDependency::getKey)
+                    .collect(Collectors.toSet());
 
-                Path filePath = visit.getPath();
-                try {
-                    // Parse workflow to extract metadata (namespace, name, version)
-                    Workflow workflow = WorkflowReader.readWorkflow(filePath);
-
-                    // No need to read content - we'll load from classpath at runtime
-                    DiscoveredWorkflowBuildItem item = DiscoveredWorkflowBuildItem.fromSpec(
-                            relativePath,
-                            workflow);
-
-                    tryAddUniqueWorkflow(item, workflowsMap);
-                    LOG.debug("Discovered workflow: {} at {}", item.workflowDefinitionId(), relativePath);
-                } catch (IOException e) {
-                    LOG.error("Failed to parse workflow file: {}", filePath, e);
-                    throw new UncheckedIOException("Error parsing workflow file: " + filePath, e);
+            for (ApplicationArchive archive : archives.getApplicationArchives()) {
+                if (archive.getKey() != null && transitiveDependencies.contains(archive.getKey())) {
+                    LOG.debug("Skipping transitive dependency {} - only direct dependencies contribute workflows",
+                            archive.getKey().toGacString());
+                    continue;
                 }
+                scanArchive(archive, false, flowResourcePath, workflowsMap, workflowOrigins);
             }
-        }));
+        }
 
         // Produce workflow build items
         workflowsMap.values().forEach(workflows::produce);
@@ -90,16 +110,84 @@ public class FlowResourceCollectorProcessor {
         }
     }
 
-    private static void tryAddUniqueWorkflow(DiscoveredWorkflowBuildItem item,
-            Map<String, DiscoveredWorkflowBuildItem> uniqueWorkflows) {
-        DiscoveredWorkflowBuildItem existing = uniqueWorkflows.put(item.specIdentifier(), item);
-        if (existing != null) {
+    private static void scanArchive(ApplicationArchive archive, boolean rootArchive, String flowResourcePath,
+            Map<String, DiscoveredWorkflowBuildItem> workflowsMap, Map<String, String> workflowOrigins) {
+        final String archiveLabel = rootArchive ? "application"
+                : archive.getKey() != null ? archive.getKey().toGacString() : "unknown archive";
+
+        // walkIfContains short-circuits archives without the flow directory (e.g. Jandex-indexed
+        // dependencies that are application archives for other reasons) and visits only its subtree
+        archive.accept(tree -> tree.walkIfContains(flowResourcePath, visit -> {
+            String relativePath = visit.getRelativePath("/");
+
+            // Only process files in the configured flow directory
+            if (relativePath.startsWith(flowResourcePath + "/") &&
+                    WorkflowNameUtils.SUPPORTED_WORKFLOW_FILE_EXTENSIONS.stream()
+                            .anyMatch(relativePath::endsWith)) {
+
+                Path filePath = visit.getPath();
+                try {
+                    // Parse workflow to extract metadata (namespace, name, version)
+                    Workflow workflow = WorkflowReader.readWorkflow(filePath);
+
+                    // No need to read content - we'll load from classpath at runtime
+                    DiscoveredWorkflowBuildItem item = rootArchive
+                            ? DiscoveredWorkflowBuildItem.fromSpec(relativePath, workflow)
+                            : DiscoveredWorkflowBuildItem.fromDependencySpec(relativePath, workflow);
+
+                    tryAddUniqueWorkflow(item, archiveLabel, workflowsMap, workflowOrigins);
+                    LOG.debug("Discovered workflow: {} at {}", item.workflowDefinitionId(), relativePath);
+                } catch (IOException e) {
+                    LOG.error("Failed to parse workflow file: {}", filePath, e);
+                    throw new UncheckedIOException("Error parsing workflow file: " + filePath, e);
+                }
+            }
+        }));
+    }
+
+    private static void tryAddUniqueWorkflow(DiscoveredWorkflowBuildItem item, String archiveLabel,
+            Map<String, DiscoveredWorkflowBuildItem> uniqueWorkflows, Map<String, String> workflowOrigins) {
+        DiscoveredWorkflowBuildItem existing = uniqueWorkflows.get(item.specIdentifier());
+
+        if (existing == null) {
+            uniqueWorkflows.put(item.specIdentifier(), item);
+            workflowOrigins.put(item.specIdentifier(), archiveLabel);
+            return;
+        }
+
+        if (item.fromRootArchive()) {
             // Allow test resources to override main resources (Maven convention)
             // The tree walk processes resources in order, so the last one wins
+            uniqueWorkflows.put(item.specIdentifier(), item);
+            workflowOrigins.put(item.specIdentifier(), archiveLabel);
             LOG.debug("Workflow {} found in multiple locations - using {}, overriding {}",
                     item.workflowDefinitionId(),
                     item.definitionResourcePath(),
                     existing.definitionResourcePath());
+            return;
         }
+
+        if (existing.fromRootArchive()) {
+            // The application's own workflow always wins over a dependency-provided one
+            LOG.info("Workflow {}: application definition at '{}' overrides dependency-provided definition at '{}' ({})",
+                    item.workflowDefinitionId(),
+                    existing.definitionResourcePath(),
+                    item.definitionResourcePath(),
+                    archiveLabel);
+            return;
+        }
+
+        // Same workflow identifier contributed by two dependency archives: fail the build,
+        // silently picking one would depend on classpath ordering and be non-reproducible
+        throw new IllegalStateException(String.format(
+                "Duplicate workflow '%s' contributed by multiple dependencies: '%s' (%s) and '%s' (%s). " +
+                        "Workflow identifiers (namespace:name:version) must be unique across dependencies. " +
+                        "Rename one of them, or disable dependency scanning with " +
+                        "quarkus.flow.definitions.scan-dependencies=false.",
+                item.specIdentifier(),
+                existing.definitionResourcePath(),
+                workflowOrigins.get(item.specIdentifier()),
+                item.definitionResourcePath(),
+                archiveLabel));
     }
 }

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/WorkflowFromDependencyConflictTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/WorkflowFromDependencyConflictTest.java
@@ -1,0 +1,54 @@
+package io.quarkiverse.flow.deployment.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WorkflowFromDependencyConflictTest {
+
+    private static final String DEP_A_WORKFLOW = """
+            document:
+              dsl: '1.0.0'
+              namespace: library
+              name: conflicting
+              version: '1.0.0'
+            do:
+              - depATask:
+                  set:
+                    message: from-dependency-a
+            """;
+
+    private static final String DEP_B_WORKFLOW = """
+            document:
+              dsl: '1.0.0'
+              namespace: library
+              name: conflicting
+              version: '1.0.0'
+            do:
+              - depBTask:
+                  set:
+                    message: from-dependency-b
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> {
+            })
+            .withAdditionalDependency(jar -> jar
+                    .addAsResource(new StringAsset(DEP_A_WORKFLOW), "flow/dep-a.yaml"))
+            .withAdditionalDependency(jar -> jar
+                    .addAsResource(new StringAsset(DEP_B_WORKFLOW), "flow/dep-b.yaml"))
+            .assertException(t -> assertTrue(
+                    t.getMessage().contains("Duplicate workflow 'library:conflicting:1.0.0'"),
+                    () -> "Unexpected failure: " + t.getMessage()));
+
+    @Test
+    void build_fails_when_two_dependencies_provide_the_same_workflow() {
+        fail("Deployment should have failed due to duplicate workflows across dependencies");
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/WorkflowFromDependencyCustomDirTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/WorkflowFromDependencyCustomDirTest.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.flow.deployment.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+import io.serverlessworkflow.impl.WorkflowDefinition;
+import io.smallrye.common.annotation.Identifier;
+
+public class WorkflowFromDependencyCustomDirTest {
+
+    private static final String DEP_WORKFLOW = """
+            document:
+              dsl: '1.0.0'
+              namespace: library
+              name: dep-hello
+              version: '1.0.0'
+            do:
+              - depTask:
+                  set:
+                    message: from-dependency
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> {
+            })
+            .withAdditionalDependency(jar -> jar
+                    .addAsResource(new StringAsset(DEP_WORKFLOW), "workflows/dep-hello.yaml"))
+            .overrideConfigKey("quarkus.flow.definitions.dir", "workflows");
+
+    @Test
+    void dependency_workflow_is_discovered_in_custom_dir() {
+        var handle = Arc.container().instance(WorkflowDefinition.class,
+                Identifier.Literal.of("library:dep-hello:1.0.0"));
+        assertTrue(handle.isAvailable());
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/WorkflowFromDependencyDisabledTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/WorkflowFromDependencyDisabledTest.java
@@ -1,0 +1,62 @@
+package io.quarkiverse.flow.deployment.test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+import io.serverlessworkflow.impl.WorkflowDefinition;
+import io.smallrye.common.annotation.Identifier;
+
+public class WorkflowFromDependencyDisabledTest {
+
+    private static final String APP_WORKFLOW = """
+            document:
+              dsl: '1.0.0'
+              namespace: app
+              name: app-hello
+              version: '1.0.0'
+            do:
+              - appTask:
+                  set:
+                    message: from-app
+            """;
+
+    private static final String DEP_WORKFLOW = """
+            document:
+              dsl: '1.0.0'
+              namespace: library
+              name: dep-hello
+              version: '1.0.0'
+            do:
+              - depTask:
+                  set:
+                    message: from-dependency
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    .addAsResource(new StringAsset(APP_WORKFLOW), "flow/app-hello.yaml"))
+            .withAdditionalDependency(jar -> jar
+                    .addAsResource(new StringAsset(DEP_WORKFLOW), "flow/dep-hello.yaml"))
+            .overrideConfigKey("quarkus.flow.definitions.scan-dependencies", "false");
+
+    @Test
+    void application_workflow_is_still_discovered() {
+        var handle = Arc.container().instance(WorkflowDefinition.class,
+                Identifier.Literal.of("app:app-hello:1.0.0"));
+        assertTrue(handle.isAvailable());
+    }
+
+    @Test
+    void dependency_workflow_is_not_discovered() {
+        var handle = Arc.container().instance(WorkflowDefinition.class,
+                Identifier.Literal.of("library:dep-hello:1.0.0"));
+        assertFalse(handle.isAvailable());
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/WorkflowFromDependencyOverrideTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/WorkflowFromDependencyOverrideTest.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.flow.deployment.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+import io.serverlessworkflow.impl.WorkflowDefinition;
+import io.smallrye.common.annotation.Identifier;
+
+public class WorkflowFromDependencyOverrideTest {
+
+    private static final String APP_WORKFLOW = """
+            document:
+              dsl: '1.0.0'
+              namespace: default
+              name: shared
+              version: '1.0.0'
+            do:
+              - appTask:
+                  set:
+                    message: from-app
+            """;
+
+    private static final String DEP_WORKFLOW = """
+            document:
+              dsl: '1.0.0'
+              namespace: default
+              name: shared
+              version: '1.0.0'
+            do:
+              - depTask:
+                  set:
+                    message: from-dependency
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    .addAsResource(new StringAsset(APP_WORKFLOW), "flow/shared.yaml"))
+            .withAdditionalDependency(jar -> jar
+                    .addAsResource(new StringAsset(DEP_WORKFLOW), "flow/dep-shared.yaml"));
+
+    @Test
+    void application_workflow_overrides_dependency_workflow() {
+        var handle = Arc.container().instance(WorkflowDefinition.class,
+                Identifier.Literal.of("default:shared:1.0.0"));
+        assertTrue(handle.isAvailable());
+
+        // The application's definition must win: its first task is named appTask
+        var firstTask = handle.get().workflow().getDo().get(0);
+        assertEquals("appTask", firstTask.getName());
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/WorkflowFromDependencyTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/WorkflowFromDependencyTest.java
@@ -1,0 +1,60 @@
+package io.quarkiverse.flow.deployment.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+import io.serverlessworkflow.impl.WorkflowDefinition;
+import io.smallrye.common.annotation.Identifier;
+
+public class WorkflowFromDependencyTest {
+
+    private static final String APP_WORKFLOW = """
+            document:
+              dsl: '1.0.0'
+              namespace: app
+              name: app-hello
+              version: '1.0.0'
+            do:
+              - appTask:
+                  set:
+                    message: from-app
+            """;
+
+    private static final String DEP_WORKFLOW = """
+            document:
+              dsl: '1.0.0'
+              namespace: library
+              name: dep-hello
+              version: '1.0.0'
+            do:
+              - depTask:
+                  set:
+                    message: from-dependency
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    .addAsResource(new StringAsset(APP_WORKFLOW), "flow/app-hello.yaml"))
+            .withAdditionalDependency(jar -> jar
+                    .addAsResource(new StringAsset(DEP_WORKFLOW), "flow/dep-hello.yaml"));
+
+    @Test
+    void application_workflow_is_discovered() {
+        var handle = Arc.container().instance(WorkflowDefinition.class,
+                Identifier.Literal.of("app:app-hello:1.0.0"));
+        assertTrue(handle.isAvailable());
+    }
+
+    @Test
+    void dependency_workflow_is_discovered() {
+        var handle = Arc.container().instance(WorkflowDefinition.class,
+                Identifier.Literal.of("library:dep-hello:1.0.0"));
+        assertTrue(handle.isAvailable());
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowDefinitionsConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowDefinitionsConfig.java
@@ -70,6 +70,22 @@ public interface FlowDefinitionsConfig {
     Optional<String> dir();
 
     /**
+     * Whether workflow definition files should also be discovered inside the JARs of the
+     * application's <b>direct</b> dependencies.
+     * <p>
+     * When enabled, any direct dependency containing the configured definitions directory
+     * (see <code>quarkus.flow.definitions.dir</code>) contributes its workflow files at
+     * build time, exactly as if they were part of the application. Transitive dependencies
+     * are never scanned. Workflows provided by the application always override
+     * dependency-provided workflows with the same <code>namespace:name:version</code>
+     * identifier. The same identifier provided by two different dependencies fails the build.
+     * <p>
+     * Set to <code>false</code> to only discover workflows from the application's own resources.
+     */
+    @WithDefault("true")
+    boolean scanDependencies();
+
+    /**
      * Naming strategy to be used when generating {@link Identifier#value()} for {@link io.quarkiverse.flow.Flow} and
      * {@link io.serverlessworkflow.impl.WorkflowDefinition} beans generated from YAML/JSON DSL.
      * <p>

--- a/docs/modules/ROOT/pages/includes/quarkus-flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow.adoc
@@ -61,6 +61,31 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++flow+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-definitions-scan-dependencies]] [.property-path]##link:#quarkus-flow_quarkus-flow-definitions-scan-dependencies[`+++quarkus.flow.definitions.scan-dependencies+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.definitions.scan-dependencies+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether workflow definition files should also be discovered inside the JARs of the application's *direct* dependencies.
+
+When enabled, any direct dependency containing the configured definitions directory (see `quarkus.flow.definitions.dir`) contributes its workflow files at build time, exactly as if they were part of the application. Transitive dependencies are never scanned. Workflows provided by the application always override dependency-provided workflows with the same `namespace:name:version` identifier. The same identifier provided by two different dependencies fails the build.
+
+Set to `false` to only discover workflows from the application's own resources.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DEFINITIONS_SCAN_DEPENDENCIES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_DEFINITIONS_SCAN_DEPENDENCIES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-definitions-naming-strategy]] [.property-path]##link:#quarkus-flow_quarkus-flow-definitions-naming-strategy[`+++quarkus.flow.definitions.naming-strategy+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.definitions.naming-strategy+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow_quarkus.flow.adoc
@@ -61,6 +61,31 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++flow+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-definitions-scan-dependencies]] [.property-path]##link:#quarkus-flow_quarkus-flow-definitions-scan-dependencies[`+++quarkus.flow.definitions.scan-dependencies+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.definitions.scan-dependencies+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether workflow definition files should also be discovered inside the JARs of the application's *direct* dependencies.
+
+When enabled, any direct dependency containing the configured definitions directory (see `quarkus.flow.definitions.dir`) contributes its workflow files at build time, exactly as if they were part of the application. Transitive dependencies are never scanned. Workflows provided by the application always override dependency-provided workflows with the same `namespace:name:version` identifier. The same identifier provided by two different dependencies fails the build.
+
+Set to `false` to only discover workflows from the application's own resources.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DEFINITIONS_SCAN_DEPENDENCIES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_DEFINITIONS_SCAN_DEPENDENCIES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-flow_quarkus-flow-definitions-naming-strategy]] [.property-path]##link:#quarkus-flow_quarkus-flow-definitions-naming-strategy[`+++quarkus.flow.definitions.naming-strategy+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.definitions.naming-strategy+++[]

--- a/docs/modules/ROOT/pages/workflow-definitions.adoc
+++ b/docs/modules/ROOT/pages/workflow-definitions.adoc
@@ -65,6 +65,51 @@ In this case, Quarkus Flow uses `src/test/resources/flow/echo.yaml` during tests
 Only exact relative-path matches are overridden. For example, `src/test/resources/flow/echo.yaml` does *not* override `src/main/resources/flow/workflows/echo.yaml`.
 ====
 
+=== 1.1. Share workflows through dependency JARs
+
+Workflow files can also be contributed by JAR dependencies. Any *direct* dependency of the application that contains the configured definitions directory (default `flow/`) has its workflow files discovered at build time, exactly as if they were part of the application:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.acme</groupId>
+    <artifactId>workflow-library</artifactId>
+    <version>1.0.0</version>
+</dependency>
+----
+
+The library is a plain JAR — no Quarkus extension, Jandex index, or `beans.xml` required. It just needs to ship its workflow files under the same directory convention:
+
+[source]
+----
+workflow-library/
+└── src/main/resources/
+    └── flow/
+        └── a-workflow.yaml
+----
+
+Because discovery happens at build time, dependency-provided workflows get the same treatment as application workflows: build-time validation, CDI bean generation, and native image support.
+
+The following rules apply:
+
+* Only *direct* dependencies contribute workflows. Transitive dependencies are never scanned — if a workflow library is pulled in indirectly, declare it explicitly in the application to opt in to its workflows.
+* The scanned directory is determined by the *consuming application's* `quarkus.flow.definitions.dir`. Libraries should ship workflows under the default `flow/` directory unless all consumers agree on a custom one.
+* If the application defines a workflow with the same `namespace`, `name`, and `version` as a dependency-provided one, the *application definition wins* and the dependency's is ignored (a log message is emitted).
+* If two *different dependencies* provide the same `namespace`, `name`, and `version`, the build fails — rename one of them to resolve the ambiguity.
+* Files inside dependency JARs are not live-reloaded in dev mode. To pick up changes, rebuild and reinstall the library (standard multi-module dev mode workspace support applies).
+
+To restrict discovery to the application's own resources, disable dependency scanning:
+
+[source,properties]
+----
+quarkus.flow.definitions.scan-dependencies=false
+----
+
+[NOTE]
+====
+Workflows written with the Java DSL (classes extending `Flow`) inside a dependency JAR are discovered through CDI bean discovery instead. For that, the dependency must be indexed — for example by adding a `META-INF/beans.xml`, the Jandex Maven plugin, or `quarkus.index-dependency.*` entries in the application.
+====
+
 == 2. Inject the `Flow` bean
 
 During the Quarkus build, the engine parses your YAML files and generates `WorkflowDefinition` and `Flow` CDI beans for them.

--- a/examples/README.md
+++ b/examples/README.md
@@ -53,6 +53,7 @@ cd examples/<example-name>
 - [Petstore OpenAPI](petstore-openapi/README.md): The famous Petstore Demo calling HTTP services via an OpenAPI specification file descriptor.
 - [Resilient Task Orchestrator](resilient-task-orchestrator/README.md): Production-ready example demonstrating **event-driven task orchestration** with fault isolation, automatic retry, idempotent execution, and state reconciliation for safe resume after failures.
 - [Suspend Resume and Abort](suspend-resume-abort/README.md): A minimal example that illustrate suspend, resume and cancel workflow capabilities, plus durability.
+- [Workflows From JARs](workflows-from-jars/README.md): Two workflow libraries packaged as **plain JARs** consumed by an orchestrator application — build-time discovery of workflows from Maven dependencies, plus local override of a library-provided workflow.
 
 
 ## How to add new examples

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -124,6 +124,7 @@
         <module>resilient-task-orchestrator</module>
         <module>greeting-runner</module>
         <module>auth-oauth2-oidc</module>
+        <module>workflows-from-jars</module>
         <module>opentelemetry</module>
     </modules>
 

--- a/examples/workflows-from-jars/README.md
+++ b/examples/workflows-from-jars/README.md
@@ -1,0 +1,109 @@
+# Workflows From JARs
+
+This example shows how a Quarkus Flow application can consume workflow
+definitions shipped inside **plain JAR dependencies** — the "workflow library"
+pattern: each team publishes its workflows as a versioned Maven artifact, and
+an orchestrator application composes them by declaring dependencies. No copying
+of files, no `maven-dependency-plugin` unpack tricks.
+
+## Layout
+
+```
+workflows-from-jars/
+├── payments-workflows/            # Plain JAR: no Quarkus, no Jandex, no beans.xml
+│   └── src/main/resources/flow/
+│       ├── payment-authorization.yaml   # payments:authorize:1.0.0
+│       └── discount.yaml                # payments:discount:1.0.0 (5% standard policy)
+├── shipping-workflows/            # A second, independent library
+│   └── src/main/resources/flow/
+│       └── shipping-quote.yaml          # shipping:quote:1.0.0
+└── orchestrator-app/              # Quarkus app that depends on both libraries
+    ├── src/main/resources/flow/
+    │   └── discount.yaml                # Redefines payments:discount:1.0.0 (10% promo)
+    └── src/main/java/org/acme/OrderResource.java
+```
+
+The libraries only ship YAML files under the conventional `flow/` directory.
+The application declares them as regular Maven dependencies:
+
+```xml
+<dependency>
+    <groupId>org.acme</groupId>
+    <artifactId>payments-workflows</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+</dependency>
+<dependency>
+    <groupId>org.acme</groupId>
+    <artifactId>shipping-workflows</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+</dependency>
+```
+
+That is all it takes. At **build time**, Quarkus Flow scans dependency JARs
+containing the configured definitions directory (default `flow/`), validates
+the workflows, and generates the same CDI beans it would for application-owned
+files:
+
+```java
+@Inject
+@Identifier("payments:authorize")
+Flow authorizePayment;
+```
+
+## Application override
+
+`payments-workflows` ships `payments:discount:1.0.0` with a standard 5% policy.
+The orchestrator redefines the *same* workflow (same `namespace:name:version`)
+in its own `src/main/resources/flow/discount.yaml` with a promotional 10%
+policy. The application definition always wins over a dependency-provided one —
+useful for customizing a shared workflow locally without forking the library.
+The override is logged during augmentation (visible in dev mode and in builds
+with build-time logging enabled):
+
+```
+Workflow payments:discount:1.0.0: application definition at 'flow/discount.yaml'
+overrides dependency-provided definition at 'flow/discount.yaml' (org.acme:payments-workflows)
+```
+
+## Why build time matters
+
+- A malformed workflow in a library breaks `mvn package`, not production.
+- The same workflow identifier shipped by two *different* dependencies fails
+  the build instead of silently picking one by classpath order.
+- Native image and container builds work out of the box, since the files are
+  registered as classpath resources during the build.
+
+## Running
+
+```bash
+# From this directory: builds the libraries, then the app (tests included)
+mvn install
+
+# Dev mode
+cd orchestrator-app
+mvn quarkus:dev
+```
+
+Then:
+
+```bash
+curl 'localhost:8080/orders/authorize?orderId=42&amount=100'
+# {"orderId":"42","status":"AUTHORIZED","fee":2}
+
+curl 'localhost:8080/orders/shipping-quote?weightKg=10'
+# {"carrier":"FlowExpress","weightKg":10,"cost":20}
+
+curl 'localhost:8080/orders/discount?amount=100'
+# {"policy":"promotional","amount":100,"total":90}   <- the app's 10% policy, not the library's 5%
+```
+
+## Opting out
+
+To restrict discovery to the application's own resources:
+
+```properties
+quarkus.flow.definitions.scan-dependencies=false
+```
+
+See the [Define workflows from YAML files](https://docs.quarkiverse.io/quarkus-flow/dev/workflow-definitions.html)
+guide for the full set of precedence rules.

--- a/examples/workflows-from-jars/orchestrator-app/pom.xml
+++ b/examples/workflows-from-jars/orchestrator-app/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>workflows-from-jars-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>orchestrator-app</artifactId>
+    <name>Quarkus Flow :: Examples :: Workflows From JARs :: Orchestrator App</name>
+
+    <dependencies>
+        <!-- Quarkus Flow core -->
+        <dependency>
+            <groupId>io.quarkiverse.flow</groupId>
+            <artifactId>quarkus-flow</artifactId>
+            <version>${quarkus.flow.version}</version>
+        </dependency>
+
+        <!--
+          Workflow libraries: plain JARs shipping YAML workflow files under flow/.
+          Adding the dependencies is all it takes - the workflows are discovered
+          at build time and exposed as CDI beans.
+        -->
+        <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>payments-workflows</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>shipping-workflows</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- REST + JSON support -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/workflows-from-jars/orchestrator-app/src/main/java/org/acme/OrderResource.java
+++ b/examples/workflows-from-jars/orchestrator-app/src/main/java/org/acme/OrderResource.java
@@ -1,0 +1,64 @@
+package org.acme;
+
+import java.util.Map;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+
+import io.quarkiverse.flow.Flow;
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.mutiny.Uni;
+
+@Path("/orders")
+public class OrderResource {
+
+    /**
+     * Contributed by the payments-workflows JAR - not defined in this application.
+     */
+    @Inject
+    @Identifier("payments:authorize")
+    Flow authorizePayment;
+
+    /**
+     * Contributed by the shipping-workflows JAR - not defined in this application.
+     */
+    @Inject
+    @Identifier("shipping:quote")
+    Flow shippingQuote;
+
+    /**
+     * Also shipped by payments-workflows (5% standard policy), but this application
+     * redefines it in src/main/resources/flow/discount.yaml (10% promotional policy).
+     * The application definition always wins over a dependency-provided one.
+     */
+    @Inject
+    @Identifier("payments:discount")
+    Flow discount;
+
+    @GET
+    @Path("/authorize")
+    public Uni<Map<String, Object>> authorize(@QueryParam("orderId") String orderId,
+            @QueryParam("amount") double amount) {
+        return run(authorizePayment, Map.of("orderId", orderId, "amount", amount));
+    }
+
+    @GET
+    @Path("/shipping-quote")
+    public Uni<Map<String, Object>> shippingQuote(@QueryParam("weightKg") double weightKg) {
+        return run(shippingQuote, Map.of("weightKg", weightKg));
+    }
+
+    @GET
+    @Path("/discount")
+    public Uni<Map<String, Object>> applyDiscount(@QueryParam("amount") double amount) {
+        return run(discount, Map.of("amount", amount));
+    }
+
+    private static Uni<Map<String, Object>> run(Flow flow, Map<String, Object> input) {
+        return flow.startInstance(input)
+                .onItem()
+                .transform(wf -> wf.asMap().orElseThrow());
+    }
+}

--- a/examples/workflows-from-jars/orchestrator-app/src/main/resources/application.properties
+++ b/examples/workflows-from-jars/orchestrator-app/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.http.test-port=0

--- a/examples/workflows-from-jars/orchestrator-app/src/main/resources/flow/discount.yaml
+++ b/examples/workflows-from-jars/orchestrator-app/src/main/resources/flow/discount.yaml
@@ -1,0 +1,12 @@
+document:
+  dsl: '1.0.0'
+  namespace: payments
+  name: discount
+  version: '1.0.0'
+
+do:
+  - applyPromotionalDiscount:
+      set:
+        policy: promotional
+        amount: '${ .amount }'
+        total: '${ .amount - (.amount * 0.10) }'

--- a/examples/workflows-from-jars/orchestrator-app/src/test/java/org/acme/OrderWorkflowsTest.java
+++ b/examples/workflows-from-jars/orchestrator-app/src/test/java/org/acme/OrderWorkflowsTest.java
@@ -1,0 +1,53 @@
+package org.acme;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class OrderWorkflowsTest {
+
+    @Test
+    @DisplayName("test_workflow_from_payments_library_executes")
+    void test_workflow_from_payments_library_executes() {
+        given()
+                .queryParam("orderId", "42")
+                .queryParam("amount", 100)
+                .when()
+                .get("/orders/authorize")
+                .then()
+                .statusCode(200)
+                .body("status", is("AUTHORIZED"))
+                .body("orderId", is("42"));
+    }
+
+    @Test
+    @DisplayName("test_workflow_from_shipping_library_executes")
+    void test_workflow_from_shipping_library_executes() {
+        given()
+                .queryParam("weightKg", 10)
+                .when()
+                .get("/orders/shipping-quote")
+                .then()
+                .statusCode(200)
+                .body("carrier", is("FlowExpress"));
+    }
+
+    @Test
+    @DisplayName("test_application_discount_overrides_library_discount")
+    void test_application_discount_overrides_library_discount() {
+        // payments-workflows ships a "standard" policy for payments:discount:1.0.0;
+        // the application redefines it as "promotional", and the application wins
+        given()
+                .queryParam("amount", 100)
+                .when()
+                .get("/orders/discount")
+                .then()
+                .statusCode(200)
+                .body("policy", is("promotional"));
+    }
+}

--- a/examples/workflows-from-jars/payments-workflows/pom.xml
+++ b/examples/workflows-from-jars/payments-workflows/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>workflows-from-jars-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>payments-workflows</artifactId>
+    <name>Quarkus Flow :: Examples :: Workflows From JARs :: Payments Library</name>
+
+    <!-- Intentionally a plain JAR: shipping YAML files under src/main/resources/flow
+         is all it takes for consumers to discover these workflows at build time. -->
+</project>

--- a/examples/workflows-from-jars/payments-workflows/src/main/resources/flow/discount.yaml
+++ b/examples/workflows-from-jars/payments-workflows/src/main/resources/flow/discount.yaml
@@ -1,0 +1,12 @@
+document:
+  dsl: '1.0.0'
+  namespace: payments
+  name: discount
+  version: '1.0.0'
+
+do:
+  - applyStandardDiscount:
+      set:
+        policy: standard
+        amount: '${ .amount }'
+        total: '${ .amount - (.amount * 0.05) }'

--- a/examples/workflows-from-jars/payments-workflows/src/main/resources/flow/payment-authorization.yaml
+++ b/examples/workflows-from-jars/payments-workflows/src/main/resources/flow/payment-authorization.yaml
@@ -1,0 +1,12 @@
+document:
+  dsl: '1.0.0'
+  namespace: payments
+  name: authorize
+  version: '1.0.0'
+
+do:
+  - authorizePayment:
+      set:
+        orderId: '${ .orderId }'
+        status: AUTHORIZED
+        fee: '${ .amount * 0.02 }'

--- a/examples/workflows-from-jars/pom.xml
+++ b/examples/workflows-from-jars/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.acme</groupId>
+    <artifactId>workflows-from-jars-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>Quarkus Flow :: Examples :: Workflows From JARs</name>
+    <packaging>pom</packaging>
+
+    <properties>
+        <compiler-plugin.version>3.15.0</compiler-plugin.version>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.37.1</quarkus.platform.version>
+        <skipITs>true</skipITs>
+        <surefire-plugin.version>3.5.6</surefire-plugin.version>
+
+        <quarkus.flow.version>1.0.0-SNAPSHOT</quarkus.flow.version>
+    </properties>
+
+    <modules>
+        <!-- Plain JARs shipping workflow definition files under src/main/resources/flow -->
+        <module>payments-workflows</module>
+        <module>shipping-workflows</module>
+        <!-- Quarkus application consuming the libraries' workflows at build time -->
+        <module>orchestrator-app</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/examples/workflows-from-jars/shipping-workflows/pom.xml
+++ b/examples/workflows-from-jars/shipping-workflows/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>workflows-from-jars-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>shipping-workflows</artifactId>
+    <name>Quarkus Flow :: Examples :: Workflows From JARs :: Shipping Library</name>
+
+    <!-- Intentionally a plain JAR: shipping YAML files under src/main/resources/flow
+         is all it takes for consumers to discover these workflows at build time. -->
+</project>

--- a/examples/workflows-from-jars/shipping-workflows/src/main/resources/flow/shipping-quote.yaml
+++ b/examples/workflows-from-jars/shipping-workflows/src/main/resources/flow/shipping-quote.yaml
@@ -1,0 +1,12 @@
+document:
+  dsl: '1.0.0'
+  namespace: shipping
+  name: quote
+  version: '1.0.0'
+
+do:
+  - quoteShipping:
+      set:
+        carrier: FlowExpress
+        weightKg: '${ .weightKg }'
+        cost: '${ 5 + (.weightKg * 1.5) }'


### PR DESCRIPTION

## Description

Extend build-time resource discovery to scan dependency `JJARs`

-  Register the flow directory as an application archive marker.,  Produce an `AdditionalApplicationArchiveMarkerBuildItem` for the configured 

-  Scan all application archives, not just the root, Change `collectWorkflowFiles` to walk the root archive first, then every
   other application archive, applying the same extension filter
   (`.yaml`/`.yml`/`.json`) under the configured directory.

- Precedence rules (deterministic): Root archive (application, with test-over-main precedence) `always wins`
     over dependency-provided workflows with the same identifier
     (`namespace:name:version`). 

Closes: #760 

## Changes

- Added support for discovering workflow definition files from dependency `jJARs.
- Introduced configuration option `quarkus.flow.definitions.scan-dependencies` to control this behavior.
- Updated `DiscoveredWorkflowBuildItem` to track if workflows originate from the application's root archive.

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [X] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [X] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [X] Code follows the project's code conventions
- [X] Tests have been added/updated to cover the changes
- [X] Documentation has been updated (if user-facing changes)
- [X] Commit messages are clear and follow conventional commits style
- [X] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [X] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)