### PR TITLE
Rename to Open Workflow Specification

### DIFF
--- a/.bob/rules/shortcuts.md
+++ b/.bob/rules/shortcuts.md
@@ -29,7 +29,7 @@ When the user asks about project conventions, testing, or build processes, read 
 
 ## External Resources
 
-- [CNCF Serverless Workflow Spec](https://github.com/serverlessworkflow/specification)
+- [Open Workflow Spec](https://github.com/open-workflow-specification/specification)
 - [LangChain4j Agentic Workflows](https://docs.langchain4j.dev/tutorials/agents)
 - [Quarkus Extension Guide](https://quarkus.io/guides/writing-extensions)
 - [Project Documentation](https://docs.quarkiverse.io/quarkus-flow/dev/)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: Q&A / How-to (Discussions)
     url: https://github.com/quarkiverse/quarkus-flow/discussions
     about: Usage questions, examples, and troubleshooting that isn’t a bug.
-  - name: CNCF Serverless Workflow Spec
-    url: https://serverlessworkflow.io/
+  - name: Open Workflow Spec
+    url: https://open-workflow-specification.org/
     about: Reference for the underlying workflow spec and DSL.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,11 +82,11 @@ This guide helps Claude Code (and contributors using it) work effectively with t
 
 ## Project Overview
 
-**Quarkus Flow** is a lightweight workflow engine for Quarkus based on the CNCF Serverless Workflow specification. It supports classic workflows and Agentic AI orchestrations with LangChain4j integration.
+**Quarkus Flow** is a lightweight workflow engine for Quarkus based on the Open Workflow specification (CNCF sandbox project). It supports classic workflows and Agentic AI orchestrations with LangChain4j integration.
 
 - **Tech Stack**: Java 17+, Maven, Quarkus framework
 - **Architecture**: Multi-module Quarkus extension with runtime/deployment split
-- **Spec**: CNCF Serverless Workflow (https://serverlessworkflow.io/)
+- **Spec**: Open Workflow (https://open-workflow-specification.org/)
 - **Docs**: https://docs.quarkiverse.io/quarkus-flow/dev/
 
 ## Repository Structure
@@ -174,7 +174,7 @@ Each module follows Quarkus extension structure:
 - Runtime beans use standard CDI annotations (`@ApplicationScoped`, etc.)
 - Build items are the contract between build steps
 
-### Serverless Workflow DSL
+### Open Workflow DSL
 - Workflows extend `io.quarkiverse.flow.Flow`
 - Use the fluent DSL from `io.quarkiverse.flow.dsl.FlowDSL`
 - Support both Java DSL and YAML workflow definitions
@@ -268,7 +268,7 @@ When adding dependencies:
 ## Helpful Context for AI Assistance
 
 ### When asked about workflow features
-- Check CNCF Serverless Workflow spec compliance first
+- Check Open Workflow spec compliance first
 - Refer to `io.serverlessworkflow` packages for DSL
 - Examples in `examples/` show real usage patterns
 
@@ -296,7 +296,7 @@ When adding dependencies:
 
 ## External Resources
 
-- CNCF Serverless Workflow Spec: https://github.com/serverlessworkflow/specification
+- Open Workflow Spec: https://github.com/open-workflow-specification/specification
 - LangChain4j Agentic Workflows: https://docs.langchain4j.dev/tutorials/agents
 - Quarkus Extension Guide: https://quarkus.io/guides/writing-extensions
 - Project docs: https://docs.quarkiverse.io/quarkus-flow/dev/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ Why this matters:
 - **deployment/**: Build-time processors, code generation (`@BuildStep`)
 - **integration-tests/**: Integration tests for the extension
 
-### Serverless Workflow DSL
+### Open Workflow DSL
 
 - Workflows extend `io.quarkiverse.flow.Flow`
 - Use the fluent DSL: `io.quarkiverse.flow.dsl.FlowDSL`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Build with Integration Tests](https://github.com/quarkiverse/quarkus-flow/actions/workflows/build-it.yml/badge.svg?branch=main&event=push)](https://github.com/quarkiverse/quarkus-flow/actions/workflows/build-it.yml)
 [![Build](https://github.com/quarkiverse/quarkus-flow/actions/workflows/build.yml/badge.svg?branch=main&event=push)](https://github.com/quarkiverse/quarkus-flow/actions/workflows/build.yml)
 
-**Quarkus Flow** is a lightweight, low-dependency, production-grade workflow engine for Quarkus, built on the [Serverless Workflow](https://serverlessworkflow.io/) specification CNCF sandbox project.
+**Quarkus Flow** is a lightweight, low-dependency, production-grade workflow engine for Quarkus, built on the [Open Workflow](https://open-workflow-specification.org/) Specification (CNCF sandbox project).
 
 Use it to model **classic workflows** *and* **Agentic AI orchestrations**, with first-class CDI/Quarkus ergonomics.
 
@@ -149,7 +149,7 @@ Run:
 ```
 
 **Next steps:**
-- **Load YAML workflows:** See [Workflow Definitions](https://docs.quarkiverse.io/quarkus-flow/dev/workflow-definitions.html) to load [CNCF Workflow DSL](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md) files
+- **Load YAML workflows:** See [Workflow Definitions](https://docs.quarkiverse.io/quarkus-flow/dev/workflow-definitions.html) to load [Open Workflow DSL](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md) files
 - **Add persistence:** See [Persistence](https://docs.quarkiverse.io/quarkus-flow/dev/persistence.html) for MVStore, JPA, or Redis backends
 - **Add messaging:** See [Messaging](https://docs.quarkiverse.io/quarkus-flow/dev/messaging.html) for Kafka/AMQP integration
 - **Explore examples:** Check out [`examples/`](examples/) for complete sample applications

--- a/adr/2026-05-05-workflow-runner-rest-api-design.md
+++ b/adr/2026-05-05-workflow-runner-rest-api-design.md
@@ -21,7 +21,7 @@ This specification defines the design for the Quarkus Flow Runner REST API, a ne
 
 - Custom persistence layer (reuse existing Quarkus Flow persistence infrastructure)
 - WebSocket streaming (deferred to future release)
-- Custom workflow DSL (use existing CNCF Serverless Workflow spec)
+- Custom workflow DSL (use existing Open Workflow spec)
 - Kubernetes-specific features in the extension (operator handles those)
 
 ## Scope Limitations
@@ -1112,6 +1112,6 @@ runner/
 ## References
 
 - Issue: https://github.com/quarkiverse/quarkus-flow/issues/52
-- CNCF Serverless Workflow Spec: https://serverlessworkflow.io/
+- Open Workflow Specification (CNCF sandbox project): https://open-workflow-specification.org/
 - Quarkus Extension Guide: https://quarkus.io/guides/writing-extensions
 - Quarkus OIDC: https://quarkus.io/guides/security-oidc-bearer-token-authentication

--- a/adr/2026-05-15-buildtime-agentic-workflow-generation.md
+++ b/adr/2026-05-15-buildtime-agentic-workflow-generation.md
@@ -542,7 +542,7 @@ Quarkus deployment processors cannot field-inject build-time config. It must be 
 
 ## References
 
-- CNCF Serverless Workflow Specification: https://serverlessworkflow.io/
+- Open Workflow Specification (CNCF sandbox project): https://open-workflow-specification.org/
 - LangChain4j Agentic API: https://docs.langchain4j.dev/tutorials/agents
 - Quarkus Extension Development: https://quarkus.io/guides/writing-extensions
 - Quarkus Gizmo: https://github.com/quarkusio/gizmo

--- a/adr/2026-06-03-token-propagation-exchange-design.md
+++ b/adr/2026-06-03-token-propagation-exchange-design.md
@@ -17,7 +17,7 @@ This feature addresses:
 ### Key Requirements
 
 1. Support both **token propagation** (forward original token) and **token exchange** (swap for service-specific token)
-2. Work with **Serverless Workflow 1.0.0 specification** OAuth2 definitions
+2. Work with **Open Workflow 1.0.0 specification** OAuth2 definitions
 3. Integrate seamlessly with **OpenAPI** task calls
 4. Support **multiple OIDC servers** (named OIDC clients per auth scheme)
 5. Implement **token caching** with proper lifecycle management
@@ -38,7 +38,7 @@ User → [App Security: Is user allowed?] → Workflow Engine → [Task Auth: Ho
 
 ## Decision
 
-Implement a **hybrid approach** using Serverless Workflow 1.0.0 OAuth2 definitions with Quarkus-specific authentication provider layer and smart defaults.
+Implement a **hybrid approach** using Open Workflow 1.0.0 OAuth2 definitions with Quarkus-specific authentication provider layer and smart defaults.
 
 ### Phased Implementation
 
@@ -123,13 +123,13 @@ No architectural blocker was found, the gaps are *additive* not redesigns.
   sufficient for Phase 0/Phase 1 as long as the executor service provides worker threads. **Long-term**,
   both SPIs should offer async/reactive variants (returning `Uni`/`CompletableFuture`) to be
   safe regardless of the calling thread — tracked upstream as
-  [sdk-java#1510](https://github.com/serverlessworkflow/sdk-java/issues/1510).
+  [sdk-java#1510](https://github.com/open-workflow-specification/sdk-java/issues/1510).
 - **Risk 2 — OpenAPI `securityScheme` → credential mapping is manual** (see Q3). "Secure-by-spec"
   ergonomics must be built on top.
 - **Risk 3 — token exchange and password grants validated.** Removes the biggest unknown.
 - **Risk 4 — `use.authentications(...)` DSL is verbose** (five nested lambdas + fully-qualified enums for
   one client). DX gap, not a correctness blocker; Phase 1 should offer a flatter shorthand. Tracked
-  upstream as [sdk-java#1509](https://github.com/serverlessworkflow/sdk-java/issues/1509).
+  upstream as [sdk-java#1509](https://github.com/open-workflow-specification/sdk-java/issues/1509).
 - **Risk 5 — sdk-java thread context propagation is not guaranteed (open upstream issue).** Quarkus
   Flow injects a `QuarkusManagedExecutor` as the SDK's `ExecutorService` so that task execution runs on
   managed threads with CDI request context and thread-locals propagated. In practice **not all SDK
@@ -141,9 +141,9 @@ No architectural blocker was found, the gaps are *additive* not redesigns.
   Quarkus Flow bug. **Mitigation until fixed:** prefer subject-token sources that do not depend on
   thread context (explicit workflow input over `SecurityIdentity`), and resolve/cache tokens off the
   affected threads. Tracked upstream as
-  [sdk-java#1481](https://github.com/serverlessworkflow/sdk-java/issues/1481).
+  [sdk-java#1481](https://github.com/open-workflow-specification/sdk-java/issues/1481).
 - **Risk 6 — no hook to override the SDK's authentication call (RESOLVED upstream by
-  [sdk-java#1486](https://github.com/serverlessworkflow/sdk-java/issues/1486)).** Originally the SDK's
+  [sdk-java#1486](https://github.com/open-workflow-specification/sdk-java/issues/1486)).** Originally the SDK's
   `AuthProviderFactory` was a static utility with no plug-in seam, so an extension could not intercept
   or replace how authentications are resolved/executed. PR #1486 introduced a **pluggable
   `AuthProviderFactory`** (plus
@@ -157,7 +157,7 @@ No architectural blocker was found, the gaps are *additive* not redesigns.
 
 The findings above revise the following sections of this ADR (revisions marked inline):
 - **§1 OpenAPI Integration** — **will not be applied**; the spec discussion in
-  [specification#1158](https://github.com/serverlessworkflow/specification/issues/1158) supersedes
+  [specification#1158](https://github.com/open-workflow-specification/specification/issues/1158) supersedes
   this revision. The OpenAPI `securityScheme` → credential auto-mapping (Risk 3) and the
   `ServiceLoader`/sync-bound decorator concerns (Risk 1, Risk 2) are no longer relevant to
   Quarkus Flow's design.
@@ -168,20 +168,20 @@ The findings above revise the following sections of this ADR (revisions marked i
 ### Upstream SDK change requests raised
 
 Async/reactive variants for both `HttpRequestDecorator.decorate` and `AuthProvider.content` (Risk 1)
-— [sdk-java#1510](https://github.com/serverlessworkflow/sdk-java/issues/1510); flatter shorthand
+— [sdk-java#1510](https://github.com/open-workflow-specification/sdk-java/issues/1510); flatter shorthand
 for named authentications (Risk 4) —
-[sdk-java#1509](https://github.com/serverlessworkflow/sdk-java/issues/1509).
+[sdk-java#1509](https://github.com/open-workflow-specification/sdk-java/issues/1509).
 
 Optional OpenAPI `securityScheme`→`Authentication` mapping (Risk 3) —
-[specification#1158](https://github.com/serverlessworkflow/specification/issues/1158), **rejected**
+[specification#1158](https://github.com/open-workflow-specification/specification/issues/1158), **rejected**
 by spec maintainers.
 
 Pluggable `AuthProviderFactory` so an extension can own authentication — **delivered** by
-[sdk-java#1486](https://github.com/serverlessworkflow/sdk-java/issues/1486) (in 7.24.0.Final);
+[sdk-java#1486](https://github.com/open-workflow-specification/sdk-java/issues/1486) (in 7.24.0.Final);
 see Risk 6.
 
 Reliable thread-context propagation so SDK task stages run on the injected `QuarkusManagedExecutor`
-(Risk 5) — [sdk-java#1481](https://github.com/serverlessworkflow/sdk-java/issues/1481), **open**.
+(Risk 5) — [sdk-java#1481](https://github.com/open-workflow-specification/sdk-java/issues/1481), **open**.
 
 ### Shipped implementation note (2026-06-30)
 
@@ -248,14 +248,14 @@ User → [Quarkus Security] → Workflow Engine
 > (see [Shipped implementation note](#shipped-implementation-note-2026-06-30)), not the
 > `HttpRequestDecorator` design below. Additionally, the OpenAPI `securityScheme` → credential
 > auto-mapping discussion is tracked in
-> [specification#1158](https://github.com/serverlessworkflow/specification/issues/1158) and will
+> [specification#1158](https://github.com/open-workflow-specification/specification/issues/1158) and will
 > not be pursued in Quarkus Flow.
 >
 > The original design is kept below for historical context only.
 
 **Integration Point**: SDK's `HttpRequestDecorator` (ServiceLoader)
 
-The Serverless Workflow SDK's `HttpExecutor` loads `HttpRequestDecorator` implementations via ServiceLoader, allowing us to intercept HTTP requests before execution.
+The Open Workflow SDK's `HttpExecutor` loads `HttpRequestDecorator` implementations via ServiceLoader, allowing us to intercept HTTP requests before execution.
 
 **Authentication Resolution Flow**:
 ```
@@ -1636,7 +1636,7 @@ quarkus.openapi-generator.<service>.auth.<name>.token-propagation
 ## References
 
 - [SonataFlow Token Exchange Documentation](https://sonataflow.org/serverlessworkflow/main/security/token-exchange-for-openapi-services.html)
-- [Serverless Workflow 1.0.0 Specification](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md)
+- [Open Workflow 1.0.0 Specification](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md)
 - [OAuth 2.0 Token Exchange (RFC 8693)](https://datatracker.ietf.org/doc/html/rfc8693)
 - [Quarkus OIDC Client Guide](https://quarkus.io/guides/security-openid-connect-client)
 - [Quarkus Flow HttpClientProvider](core/runtime/src/main/java/io/quarkiverse/flow/providers/HttpClientProvider.java)

--- a/adr/2026-07-06-oidc-client-delegation.md
+++ b/adr/2026-07-06-oidc-client-delegation.md
@@ -49,7 +49,7 @@ quarkus.flow.oidc.client."acme\:orders\:1.0.0.task.payment".name=ordersV1Auth
    - Clients created by `quarkus-oidc-client` extension at startup
 
 2. **Startup** (Java DSL workflows):
-   - Serverless Workflow SDK calls `AuthProviderFactory.getAuth()` once per workflow
+   - Open Workflow SDK calls `AuthProviderFactory.getAuth()` once per workflow
    - `OidcAuthProviderFactory` registers static OIDC clients eagerly
    - Clients stored in `OidcClientRegistry` for runtime lookup
 
@@ -77,7 +77,7 @@ quarkus.flow.oidc.client."acme\:orders\:1.0.0.task.payment".name=ordersV1Auth
 **OAuth2 vs OIDC Token Paths:**
 - OIDC (`FuncDSL.oidc()`) → discovery enabled, NO explicit tokenPath
 - OAuth2 (`FuncDSL.oauth2()`) → discovery disabled, explicit tokenPath required
-- Default tokenPath: `/oauth2/token` per CNCF Serverless Workflow spec
+- Default tokenPath: `/oauth2/token` per Open Workflow spec
 
 ## Design Philosophy: Authentication Reuse
 
@@ -124,7 +124,7 @@ workflow("orders")
 **Our responsibility**: Provide predictable client creation tools  
 **User's responsibility**: Choose the right pattern (inline vs named) for their reuse needs
 
-**Key insight**: This is a **1:1 mapping with the Serverless Workflow DSL**. The specification already provides the reuse primitive (`use`). We simply honor it:
+**Key insight**: This is a **1:1 mapping with the Open Workflow DSL**. The specification already provides the reuse primitive (`use`). We simply honor it:
 - Inline auth in DSL → isolated OIDC client in runtime
 - Named policy in DSL → shared OIDC client in runtime
 
@@ -139,10 +139,10 @@ No hidden optimization, no magic deduplication - just pure DSL semantics. Users 
 
 **File:** `oidc/runtime/src/main/java/io/quarkiverse/flow/oidc/impl/OidcAuthProviderFactory.java`
 
-**Lifecycle:** Called by Serverless Workflow SDK **once at application startup** per workflow, not per HTTP request.
+**Lifecycle:** Called by Open Workflow SDK **once at application startup** per workflow, not per HTTP request.
 
 **Responsibilities:**
-- Implements `AuthProviderFactory` interface from Serverless Workflow SDK
+- Implements `AuthProviderFactory` interface from Open Workflow SDK
 - Called when SDK needs an auth provider for OAuth2/OIDC authentication
 - Triggers static OIDC client registration via `OidcClientWorkflowRegistrar`
 - Returns `OidcClientAuthProvider` instance to SDK (SDK caches it)
@@ -622,7 +622,7 @@ HTTP Request Time (workflow executes):
 
 ### Background
 
-The Serverless Workflow spec defines `OAuth2AuthenticationPolicyConfiguration` as a union type:
+The Open Workflow spec defines `OAuth2AuthenticationPolicyConfiguration` as a union type:
 
 ```
 OAuth2AuthenticationPolicyConfiguration:
@@ -678,4 +678,4 @@ To support secret-based OAuth2:
 
 ### Related Spec Reference
 
-[Serverless Workflow DSL Reference - OAuth2 Authentication](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md)
+[Open Workflow DSL Reference - OAuth2 Authentication](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md)

--- a/adr/2026-07-07-unified-client-naming-pattern.md
+++ b/adr/2026-07-07-unified-client-naming-pattern.md
@@ -273,7 +273,7 @@ workflow("orders")
 
 **Trade-off:** Inline auth = isolated (one-off), Named policies = shared (common auth)
 
-**1:1 DSL mapping:** This follows the Serverless Workflow specification exactly - the spec provides the reuse primitive (`use`), we honor it. No framework magic.
+**1:1 DSL mapping:** This follows the Open Workflow specification exactly - the spec provides the reuse primitive (`use`), we honor it. No framework magic.
 
 ## Documentation Updates
 

--- a/adr/2026-07-20-experimental-dsl-migration-assessment.md
+++ b/adr/2026-07-20-experimental-dsl-migration-assessment.md
@@ -8,7 +8,7 @@
 
 ## Context
 
-The Serverless Workflow SDK Java contains an `experimental/` module that provides a Java-native functional DSL for defining workflows using lambdas, functions, and predicates. This code is tightly coupled to Quarkus Flow (it's the primary user-facing API) and has no consumers within the SDK itself. Moving it to Quarkus Flow under a `dsl` namespace gives it a proper home, clearer ownership, and allows independent evolution.
+The Open Workflow SDK Java contains an `experimental/` module that provides a Java-native functional DSL for defining workflows using lambdas, functions, and predicates. This code is tightly coupled to Quarkus Flow (it's the primary user-facing API) and has no consumers within the SDK itself. Moving it to Quarkus Flow under a `dsl` namespace gives it a proper home, clearer ownership, and allows independent evolution.
 
 This is a **pure move** — no functional changes, fixes, or additions in this phase.
 

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowDevUIProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowDevUIProcessor.java
@@ -28,8 +28,8 @@ public class FlowDevUIProcessor {
                 .dynamicLabelJsonRPCMethodName(
                         "getNumbersOfWorkflows")
                 .icon("font-awesome-solid:diagram-project"));
-        cardPage.addLibraryVersion("io.serverlessworkflow", "serverlessworkflow-impl-core", "CNCF Workflow SDK",
-                "https://serverlessworkflow.io/");
+        cardPage.addLibraryVersion("io.serverlessworkflow", "serverlessworkflow-impl-core", "Open Workflow SDK",
+                "https://open-workflow-specification.org/");
         cardPage.addLibraryVersion("io.cloudevents", "cloudevents-json-jackson", "CloudEvents SDK",
                 "https://cloudevents.github.io/sdk-java/");
         cardPage.addLibraryVersion("net.thisptr", "jackson-jq", "Jackson JQ", "https://github.com/eiiches/jackson-jq");

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/WorkflowNamingConverter.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/WorkflowNamingConverter.java
@@ -10,7 +10,7 @@ public interface WorkflowNamingConverter {
      * Converts a <code>document.namespace</code> from Workflow specification to a Java package name.
      * <p>
      * This method assumes that the provided namespace is valid according to the
-     * <a href="https://github.com/serverlessworkflow/specification/blob/main/schema/workflow.yaml">CNCF Specification</a>.
+     * <a href="https://github.com/open-workflow-specification/specification/blob/main/schema/workflow.yaml">CNCF Specification</a>.
      *
      * @param namespace the CNCF <code>document.namespace</code> to convert
      * @return the corresponding Java package name
@@ -24,7 +24,7 @@ public interface WorkflowNamingConverter {
      * Converts a <code>document.name</code> from a Workflow Specification to a Java class name.
      * <p>
      * This method assumes that the provided name is valid according to the
-     * <a href="https://github.com/serverlessworkflow/specification/blob/main/schema/workflow.yaml">CNCF Specification</a>.
+     * <a href="https://github.com/open-workflow-specification/specification/blob/main/schema/workflow.yaml">CNCF Specification</a>.
      * <p>
      * Example:
      * <code>

--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/WorkflowNamingConverter.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/WorkflowNamingConverter.java
@@ -10,7 +10,8 @@ public interface WorkflowNamingConverter {
      * Converts a <code>document.namespace</code> from Workflow specification to a Java package name.
      * <p>
      * This method assumes that the provided namespace is valid according to the
-     * <a href="https://github.com/open-workflow-specification/specification/blob/main/schema/workflow.yaml">CNCF Specification</a>.
+     * <a href="https://github.com/open-workflow-specification/specification/blob/main/schema/workflow.yaml">CNCF
+     * Specification</a>.
      *
      * @param namespace the CNCF <code>document.namespace</code> to convert
      * @return the corresponding Java package name
@@ -24,7 +25,8 @@ public interface WorkflowNamingConverter {
      * Converts a <code>document.name</code> from a Workflow Specification to a Java class name.
      * <p>
      * This method assumes that the provided name is valid according to the
-     * <a href="https://github.com/open-workflow-specification/specification/blob/main/schema/workflow.yaml">CNCF Specification</a>.
+     * <a href="https://github.com/open-workflow-specification/specification/blob/main/schema/workflow.yaml">CNCF
+     * Specification</a>.
      * <p>
      * Example:
      * <code>

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/secrets/SecretMissingResolutionTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/secrets/SecretMissingResolutionTest.java
@@ -47,7 +47,7 @@ public class SecretMissingResolutionTest {
         });
 
         var msg = String.valueOf(ex.getMessage()).toLowerCase();
-        assertTrue(msg.contains("https://serverlessworkflow.io/spec/1.0.0/errors/authorization,"),
+        assertTrue(msg.contains("https://open-workflow-specification.org/spec/1.0.0/errors/authorization,"),
                 "Expected error message to mention secret resolution");
     }
 

--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/secrets/SecretMissingResolutionTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/secrets/SecretMissingResolutionTest.java
@@ -47,7 +47,7 @@ public class SecretMissingResolutionTest {
         });
 
         var msg = String.valueOf(ex.getMessage()).toLowerCase();
-        assertTrue(msg.contains("https://open-workflow-specification.org/spec/1.0.0/errors/authorization,"),
+        assertTrue(msg.contains("https://serverlessworkflow.io/spec/1.0.0/errors/authorization,"),
                 "Expected error message to mention secret resolution");
     }
 

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/HelloResourceTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/HelloResourceTest.java
@@ -49,7 +49,7 @@ public class HelloResourceTest {
                 .then()
                 .statusCode(503)
                 .contentType(ContentType.JSON)
-                .body("type", containsString("https://serverlessworkflow.io/spec/1.0.0/errors/communication"));
+                .body("type", containsString("https://open-workflow-specification.org/spec/1.0.0/errors/communication"));
     }
 
     private static void shouldExecuteGetRequestForEchoName(String path) {

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/HelloResourceTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/HelloResourceTest.java
@@ -49,7 +49,7 @@ public class HelloResourceTest {
                 .then()
                 .statusCode(503)
                 .contentType(ContentType.JSON)
-                .body("type", containsString("https://open-workflow-specification.org/spec/1.0.0/errors/communication"));
+                .body("type", containsString("https://serverlessworkflow.io/spec/1.0.0/errors/communication"));
     }
 
     private static void shouldExecuteGetRequestForEchoName(String path) {

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingWithQuarkusLoggingJsonTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/StructuredLoggingWithQuarkusLoggingJsonTest.java
@@ -99,11 +99,11 @@ public class StructuredLoggingWithQuarkusLoggingJsonTest {
                             line)
                     .isTrue();
 
-            // Should be a Serverless Workflow CloudEvent type
+            // Should be an Open Workflow CloudEvent type
             String eventType = event.get("eventType").asText();
             assertThat(eventType)
                     .withFailMessage(
-                            "Event type should be a Serverless Workflow CloudEvent type (io.serverlessworkflow.*). Found: %s",
+                            "Event type should be an Open Workflow CloudEvent type (io.serverlessworkflow.*). Found: %s",
                             eventType)
                     .startsWith("io.serverlessworkflow.");
 

--- a/core/runtime/src/main/java/io/quarkiverse/flow/Flow.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/Flow.java
@@ -13,9 +13,9 @@ import io.smallrye.common.annotation.Identifier;
 import io.smallrye.mutiny.Uni;
 
 /**
- * Base class for defining CNCF Serverless Workflows in Quarkus Flow.
+ * Base class for defining Open Workflow (CNCF sandbox project) definitions in Quarkus Flow.
  * <p>
- * Extend this class to create workflow definitions using the Java DSL from the CNCF Serverless Workflow SDK. Your workflow
+ * Extend this class to create workflow definitions using the Java DSL from the Open Workflow SDK. Your workflow
  * class must be a CDI bean (typically {@code @ApplicationScoped}) and implement the {@link #descriptor()} method to define
  * the workflow structure.
  * <p>
@@ -81,7 +81,7 @@ import io.smallrye.mutiny.Uni;
  * @see Flowable
  * @see WorkflowDefinition
  * @see WorkflowInstance
- * @see <a href="https://serverlessworkflow.io/">CNCF Serverless Workflow Specification</a>
+ * @see <a href="https://open-workflow-specification.org/">Open Workflow Specification (CNCF sandbox project)</a>
  */
 public abstract class Flow implements Flowable {
 
@@ -95,10 +95,10 @@ public abstract class Flow implements Flowable {
     }
 
     /**
-     * Defines the workflow structure using the CNCF Serverless Workflow Java DSL.
+     * Defines the workflow structure using the Open Workflow Java DSL.
      * <p>
      * This is the core method you must implement when extending {@link Flow}. It defines your workflow's tasks, data flow,
-     * error handling, and execution logic using the fluent DSL provided by the CNCF Serverless Workflow SDK.
+     * error handling, and execution logic using the fluent DSL provided by the Open Workflow SDK.
      * <p>
      * The descriptor is evaluated once at build time. Quarkus Flow processes it to create an optimized
      * {@link WorkflowDefinition} that can be used to execute workflow instances at runtime.

--- a/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowSecretsConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowSecretsConfig.java
@@ -23,7 +23,8 @@ public interface FlowSecretsConfig {
      * @see <a href="https://quarkus.io/guides/credentials-provider>Using a Credentials Provider</a>
      * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl.md#secret">Open Workflow
      *      Specification - Secrets</a>
-     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#authentication">Open
+     * @see <a href=
+     *      "https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#authentication">Open
      *      Workflow Specification - Authentication</a>
      */
     Optional<String> credentialsProviderName();

--- a/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowSecretsConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/config/FlowSecretsConfig.java
@@ -21,9 +21,9 @@ public interface FlowSecretsConfig {
      * This means that every {@link io.serverlessworkflow.impl.WorkflowDefinition} will use the same credential provider.
      *
      * @see <a href="https://quarkus.io/guides/credentials-provider>Using a Credentials Provider</a>
-     * @see <a href="https://github.com/serverlessworkflow/specification/blob/main/dsl.md#secret">CNCF Workflow Specification -
-     *      Secrets</a>
-     * @see <a href="https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#authentication">CNCF
+     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl.md#secret">Open Workflow
+     *      Specification - Secrets</a>
+     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#authentication">Open
      *      Workflow Specification - Authentication</a>
      */
     Optional<String> credentialsProviderName();

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FuncEventFilterSpec.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FuncEventFilterSpec.java
@@ -19,7 +19,7 @@ import io.serverlessworkflow.impl.WorkflowContextData;
 import io.serverlessworkflow.impl.jackson.JsonUtils;
 
 /**
- * Fluent DSL specification builder for configuring CloudEvent filters within a Serverless Workflow
+ * Fluent DSL specification builder for configuring CloudEvent filters within an Open Workflow
  * execution.
  */
 public final class FuncEventFilterSpec

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FuncListenSpec.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FuncListenSpec.java
@@ -11,7 +11,7 @@ import io.serverlessworkflow.api.types.ListenTaskConfiguration;
  * {@link #envelope()} to control how the CloudEvent collection is unwrapped.
  *
  * <p>
- * By design, the Serverless Workflow specification always delivers events as a collection,
+ * By design, the Open Workflow specification always delivers events as a collection,
  * even when only one event is expected (via {@code toOne()}). Call {@link #first()} to
  * explicitly extract the first element from that collection so downstream tasks receive
  * a single object rather than a single-element array.

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FuncScheduleEventSpec.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FuncScheduleEventSpec.java
@@ -12,7 +12,7 @@ import io.serverlessworkflow.fluent.spec.dsl.DSL;
  * collection is unwrapped before the first task receives it.
  *
  * <p>
- * By design, the Serverless Workflow specification always delivers consumed events as a
+ * By design, the Open Workflow specification always delivers consumed events as a
  * collection — even when only one event is expected (via {@code one()}). Call
  * {@link #first()} to explicitly extract the first element from that collection so
  * downstream tasks receive a single object rather than a single-element array.

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/Step.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/Step.java
@@ -61,7 +61,7 @@ abstract class Step<SELF extends Step<SELF, B>, B> implements FuncTaskConfigurer
      * @param taskName the name of the next task to execute
      * @return this step for further chaining
      * @see <a
-     *      href="https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#task">DSL
+     *      href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#task">DSL
      *      Reference - Task</a>
      */
     public SELF then(String taskName) {
@@ -76,7 +76,7 @@ abstract class Step<SELF extends Step<SELF, B>, B> implements FuncTaskConfigurer
      * @param directive the flow directive (e.g., {@link FlowDirectiveEnum#END})
      * @return this step for further chaining
      * @see <a
-     *      href="https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#task">DSL
+     *      href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#task">DSL
      *      Reference - Task</a>
      */
     public SELF then(FlowDirectiveEnum directive) {

--- a/core/runtime/src/main/java/io/quarkiverse/flow/structuredlogging/EventFormatter.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/structuredlogging/EventFormatter.java
@@ -72,7 +72,7 @@ public class EventFormatter {
     private static final String FIELD_LAST_UPDATE_TIME = "lastUpdateTime";
     private static final String FIELD_INPUT = "input";
     private static final String FIELD_OUTPUT = "output";
-    // See https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#properties-53
+    // See https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#properties-53
     private static final String FIELD_ERROR = "error";
     private static final String FIELD_WORKFLOW_NAMESPACE = "workflowNamespace";
     private static final String FIELD_WORKFLOW_NAME = "workflowName";
@@ -250,7 +250,7 @@ public class EventFormatter {
 
     private Map<String, Object> baseWorkflowEvent(String filterKey, WorkflowEvent event) {
         Map<String, Object> json = new HashMap<>();
-        // Use official CloudEvent type from SW specification
+        // Use official CloudEvent type from Open Workflow specification
         json.put(FIELD_EVENT_TYPE, StructuredLoggingEventTypes.toCloudEventType(filterKey));
         json.put(FIELD_TIMESTAMP, formatTimestamp(event.eventDate()));
         json.put(FIELD_INSTANCE_ID, event.workflowContext().instanceData().id());

--- a/core/runtime/src/main/java/io/quarkiverse/flow/structuredlogging/StructuredLoggingEventTypes.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/structuredlogging/StructuredLoggingEventTypes.java
@@ -11,15 +11,15 @@ import io.serverlessworkflow.impl.LifecycleEvents;
  * <ul>
  * <li><b>Configuration filtering keys</b>: Simplified, user-friendly event type names for
  * configuring which events to log (e.g., {@code workflow.instance.started})
- * <li><b>CloudEvent type mapping</b>: Maps filter keys to official Serverless Workflow
+ * <li><b>CloudEvent type mapping</b>: Maps filter keys to official Open Workflow
  * specification CloudEvent types (e.g., {@code io.serverlessworkflow.workflow.started.v1})
  * </ul>
  * <p>
- * The official CloudEvent types are defined in the Serverless Workflow SDK:
+ * The official CloudEvent types are defined in the Open Workflow SDK:
  * {@code io.serverlessworkflow.impl.lifecycle.ce.AbstractLifeCyclePublisher}
  * <p>
  * <b>Note:</b> The CloudEvent type constants are temporarily copied here because they are
- * private in the SDK. See: https://github.com/serverlessworkflow/sdk-java/issues/1314
+ * private in the SDK. See: https://github.com/open-workflow-specification/sdk-java/issues/1314
  * Once made public in the SDK, we should reference them directly instead.
  */
 final class StructuredLoggingEventTypes {
@@ -52,11 +52,11 @@ final class StructuredLoggingEventTypes {
     static final String WORKFLOW_TASK_RETRIED = "workflow.task.retried";
 
     // ========================================
-    // Official Serverless Workflow CloudEvent Types
+    // Official Open Workflow CloudEvent Types
     // ========================================
-    // These are the official CloudEvent types from the SW specification
+    // These are the official CloudEvent types from the OWS specification
     // Source: io.serverlessworkflow.impl.lifecycle.ce.AbstractLifeCyclePublisher
-    // TODO: Replace with direct references once https://github.com/serverlessworkflow/sdk-java/issues/1314 is resolved
+    // TODO: Replace with direct references once https://github.com/open-workflow-specification/sdk-java/issues/1314 is resolved
 
     // ========================================
     // Filter Key → CloudEvent Type Mapping
@@ -82,7 +82,7 @@ final class StructuredLoggingEventTypes {
             Map.entry(WORKFLOW_TASK_RETRIED, LifecycleEvents.TASK_RETRIED));
 
     /**
-     * Maps a filter key (simplified event type) to the official Serverless Workflow CloudEvent type.
+     * Maps a filter key (simplified event type) to the official Open Workflow CloudEvent type.
      *
      * @param filterKey the simplified event type used for filtering (e.g., "workflow.instance.started")
      * @return the official CloudEvent type (e.g., "io.serverlessworkflow.workflow.started.v1")

--- a/core/runtime/src/main/java/io/quarkiverse/flow/tracing/TraceLoggerExecutionListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/tracing/TraceLoggerExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-Present The Serverless Workflow Specification Authors
+ * Copyright 2020-Present The Open Workflow Specification Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/modules/ROOT/pages/concepts-agentic-langchain4j.adoc
+++ b/docs/modules/ROOT/pages/concepts-agentic-langchain4j.adoc
@@ -17,7 +17,7 @@ For practical instructions on building these workflows, see xref:langchain4j.ado
 
 When you add the `quarkus-flow-langchain4j` extension to your project, Quarkus Flow acts as an Ahead-of-Time (AoT) compiler for your AI patterns.
 
-It does not run a separate "AI Engine" at runtime. Instead, during the Quarkus build phase, it translates LangChain4j semantics directly into the CNCF Serverless Workflow vocabulary.
+It does not run a separate "AI Engine" at runtime. Instead, during the Quarkus build phase, it translates LangChain4j semantics directly into the Open Workflow vocabulary.
 
 === The Compilation Process
 1. **Scanning:** The extension scans your interfaces for methods annotated with Agentic routing annotations (like `@SequenceAgent` or `@ParallelAgent`).
@@ -58,7 +58,7 @@ Each builder method (`newSequential()`, `newParallel()`, `newLoop()`, `newCondit
 3. **Creates a fresh WorkflowApplication** instance with isolated workflow definition cache
 4. **Returns a proxy UntypedAgent** that delegates to the generated workflow
 
-This approach mirrors LangChain4j's own runtime builder API while generating standard CNCF Serverless Workflow definitions under the hood.
+This approach mirrors LangChain4j's own runtime builder API while generating standard Open Workflow definitions under the hood.
 
 === Isolation and State Management
 

--- a/docs/modules/ROOT/pages/concepts-architecture.adoc
+++ b/docs/modules/ROOT/pages/concepts-architecture.adoc
@@ -1,7 +1,7 @@
 = Concepts & architecture
 :page-role: explanation
 
-This page explains the core concepts behind Quarkus Flow, its internal architecture, and how it maps to the CNCF Serverless Workflow Specification.
+This page explains the core concepts behind Quarkus Flow, its internal architecture, and how it maps to the Open Workflow Specification (CNCF sandbox project).
 
 == The Build-Time Engine Paradigm
 
@@ -15,7 +15,7 @@ Because the workflow definition is already compiled and injected, the runtime en
 
 == Specification Alignment
 
-Quarkus Flow uses the link:https://serverlessworkflow.io/[CNCF Serverless Workflow] specification as its foundational vocabulary. When you write a flow using the Java DSL, you are programmatically generating a CNCF-compliant model.
+Quarkus Flow uses the link:https://open-workflow-specification.org/[Open Workflow] specification as its foundational vocabulary. When you write a flow using the Java DSL, you are programmatically generating a CNCF-compliant model.
 
 * **Workflow (Flow):** The overarching container representing the process.
 * **Task:** A distinct step in the workflow (e.g., executing a function, waiting for an event, or evaluating a condition).

--- a/docs/modules/ROOT/pages/data-flow.adoc
+++ b/docs/modules/ROOT/pages/data-flow.adoc
@@ -8,7 +8,7 @@ However, a task rarely needs the *entire* workflow context to do its job, and it
 
 
 
-To manage this, the Serverless Workflow specification defines a strict Data Flow model. Every task can define:
+To manage this, the Open Workflow specification defines a strict Data Flow model. Every task can define:
 
 * **Input:** What specific data the task extracts from the workflow context before executing.
 * **Output:** How to format the raw result produced by the task.
@@ -156,9 +156,9 @@ application code.
 Complex regular expressions inside trusted workflow definitions, including ones
 backed by Java DSL filters, can still be expensive to evaluate. When you
 process untrusted or high-volume input, keep task timeout budgets explicit
-instead of relying on defaults. The Serverless
+instead of relying on defaults. The Open
 Workflow DSL defines task timeouts in the
-https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#timeout[`timeout`
+https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#timeout[`timeout`
 section of the specification].
 
 For example, this regex-heavy task is limited to 30 seconds:

--- a/docs/modules/ROOT/pages/dsl-cheatsheet.adoc
+++ b/docs/modules/ROOT/pages/dsl-cheatsheet.adoc
@@ -2,7 +2,7 @@
 :page-role: reference
 include::includes/attributes.adoc[]
 
-Quarkus Flow uses the CNCF Workflow link:https://github.com/serverlessworkflow/sdk-java[**Java Fluent DSL**] to define workflows in code.
+Quarkus Flow uses the Open Workflow link:https://github.com/open-workflow-specification/sdk-java[**Java Fluent DSL**] to define workflows in code.
 This page shows:
 
 - how to define a workflow class,
@@ -400,7 +400,7 @@ You pass the *resulting* steps/specs (e.g. `listen(...)`, `emitJson(...)`, `open
 
 == Data flow and transformations
 
-Quarkus Flow follows the Serverless Workflow Specification data-flow model: every step can shape
+Quarkus Flow follows the Open Workflow Specification data-flow model: every step can shape
 what it **extracts** as input, how it **transforms** its direct result, and what it
 **merges** back into the global context.
 

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -4,7 +4,7 @@ include::includes/attributes.adoc[]
 
 Welcome to Quarkus Flow!
 
-Quarkus Flow brings the link:https://serverlessworkflow.io/[Serverless Workflow] specification natively to Quarkus. It allows you to build durable, event-driven orchestrations and Agentic AI patterns using a highly ergonomic, type-safe Java DSL.
+Quarkus Flow brings the link:https://open-workflow-specification.org/[Open Workflow] specification natively to Quarkus. It allows you to build durable, event-driven orchestrations and Agentic AI patterns using a highly ergonomic, type-safe Java DSL.
 
 This tutorial shows the shortest path to building, exposing, and visualizing your first Quarkus Flow workflow.
 

--- a/docs/modules/ROOT/pages/grpc.adoc
+++ b/docs/modules/ROOT/pages/grpc.adoc
@@ -5,7 +5,7 @@
 include::./includes/attributes.adoc[]
 
 Quarkus Flow supports gRPC through the `quarkus-flow-grpc` module.
-It connects the Serverless Workflow gRPC executor to Quarkus gRPC channels, so you can reuse the same client routing and configuration you already use in Quarkus applications.
+It connects the Open Workflow gRPC executor to Quarkus gRPC channels, so you can reuse the same client routing and configuration you already use in Quarkus applications.
 
 == Add the dependency
 

--- a/docs/modules/ROOT/pages/http-openapi-tasks.adoc
+++ b/docs/modules/ROOT/pages/http-openapi-tasks.adoc
@@ -2,7 +2,7 @@
 :page-role: howto
 include::includes/attributes.adoc[]
 
-Quarkus Flow builds on top of the CNCF Serverless Workflow Specification to give you first-class HTTP and OpenAPI tasks.
+Quarkus Flow builds on top of the Open Workflow Specification (CNCF sandbox project) to give you first-class HTTP and OpenAPI tasks.
 
 This guide shows how to:
 
@@ -21,7 +21,7 @@ For HTTP client timeouts, TLS, proxies, and connection pooling, see xref:http-cl
 
 == 1. Call HTTP endpoints
 
-HTTP calls are represented in the CNCF Workflow Spec as `call` tasks. In Quarkus Flow, you define these using the fluent shortcuts from `io.quarkiverse.flow.dsl.FlowDSL`.
+HTTP calls are represented in the Open Workflow Spec as `call` tasks. In Quarkus Flow, you define these using the fluent shortcuts from `io.quarkiverse.flow.dsl.FlowDSL`.
 
 === 1.1 Simple GET / POST
 
@@ -181,12 +181,12 @@ When a call fails, you will see a tracing line for the failing task alongside th
 
 When an HTTP or OpenAPI task fails (e.g., a 4xx/5xx status or a timeout), the workflow engine halts execution and throws a `WorkflowException` containing a `WorkflowError`.
 
-Quarkus Flow maps this error exactly to the CNCF Specification's error model, which aligns with **RFC 7807 Problem Details**:
+Quarkus Flow maps this error exactly to the Open Workflow Specification's error model, which aligns with **RFC 7807 Problem Details**:
 
 [source,json]
 ----
 {
-  "type": "https://serverlessworkflow.io/spec/1.0.0/errors/communication",
+  "type": "https://open-workflow-specification.org/spec/1.0.0/errors/communication",
   "status": 401,
   "instance": "do/0/370b9a91-22c2-4b3e-85c4-10892c2864ff",
   "title": "HTTP 401 Unauthorized",

--- a/docs/modules/ROOT/pages/idempotency-correlation.adoc
+++ b/docs/modules/ROOT/pages/idempotency-correlation.adoc
@@ -47,7 +47,7 @@ The engine does **not** maintain a deduplication cache. If the same start event 
 
 [NOTE]
 ====
-This is by design. The Serverless Workflow specification treats every incoming event as a unique trigger. Duplicate detection at the workflow-triggering layer is the responsibility of the messaging infrastructure or of an application-level deduplication layer.
+This is by design. The Open Workflow specification treats every incoming event as a unique trigger. Duplicate detection at the workflow-triggering layer is the responsibility of the messaging infrastructure or of an application-level deduplication layer.
 ====
 
 === 2.2 No Exactly-Once Execution
@@ -277,7 +277,7 @@ This approach ensures the outbox entry is written *after* the task completes suc
 
 This is the pattern you want when a workflow pauses on a `listen(...)` task and an external system must later resume that exact workflow instance.
 
-Important distinction: this is **not** the Serverless Workflow spec's event-to-event correlation model. Here, the goal is to route an incoming callback to a specific waiting workflow instance.
+Important distinction: this is **not** the Open Workflow spec's event-to-event correlation model. Here, the goal is to route an incoming callback to a specific waiting workflow instance.
 
 Quarkus Flow supports multiple strategies for correlating callbacks to a waiting instance:
 

--- a/docs/modules/ROOT/pages/includes/quarkus-flow-oidc.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-oidc.adoc
@@ -15,7 +15,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Whether OAuth2/OIDC token negotiation should be delegated to `quarkus-oidc-client`. When disabled, the Serverless Workflow SDK falls back to its own token negotiation.
+Whether OAuth2/OIDC token negotiation should be delegated to `quarkus-oidc-client`. When disabled, the Open Workflow SDK falls back to its own token negotiation.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-flow-oidc_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-oidc_quarkus.flow.adoc
@@ -15,7 +15,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Whether OAuth2/OIDC token negotiation should be delegated to `quarkus-oidc-client`. When disabled, the Serverless Workflow SDK falls back to its own token negotiation.
+Whether OAuth2/OIDC token negotiation should be delegated to `quarkus-oidc-client`. When disabled, the Open Workflow SDK falls back to its own token negotiation.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,10 +1,10 @@
 = Quarkus Flow
 :page-layout: default
-:description: Workflow engine for Quarkus based on the CNCF Serverless Workflow Specification, with Java DSL and Agentic AI support.
+:description: Workflow engine for Quarkus based on the Open Workflow Specification (CNCF sandbox project), with Java DSL and Agentic AI support.
 
 include::./includes/attributes.adoc[]
 
-Quarkus Flow is a lightweight, native-friendly workflow engine for Quarkus, built on the link:https://serverlessworkflow.io/[CNCF Serverless Workflow Specification].
+Quarkus Flow is a lightweight, native-friendly workflow engine for Quarkus, built on the link:https://open-workflow-specification.org/[Open Workflow Specification (CNCF sandbox project)].
 It allows you to model both classic orchestrations and Agentic AI flows using a fluent Java DSL that maps directly to the specification's core concepts (such as states, transitions, and event filters), all with first-class CDI and Quarkus ergonomics.
 
 == Architecture Overview
@@ -13,7 +13,7 @@ image::architecture.svg[Quarkus Flow Architecture Diagram, align="center"]
 
 == Highlights
 
-* **CNCF-Compliant Vocabulary:** Define workflows using a fluent Java DSL that strictly adheres to the CNCF Serverless Workflow specification.
+* **CNCF-Compliant Vocabulary:** Define workflows using a fluent Java DSL that strictly adheres to the Open Workflow specification.
 * **Build-Time Optimization:** Compile-time discovery of workflow descriptors and automatic injection of compiled beans.
 * **Standard Orchestration:** Robust state management, retries, branching, and event routing directly within your Quarkus app.
 * **AI First-Class Citizen:** Seamless Agentic workflows integrating with link:https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html[LangChain4j].
@@ -79,4 +79,4 @@ Nothing stops you from a **hybrid** approach:
 
 * xref:getting-started.adoc[Getting Started (Java DSL)]
 * xref:dsl-cheatsheet.adoc[Java DSL Cheatsheet]
-* xref:specification.adoc[CNCF Specification Mapping]
+* xref:specification.adoc[Open Workflow Specification Mapping]

--- a/docs/modules/ROOT/pages/messaging.adoc
+++ b/docs/modules/ROOT/pages/messaging.adoc
@@ -223,4 +223,4 @@ When you provide these beans, the default bridge is ignored.
 
 * xref:data-flow.adoc[Data flow and context management] — how to shape event payloads.
 * xref:dsl-cheatsheet.adoc[Java DSL cheatsheet] — syntax for `emit`, `listen`, and event builders.
-* xref:specification.adoc[Serverless Workflow Spec mapping and concepts] — the spec rules for event consumption.
+* xref:specification.adoc[Open Workflow Spec mapping and concepts] — the spec rules for event consumption.

--- a/docs/modules/ROOT/pages/metrics-prometheus.adoc
+++ b/docs/modules/ROOT/pages/metrics-prometheus.adoc
@@ -33,8 +33,8 @@ or by setting `quarkus.flow.metrics.enabled=false` in `application.properties`.
 
 [NOTE]
 ====
-Metric names are aligned with the workflow state phases defined in the CNCF Serverless Workflow specification:
-https://github.com/serverlessworkflow/specification/blob/main/dsl.md#status-phases
+Metric names are aligned with the workflow state phases defined in the Open Workflow Specification (CNCF sandbox project):
+https://github.com/open-workflow-specification/specification/blob/main/dsl.md#status-phases
 ====
 
 [NOTE]
@@ -289,14 +289,14 @@ The value is `1` when HALF_OPEN and `0` otherwise.
 
 ==== Name your tasks
 
-If a task does not have an explicit name, Serverless Workflow automatically assigns a UUID as the task name.
+If a task does not have an explicit name, Open Workflow automatically assigns a UUID as the task name.
 That UUID is then used as the `task` label in metrics, making monitoring and aggregation difficult.
 
 Always provide descriptive task names to ensure meaningful metrics.
 
 ==== Make task names unique
 
-The Serverless Workflow specification does not require task names to be unique within a workflow.
+The Open Workflow specification does not require task names to be unique within a workflow.
 When multiple tasks share the same name, their metrics are aggregated under the same label.
 
 Quarkus Flow uses the combination of workflow name (`workflow`) and task name (`task`) as metric labels.

--- a/docs/modules/ROOT/pages/migration-0.13-to-0.14.adoc
+++ b/docs/modules/ROOT/pages/migration-0.13-to-0.14.adoc
@@ -1,7 +1,7 @@
 = Migration Guide: 0.13.x to 0.14.0
 include::includes/attributes.adoc[]
 
-Quarkus Flow 0.14.0 internalizes the Serverless Workflow Java Fluent DSL.
+Quarkus Flow 0.14.0 internalizes the Open Workflow Java Fluent DSL.
 The DSL classes previously lived in the SDK (`io.serverlessworkflow.impl.expression.func` and related packages) and are now part of Quarkus Flow itself under a new `io.quarkiverse.flow.dsl` namespace.
 
 This is a **source-level breaking change**: your workflow code will need import updates, but the DSL behavior is identical.

--- a/docs/modules/ROOT/pages/persistence.adoc
+++ b/docs/modules/ROOT/pages/persistence.adoc
@@ -253,7 +253,7 @@ quarkus.flow.persistence.mvstore.db-path=${user.home}/testFlowMVStore.db
 * xref:concepts-durable-workflow-k8s.adoc[Durable Workflows in Kubernetes] — architecture and concepts for distributed execution.
 * link:https://quarkus.io/guides/redis[Using the Quarkus Redis Client] — advanced Redis configuration.
 * link:https://www.h2database.com/html/mvstore.html[MVStore homepage] — deeper dive into the MVStore engine.
-* link:https://github.com/serverlessworkflow/sdk-java/tree/main/impl/persistence[Serverless Workflow Java SDK Persistence] — upstream SDK reference.
+* link:https://github.com/open-workflow-specification/sdk-java/tree/main/impl/persistence[Open Workflow Java SDK Persistence] — upstream SDK reference.
 * https://infinispan.org/docs/stable/titles/resp/resp-endpoint.html[Using the Infinispan RESP endpoint]
 * https://infinispan.org/docs/stable/titles/container_image/container_image.html[Infinispan Server container image]
 * https://infinispan.org/docs/infinispan-operator/main/operator.html[Infinispan Operator guide]

--- a/docs/modules/ROOT/pages/quarkus-flow-cookbook.adoc
+++ b/docs/modules/ROOT/pages/quarkus-flow-cookbook.adoc
@@ -416,7 +416,7 @@ do:
   - notImplemented:
       raise:
         error:
-          type: https://open-workflow-specification.org/errors/not-implemented
+          type: https://acme.org/errors/not-implemented
           status: 500
           title: Not Implemented
           detail: ${ "The workflow '\( $workflow.definition.document.name ):\( $workflow.definition.document.version )' is a work in progress and cannot be run yet" }

--- a/docs/modules/ROOT/pages/quarkus-flow-cookbook.adoc
+++ b/docs/modules/ROOT/pages/quarkus-flow-cookbook.adoc
@@ -1,4 +1,4 @@
-= Quarkus Flow & CNCF Serverless Workflow Cookbook
+= Quarkus Flow & Open Workflow Cookbook
 :page-role: reference
 include::includes/attributes.adoc[]
 
@@ -6,14 +6,14 @@ include::includes/attributes.adoc[]
 ====
 **Java DSL is Recommended**
 
-While this cookbook provides extensive examples for defining workflows using the CNCF Serverless Workflow YAML DSL (Serverless Workflow), Quarkus Flow *strongly recommends the Java DSL* as the primary method for defining workflows. The Java DSL offers superior type safety, refactoring capabilities, and seamless IDE integration.
+While this cookbook provides extensive examples for defining workflows using the Open Workflow YAML DSL (Open Workflow), Quarkus Flow *strongly recommends the Java DSL* as the primary method for defining workflows. The Java DSL offers superior type safety, refactoring capabilities, and seamless IDE integration.
 
 These YAML examples are ideal for teams maintaining specification files, or sharing definitions across different runtime environments.
 ====
 
-This cookbook provides a comprehensive collection of practical, copy-and-paste xref:workflow-definitions.adoc[YAML examples for building modern Serverless Workflows in Quarkus Flow].
+This cookbook provides a comprehensive collection of practical, copy-and-paste xref:workflow-definitions.adoc[YAML examples for building modern Open Workflows in Quarkus Flow].
 
-Every Serverless Workflow definition starts with a `document:` header to declare its identity and version, followed by a `do:` block that orchestrates the execution steps.
+Every Open Workflow definition starts with a `document:` header to declare its identity and version, followed by a `do:` block that orchestrates the execution steps.
 
 == 1. Pausing Execution (Wait State)
 To pause a workflow for a specific amount of time, use the `wait` task. You can define the duration using an ISO 8601 time string.
@@ -137,7 +137,7 @@ do:
 ----
 
 == 6. Event Consumption and Production
-Serverless Workflow integrates heavily with CloudEvents. You can pause a workflow until a specific event is received using the `listen` task, or publish events using the `emit` task.
+Open Workflow integrates heavily with CloudEvents. You can pause a workflow until a specific event is received using the `listen` task, or publish events using the `emit` task.
 
 *Listening for an Event:*
 [source,yaml]
@@ -377,7 +377,7 @@ do:
       catch:
         errors:
            with:
-            type: https://serverlessworkflow.io/spec/1.0.0/errors/communication
+            type: https://open-workflow-specification.org/spec/1.0.0/errors/communication
             status: 404
         as: error
         do:
@@ -416,7 +416,7 @@ do:
   - notImplemented:
       raise:
         error:
-          type: https://serverlessworkflow.io/errors/not-implemented
+          type: https://open-workflow-specification.org/errors/not-implemented
           status: 500
           title: Not Implemented
           detail: ${ "The workflow '\( $workflow.definition.document.name ):\( $workflow.definition.document.version )' is a work in progress and cannot be run yet" }
@@ -503,6 +503,6 @@ See xref:grpc.adoc[the gRPC guide] for the Quarkus client configuration variant.
 
 == See also
 
-* xref:specification.adoc[Serverless Workflow Spec mapping and concepts] — a quick orientation to the 1.0.0 specification components.
+* xref:specification.adoc[Open Workflow Spec mapping and concepts] — a quick orientation to the 1.0.0 specification components.
 * xref:workflow-definitions.adoc[Define workflows from YAML] — review the syntax for discovering and injecting YAML workflows.
 * xref:data-flow.adoc[Data flow and context management]: A deep dive into how `input`, `output`, and `export` manipulate the workflow data context.

--- a/docs/modules/ROOT/pages/quarkus-flow-java-cookbook.adoc
+++ b/docs/modules/ROOT/pages/quarkus-flow-java-cookbook.adoc
@@ -1,11 +1,11 @@
-= Quarkus Flow & CNCF Serverless Workflow Java Cookbook
+= Quarkus Flow & Open Workflow Java Cookbook
 :sectnums:
 :page-role: reference
 :examples-dir: ../main/java
 include::includes/attributes.adoc[]
 
 
-This cookbook provides a comprehensive collection of practical, copy-and-paste examples for building modern workflows using the Serverless Workflow Java SDK Fluent API.
+This cookbook provides a comprehensive collection of practical, copy-and-paste examples for building modern workflows using the Open Workflow Java SDK Fluent API.
 
 All workflows in Quarkus Flow are defined as CDI beans by extending the `Flow` class and overriding the `descriptor()` method.
 

--- a/docs/modules/ROOT/pages/quartz.adoc
+++ b/docs/modules/ROOT/pages/quartz.adoc
@@ -2,9 +2,9 @@
 :page-role: howto
 include::includes/attributes.adoc[]
 
-The Serverless Workflow specification allows you to define workflows that execute automatically on a recurring schedule.
+The Open Workflow specification allows you to define workflows that execute automatically on a recurring schedule.
 
-By default, the Serverless Workflow SDK engine uses a lightweight, in-memory implementation (based on `ScheduledExecutorService` and the `cron-utils` library) to trigger these executions. Additionally, Quarkus Flow provides a xref:scheduler.adoc[native Quarkus scheduler] for standalone deployments. However, for a production-grade Quarkus application deployed as a cluster of multiple instances, you must back the Quartz scheduler with a persistent, clustered JDBC job store (store-type=jdbc-cmt, clustered=true) to guarantee correct behavior. The reverse is also true: do not use it for standalone deployments.
+By default, the Open Workflow SDK engine uses a lightweight, in-memory implementation (based on `ScheduledExecutorService` and the `cron-utils` library) to trigger these executions. Additionally, Quarkus Flow provides a xref:scheduler.adoc[native Quarkus scheduler] for standalone deployments. However, for a production-grade Quarkus application deployed as a cluster of multiple instances, you must back the Quartz scheduler with a persistent, clustered JDBC job store (store-type=jdbc-cmt, clustered=true) to guarantee correct behavior. The reverse is also true: do not use it for standalone deployments.
 
 This guide shows how to:
 
@@ -103,11 +103,11 @@ do:
 
 === Quartz cron format
 
-The Serverless Workflow specification mandates that CRON expressions follow the standard **Unix** format.
+The Open Workflow specification mandates that CRON expressions follow the standard **Unix** format.
 
 The Quarkus Quartz Scheduler, however, uses the link:https://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html[Quartz] format. This means that, if you are using the Unix format in your workflow definition, you should change the CRON expression to use Quartz format.
 
 == See also
 
 * link:https://quarkus.io/guides/quartz[Quarkus Quartz guide]
-* link:https://github.com/serverlessworkflow/specification/blob/main/dsl.md#scheduling[Serverless Workflow Specification: Scheduling] — full details and edge cases for the `every`, `after`, and `cron` syntax.
+* link:https://github.com/open-workflow-specification/specification/blob/main/dsl.md#scheduling[Open Workflow Specification: Scheduling] — full details and edge cases for the `every`, `after`, and `cron` syntax.

--- a/docs/modules/ROOT/pages/reference-runner-images.adoc
+++ b/docs/modules/ROOT/pages/reference-runner-images.adoc
@@ -19,7 +19,7 @@ If you're a Java/Quarkus developer, we strongly recommend xref:getting-started.a
 
 * You're a Kubernetes administrator deploying workflows as configuration
 * Your team doesn't have Java/Quarkus expertise
-* You want to quickly test the Serverless Workflow specification locally
+* You want to quickly test the Open Workflow specification locally
 * You're deploying workflows managed by external tools or GitOps
 ====
 
@@ -31,7 +31,7 @@ The **Quarkus Flow Runner** images provide a ready-to-run workflow execution eng
 **Common use cases:**
 
 * **GitOps workflow deployment** - Store workflows in Git, deploy via Kubernetes ConfigMaps, execute via REST API
-* **Polyglot teams** - Non-Java teams can deploy workflows using the Serverless Workflow specification
+* **Polyglot teams** - Non-Java teams can deploy workflows using the Open Workflow specification
 * **Quick prototyping** - Test workflow definitions locally with Docker in seconds
 * **Platform-as-a-Service** - Build a workflow execution platform where users deploy only YAML definitions
 * **Multi-tenant hosting** - Single Runner instance serves workflows across multiple namespaces/teams

--- a/docs/modules/ROOT/pages/runner.adoc
+++ b/docs/modules/ROOT/pages/runner.adoc
@@ -2,7 +2,7 @@
 :page-role: tutorial
 include::includes/attributes.adoc[]
 
-Deploy and execute Serverless Workflow definitions via REST API.
+Deploy and execute Open Workflow definitions via REST API.
 
 The Quarkus Flow Runner extension transforms your Quarkus application into a lightweight, cloud-native workflow execution engine. Load workflow definitions from YAML/JSON files at startup, and execute them through a secured REST API.
 
@@ -87,7 +87,7 @@ quarkus.flow.runner.source.path=src/main/resources/workflows
 
 == 3. Create workflow definitions
 
-Workflow definitions follow the link:https://serverlessworkflow.io/[CNCF Serverless Workflow specification]. The Runner supports YAML and JSON formats.
+Workflow definitions follow the link:https://open-workflow-specification.org/[Open Workflow Specification (CNCF sandbox project)]. The Runner supports YAML and JSON formats.
 
 Create your first workflow definition as a YAML file.
 
@@ -975,7 +975,7 @@ Now that you have the Runner operational, explore these advanced topics:
 
 * xref:data-flow.adoc[Data flow and context management] - Understand how to manipulate data between workflow tasks
 * xref:dsl-cheatsheet.adoc[Java DSL cheatsheet] - Learn workflow DSL syntax for creating complex definitions
-* xref:specification.adoc[CNCF Specification Mapping] - Understand how Quarkus Flow maps to the Serverless Workflow spec
+* xref:specification.adoc[CNCF Specification Mapping] - Understand how Quarkus Flow maps to the Open Workflow spec
 
 **AI and Integrations:**
 

--- a/docs/modules/ROOT/pages/scheduler.adoc
+++ b/docs/modules/ROOT/pages/scheduler.adoc
@@ -2,9 +2,9 @@
 :page-role: howto
 include::includes/attributes.adoc[]
 
-The Serverless Workflow specification allows you to define workflows that execute automatically on a recurring schedule.
+The Open Workflow specification allows you to define workflows that execute automatically on a recurring schedule.
 
-By default, the Serverless Workflow SDK engine uses a lightweight, in-memory implementation (based on `ScheduledExecutorService` and the `cron-utils` library) to trigger these executions. However, for a Quarkus Flow application, **we highly recommend replacing this with the native Quarkus Scheduler integration**.
+By default, the Open Workflow SDK engine uses a lightweight, in-memory implementation (based on `ScheduledExecutorService` and the `cron-utils` library) to trigger these executions. However, for a Quarkus Flow application, **we highly recommend replacing this with the native Quarkus Scheduler integration**.
 
 This guide shows how to:
 
@@ -33,7 +33,7 @@ Adding this dependency automatically wires Quarkus Flow to use the underlying Qu
 
 == 2. Configure for specification compliance
 
-The Serverless Workflow specification mandates that CRON expressions follow the standard **Unix** format.
+The Open Workflow specification mandates that CRON expressions follow the standard **Unix** format.
 
 The Quarkus Scheduler, however, defaults to the `quartz` format. To ensure your workflow definitions behave exactly as specified by the standard, you must configure the CRON type in your application properties:
 
@@ -100,4 +100,4 @@ do:
 == See also
 
 * link:https://quarkus.io/guides/scheduler-reference[Quarkus Scheduler Reference Guide] — learn how to configure threads, metrics, and tracing for the underlying scheduler.
-* link:https://github.com/serverlessworkflow/specification/blob/main/dsl.md#scheduling[Serverless Workflow Specification: Scheduling] — full details and edge cases for the `every`, `after`, and `cron` syntax.
+* link:https://github.com/open-workflow-specification/specification/blob/main/dsl.md#scheduling[Open Workflow Specification: Scheduling] — full details and edge cases for the `every`, `after`, and `cron` syntax.

--- a/docs/modules/ROOT/pages/secrets.adoc
+++ b/docs/modules/ROOT/pages/secrets.adoc
@@ -86,7 +86,7 @@ If multiple providers exist and you do not specify which one to use, the engine 
 == 4. Error Handling and Security
 
 === Missing Secrets
-Per the Serverless Workflow Specification, if a workflow attempts to execute a task and the referenced secret handle cannot be resolved (or is missing the required keys like `username`), the engine treats this as an **authorization failure**.
+Per the Open Workflow Specification, if a workflow attempts to execute a task and the referenced secret handle cannot be resolved (or is missing the required keys like `username`), the engine treats this as an **authorization failure**.
 
 The task will immediately fail with a `WorkflowError` indicating an authorization problem (often surfacing as an HTTP `401 Unauthorized` or `403 Forbidden` if it was an HTTP task).
 
@@ -147,4 +147,4 @@ void resolves_secret_from_provider() {
 == See also
 * xref:http-openapi-tasks.adoc[Call HTTP and OpenAPI services] — using secrets for HTTP authentication.
 * link:https://quarkus.io/guides/credentials-provider[Quarkus: Using a Credentials Provider] — how to set up Vault and other providers in Quarkus.
-* link:https://github.com/serverlessworkflow/specification/blob/main/dsl.md#secret[Serverless Workflow Specification: Secrets] — the underlying standard.
+* link:https://github.com/open-workflow-specification/specification/blob/main/dsl.md#secret[Open Workflow Specification: Secrets] — the underlying standard.

--- a/docs/modules/ROOT/pages/specification.adoc
+++ b/docs/modules/ROOT/pages/specification.adoc
@@ -1,8 +1,8 @@
-= Serverless Workflow Specification mapping and concepts
+= Open Workflow Specification mapping and concepts
 :page-role: explanation
 include::includes/attributes.adoc[]
 
-This page is a fast orientation to the **CNCF Serverless Workflow Specification 1.0.0** that Quarkus Flow aligns with. It highlights the core ideas and gives you a compact cheatsheet of the most used components—each linking back to the spec for deeper reading.
+This page is a fast orientation to the **Open Workflow Specification 1.0.0 (CNCF sandbox project)** that Quarkus Flow aligns with. It highlights the core ideas and gives you a compact cheatsheet of the most used components—each linking back to the spec for deeper reading.
 
 [.lead]
 If you understand these concepts, you can read any Quarkus Flow example and know exactly what it’s doing.
@@ -22,8 +22,8 @@ Check out the xref:quarkus-flow-cookbook.adoc[] to see these concepts applied in
 
 === Quick links:
 
-* DSL overview (concepts): link:https://github.com/serverlessworkflow/specification/blob/main/dsl.md[DSL]
-* DSL reference (definitions): link:https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md[DSL Reference]
+* DSL overview (concepts): link:https://github.com/open-workflow-specification/specification/blob/main/dsl.md[DSL]
+* DSL reference (definitions): link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md[DSL Reference]
 
 == Core components (cheatsheet)
 
@@ -36,67 +36,67 @@ The CNCF 1.0.0 Specification organizes workflows around the `document` (metadata
 |**Document Metadata**
 |Top-level definition: `dsl` (version 1.0.0), `namespace`, `name`, `version`, optional `description`.
 |Identify the workflow, its domain, and which schema version you’re using.
-|link:https://github.com/serverlessworkflow/specification/blob/main/dsl.md#document[DSL]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl.md#document[DSL]
 
 |**Data model**
 |The global workflow data context (JSON). Tasks extract from, transform, and export back to this context.
 |Keep transient state, map call inputs/outputs, and drive branching conditions.
-|link:https://github.com/serverlessworkflow/specification/blob/main/dsl.md#data-flow[DSL Data Flow]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl.md#data-flow[DSL Data Flow]
 
 |**Tasks (`do`)**
 |The ordered list of steps to execute.
 |Define your core process: set → call → emit/listen → switch → loop, etc.
-|link:https://github.com/serverlessworkflow/specification/blob/main/dsl.md#task[DSL Task]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl.md#task[DSL Task]
 
 |**Task: `set`**
 |Evaluates an expression and updates the workflow data context.
 |Initialize fields, compute constants, or shape intermediate values.
-|link:https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#settask[Reference]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#settask[Reference]
 
 |**Task: `call`**
 |Invokes external endpoints or internal functions.
 |HTTP/OpenAPI calls, communicating with other microservices, or triggering LangChain4j AI agents.
-|link:https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#calltask[Reference]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#calltask[Reference]
 
 |**Task: `emit`**
 |Publishes a CloudEvent to an external broker.
 |Notify other services, fan-out architectural patterns, or broadcast integration events.
-|link:https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#emittask[Reference]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#emittask[Reference]
 
 |**Task: `listen`**
 |Pauses execution and waits for one or more CloudEvents matching specific correlation rules.
 |Human-in-the-loop approvals, asynchronous callbacks, or waiting for external system signals.
-|link:https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#listentask[Reference]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#listentask[Reference]
 
 |**Task: `switch` (Branching)**
 |Evaluates conditions (`when`) and routes execution to specific paths (`then`).
 |Feature flags, guardrails, compliance checks, or routing "happy vs. error" paths.
-|link:https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#switchtask[Reference]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#switchtask[Reference]
 
 |**Task: `for` (Loops)**
 |Iterates over a collection in the data context, executing a block of tasks for each item.
 |Batch processing, agentic revise-loops, or polling.
-|link:https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#fortask[Reference]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#fortask[Reference]
 
 |**Task: `try` (Errors)**
 |Executes a block of tasks and catches specific errors to trigger compensations or retries.
 |Wrap unreliable network calls, steer to fallback paths, and surface clear failures without crashing the instance.
-|link:https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#trytask[Reference]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#trytask[Reference]
 
 |**Timeouts**
 |Declarative time limits applied to individual tasks or the overarching workflow execution.
 |Prevent stalled processes, bound external waits, and enforce business SLAs.
-|link:https://github.com/serverlessworkflow/specification/blob/main/dsl.md#timeouts[DSL Timeouts]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl.md#timeouts[DSL Timeouts]
 
 |**Expressions & Data Filters**
 |The runtime evaluation of `input`, `output`, and `export` fields within a task using `jq`.
 |Extracting payloads from events, filtering API responses, or computing booleans for `switch` blocks. (See xref:data-flow.adoc[Data flow]).
-|link:https://github.com/serverlessworkflow/specification/blob/main/dsl.md#runtime-expressions[DSL Expressions]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl.md#runtime-expressions[DSL Expressions]
 
 |**Auth & Secrets**
 |References to credentials or API keys used during `call` tasks.
 |Securely communicate with external services without hardcoding tokens in the definition.
-|link:https://github.com/serverlessworkflow/specification/blob/main/dsl.md#authentication[DSL Auth]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl.md#authentication[DSL Auth]
 |===
 
 [NOTE]
@@ -112,7 +112,7 @@ Crucially, Quarkus Flow leans into the Quarkus "Ahead-of-Time" philosophy by dis
 
 Now that you understand the underlying specification, here is where you can see these concepts applied in Quarkus Flow:
 
-* xref:quarkus-flow-cookbook.adoc[]: A comprehensive collection of practical, copy-and-paste YAML examples for the Serverless Workflow DSL.
+* xref:quarkus-flow-cookbook.adoc[]: A comprehensive collection of practical, copy-and-paste YAML examples for the Open Workflow DSL.
 * xref:workflow-definitions.adoc[Define workflows from YAML]: review the syntax for discovering and injecting YAML workflows.
 * xref:dsl-cheatsheet.adoc[Java DSL Cheatsheet]: A quick reference of all the Java methods that map directly to these CNCF tasks.
 * xref:data-flow.adoc[Data flow and context management]: A deep dive into how `input`, `output`, and `export` manipulate the workflow data context.

--- a/docs/modules/ROOT/pages/test-debug.adoc
+++ b/docs/modules/ROOT/pages/test-debug.adoc
@@ -130,7 +130,7 @@ class CustomerProfileResourceTest {
             .get("/customer/profile")
         .then()
             .statusCode(401)
-            .body("type", equalTo("https://serverlessworkflow.io/spec/1.0.0/errors/communication"))
+            .body("type", equalTo("https://open-workflow-specification.org/spec/1.0.0/errors/communication"))
             .body("title", equalTo("HTTP 401 Unauthorized"))
             .body("status", equalTo(401));
     }

--- a/docs/modules/ROOT/pages/wk-lab-2-http-openapi.adoc
+++ b/docs/modules/ROOT/pages/wk-lab-2-http-openapi.adoc
@@ -117,7 +117,7 @@ With dev mode running (`./mvnw quarkus:dev`):
 HTTP/1.1 401 Unauthorized
 Content-Type: application/json
 {
-  "type": "https://serverlessworkflow.io/spec/1.0.0/errors/communication",
+  "type": "https://open-workflow-specification.org/spec/1.0.0/errors/communication",
   "status": 401,
   "title": "HTTP 401 Unauthorized",
   "instance": "do/0/..."

--- a/docs/modules/ROOT/pages/wk-lab-3-events-yaml.adoc
+++ b/docs/modules/ROOT/pages/wk-lab-3-events-yaml.adoc
@@ -6,7 +6,7 @@ In this lab, you will move away from the Java DSL and build a fully event-driven
 
 You will:
 
-* Define a Serverless Workflow in YAML using the 1.0.0 specification.
+* Define an Open Workflow in YAML using the 1.0.0 specification.
 * Wire the workflow to **SmallRye Reactive Messaging**.
 * Start the workflow automatically via an incoming **CloudEvent**.
 * Manually trigger the same workflow from the **Flow Dev UI** to see the dual-start capability.

--- a/docs/modules/ROOT/pages/workflow-definitions.adoc
+++ b/docs/modules/ROOT/pages/workflow-definitions.adoc
@@ -4,14 +4,14 @@ include::includes/attributes.adoc[]
 
 Quarkus Flow *recommends the Java DSL* as the primary way to define workflows because it provides type safety, refactoring support, and excellent IDE integration.
 
-However, Quarkus Flow fully supports loading xref:quarkus-flow-cookbook.adoc[CNCF Serverless Workflow 1.0.0] definitions written in YAML or JSON. This is ideal for teams that already maintain specification files or need to share definitions across different runtime environments.
+However, Quarkus Flow fully supports loading xref:quarkus-flow-cookbook.adoc[Open Workflow 1.0.0] definitions written in YAML or JSON. This is ideal for teams that already maintain specification files or need to share definitions across different runtime environments.
 
 This guide shows you how to load a YAML workflow into your Quarkus application and expose it as a standard `Flow` CDI bean that you can inject and execute.
 
 == Prerequisites
 
 * A Quarkus application with xref:getting-started.adoc[Quarkus Flow set up].
-* Basic familiarity with YAML and the xref:specification.adoc[Serverless Workflow Specification].
+* Basic familiarity with YAML and the xref:specification.adoc[Open Workflow Specification].
 
 == 1. Create the workflow specification file
 
@@ -161,7 +161,7 @@ curl "http://localhost:8080/echo?name=John"
 
 == See also
 
-* xref:quarkus-flow-cookbook.adoc[] — A comprehensive collection of practical, copy-and-paste YAML examples for the Serverless Workflow DSL.
-* xref:specification.adoc[Serverless Workflow Spec mapping and concepts] — a quick orientation to the 1.x.x specification components.
+* xref:quarkus-flow-cookbook.adoc[] — A comprehensive collection of practical, copy-and-paste YAML examples for the Open Workflow DSL.
+* xref:specification.adoc[Open Workflow Spec mapping and concepts] — a quick orientation to the 1.x.x specification components.
 * xref:data-flow.adoc[Data flow and context management] — understand how data mutates across YAML tasks.
 * xref:test-debug.adoc[Test and debug workflows] — learn how to write unit tests for your injected `Flow` beans.

--- a/examples/auth-oauth2-oidc/README.md
+++ b/examples/auth-oauth2-oidc/README.md
@@ -387,8 +387,8 @@ curl http://localhost:8080/quarkus-flow/openapi/images | jq
 
 * Quarkus Flow documentation:
   [https://docs.quarkiverse.io/quarkus-flow/dev/](https://docs.quarkiverse.io/quarkus-flow/dev/)
-* CNCF Serverless Workflow — Authentication:
-  [https://github.com/serverlessworkflow/specification](https://github.com/serverlessworkflow/specification)
+* Open Workflow Specification — Authentication:
+  [https://github.com/open-workflow-specification/specification](https://github.com/open-workflow-specification/specification)
 * Quarkus OIDC:
   [https://quarkus.io/guides/security-oidc-bearer-token-authentication](https://quarkus.io/guides/security-oidc-bearer-token-authentication)
 * Quarkus WireMock Dev Services:

--- a/examples/durable-workflows-k8s/src/main/java/org/acme/flow/durable/kube/NativeWorkflowEventListener.java
+++ b/examples/durable-workflows-k8s/src/main/java/org/acme/flow/durable/kube/NativeWorkflowEventListener.java
@@ -39,7 +39,7 @@ public class NativeWorkflowEventListener {
      */
     @SuppressWarnings("unchecked")
     void onStart(@Observes StartupEvent ev) {
-        LOGGER.info("Registering InMemory Serverless Workflow event listener...");
+        LOGGER.info("Registering InMemory Open Workflow event listener...");
 
         EventConsumer<TypeEventRegistration, TypeEventRegistrationBuilder> eventConsumer = (EventConsumer<TypeEventRegistration, TypeEventRegistrationBuilder>) workflowApplication
                 .eventConsumer();

--- a/examples/durable-workflows-k8s/src/main/resources/META-INF/resources/index.html
+++ b/examples/durable-workflows-k8s/src/main/resources/META-INF/resources/index.html
@@ -166,7 +166,7 @@
     <div class="header-panel">
         <div class="title-group">
             <h1>Durable Orchestrator</h1>
-            <p>Native Serverless Workflow Engine</p>
+            <p>Native Open Workflow Engine</p>
         </div>
         <div class="connection-status status-disconnected" id="connStatus">
             <div class="ping">

--- a/examples/greeting-runner/README.md
+++ b/examples/greeting-runner/README.md
@@ -124,4 +124,4 @@ This approach is ideal for:
 ## Learn More
 
 - [Quarkus Flow Runner Documentation](https://docs.quarkiverse.io/quarkus-flow/dev/runner.html)
-- [CNCF Serverless Workflow Specification](https://serverlessworkflow.io/)
+- [Open Workflow Specification](https://open-workflow-specification.org/)

--- a/examples/micrometer-prometheus/src/main/java/org/acme/CallForPapers.java
+++ b/examples/micrometer-prometheus/src/main/java/org/acme/CallForPapers.java
@@ -28,6 +28,6 @@ public record CallForPapers(
                         "Observability & Monitoring"),
                 "San Francisco, CA",
                 LocalDate.now().plusMonths(3),
-                "https://serverlessworkflow.io/submit");
+                "https://open-workflow-specification.org/submit");
     }
 }

--- a/examples/micrometer-prometheus/src/main/resources/flow/retryable.yaml
+++ b/examples/micrometer-prometheus/src/main/resources/flow/retryable.yaml
@@ -15,7 +15,7 @@ do:
       catch:
         errors:
           with:
-            type: https://serverlessworkflow.io/spec/1.0.0/errors/communication
+            type: https://open-workflow-specification.org/spec/1.0.0/errors/communication
             status: 500
         retry:
           delay:

--- a/examples/newsletter-drafter/README.md
+++ b/examples/newsletter-drafter/README.md
@@ -3,7 +3,7 @@
 A minimal-but-complete example that orchestrates a **Dual-Loop AI Workflow** (AI-to-AI iteration + Human-in-the-Loop review) using:
 
 - **Quarkus** (hot-reload dev mode)
-- **[Quarkus Flow](https://docs.quarkiverse.io/quarkus-flow/dev/)** (function-first fluent DSL for Serverless Workflow)
+- **[Quarkus Flow](https://docs.quarkiverse.io/quarkus-flow/dev/)** (function-first fluent DSL for Open Workflow)
 - **LangChain4j** (Declarative `@SequenceAgent` and Structured Outputs via **Ollama**)
 - **CloudEvents** over Kafka (Quarkus Dev Services)
 - A **Single Page Application (SPA)** UI with live updates via **WebSocket**
@@ -128,7 +128,7 @@ public interface AutoDraftCriticAgent {
 
 ## 🔁 The Quarkus Flow Definition
 
-The Serverless Workflow is orchestrated using the fluent `FlowWorkflowBuilder`. Notice how business logic is completely decoupled from AI prompt engineering:
+The workflow is orchestrated using the fluent `FlowWorkflowBuilder`. Notice how business logic is completely decoupled from AI prompt engineering:
 
 ```java
 public Workflow descriptor() {

--- a/examples/order-fulfillment-compensation/README.md
+++ b/examples/order-fulfillment-compensation/README.md
@@ -3,7 +3,7 @@
 A complete example demonstrating the **Compensation/Saga Pattern** for distributed transactions using:
 
 - **Quarkus** (hot-reload dev mode)
-- **[Quarkus Flow](https://docs.quarkiverse.io/quarkus-flow/dev/)** (function-first fluent DSL for Serverless Workflow)
+- **[Quarkus Flow](https://docs.quarkiverse.io/quarkus-flow/dev/)** (function-first fluent DSL for Open Workflow)
 - **Try-Catch Error Handling** with automatic compensation/rollback
 - **WebSocket** for real-time UI updates
 - A **Single Page Application (SPA)** UI with live workflow visualization
@@ -280,7 +280,7 @@ Ideas for learning and experimentation:
 ## 📖 Documentation
 
 - **Quarkus Flow**: [https://docs.quarkiverse.io/quarkus-flow/dev/](https://docs.quarkiverse.io/quarkus-flow/dev/)
-- **CNCF Serverless Workflow**: [https://serverlessworkflow.io/](https://serverlessworkflow.io/)
+- **Open Workflow Specification**: [https://open-workflow-specification.org/](https://open-workflow-specification.org/)
 - **Saga Pattern**: [https://microservices.io/patterns/data/saga.html](https://microservices.io/patterns/data/saga.html)
 
 Have fun building resilient workflows with Quarkus Flow! 🎉

--- a/grpc/README.md
+++ b/grpc/README.md
@@ -2,7 +2,7 @@
 
 Named gRPC channel support for **Quarkus Flow**.
 
-This module bridges the Serverless Workflow gRPC executor with **Quarkus gRPC clients** so you can route calls through:
+This module bridges the Open Workflow gRPC executor with **Quarkus gRPC clients** so you can route calls through:
 
 ```properties
 quarkus.grpc.clients.<name>.host=...

--- a/messaging/integration-tests-amqp/src/main/java/io/quarkiverse/flow/messaging/amqp/it/HelloMessagingFlow.java
+++ b/messaging/integration-tests-amqp/src/main/java/io/quarkiverse/flow/messaging/amqp/it/HelloMessagingFlow.java
@@ -27,9 +27,9 @@ public class HelloMessagingFlow extends Flow {
      * <p/>
      * To know more about the infrastructure configuration, please see the application.properties and the tests in this module.
      *
-     * @see <a href="https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#listen">DSL Reference:
+     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#listen">DSL Reference:
      *      Listen</a>
-     * @see <a href="https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#emit">DSL Reference:
+     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#emit">DSL Reference:
      *      Emit</a>
      */
     @Override
@@ -37,7 +37,7 @@ public class HelloMessagingFlow extends Flow {
         return FlowWorkflowBuilder.workflow()
                 // We are listening to one and only one event coming to our broker with the type "io.quarkiverse.flow.messaging.hello.request"
                 // Each event produced by the broker with this type will kick a new workflow instance.
-                // To learn more see the base specification: https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#listen
+                // To learn more see the base specification: https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#listen
                 .tasks(listen(toOne("io.quarkiverse.flow.messaging.hello.request")),
                         // "name" is expected in the message body payload
                         // by design, we receive an array from the listen task, since it's only one we are expecting it's safe to index

--- a/messaging/integration-tests-amqp/src/main/java/io/quarkiverse/flow/messaging/amqp/it/HelloMessagingFlow.java
+++ b/messaging/integration-tests-amqp/src/main/java/io/quarkiverse/flow/messaging/amqp/it/HelloMessagingFlow.java
@@ -27,9 +27,11 @@ public class HelloMessagingFlow extends Flow {
      * <p/>
      * To know more about the infrastructure configuration, please see the application.properties and the tests in this module.
      *
-     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#listen">DSL Reference:
+     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#listen">DSL
+     *      Reference:
      *      Listen</a>
-     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#emit">DSL Reference:
+     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#emit">DSL
+     *      Reference:
      *      Emit</a>
      */
     @Override

--- a/messaging/integration-tests/src/main/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlow.java
+++ b/messaging/integration-tests/src/main/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlow.java
@@ -27,9 +27,9 @@ public class HelloMessagingFlow extends Flow {
      * <p/>
      * To know more about the infrastructure configuration, please see the application.properties and the tests in this module.
      *
-     * @see <a href="https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#listen">DSL Reference:
+     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#listen">DSL Reference:
      *      Listen</a>
-     * @see <a href="https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#emit">DSL Reference:
+     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#emit">DSL Reference:
      *      Emit</a>
      */
     @Override
@@ -37,7 +37,7 @@ public class HelloMessagingFlow extends Flow {
         return FlowWorkflowBuilder.workflow("hello-messaging-flow")
                 // We are listening to one and only one event coming to our broker with the type "io.quarkiverse.flow.messaging.hello.request"
                 // Each event produced by the broker with this type will kick a new workflow instance.
-                // To learn more see the base specification: https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#listen
+                // To learn more see the base specification: https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#listen
                 .tasks(listen(toOne("io.quarkiverse.flow.messaging.hello.request").first()),
                         // "name" is expected in the message body payload
                         set("{ message: \"Hello \" + .name + \"!\" }"),

--- a/messaging/integration-tests/src/main/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlow.java
+++ b/messaging/integration-tests/src/main/java/io/quarkiverse/flow/messaging/it/HelloMessagingFlow.java
@@ -27,9 +27,11 @@ public class HelloMessagingFlow extends Flow {
      * <p/>
      * To know more about the infrastructure configuration, please see the application.properties and the tests in this module.
      *
-     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#listen">DSL Reference:
+     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#listen">DSL
+     *      Reference:
      *      Listen</a>
-     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#emit">DSL Reference:
+     * @see <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#emit">DSL
+     *      Reference:
      *      Emit</a>
      */
     @Override

--- a/messaging/integration-tests/src/main/java/io/quarkiverse/flow/messaging/it/HelloMessagingWorkflowStarter.java
+++ b/messaging/integration-tests/src/main/java/io/quarkiverse/flow/messaging/it/HelloMessagingWorkflowStarter.java
@@ -18,13 +18,13 @@ import io.quarkus.runtime.Quarkus;
  * It will keep listening to the event and once it does, it runs the workflow and exit gracefully.
  * <p/>
  * To keep creating workflow instances per event, we should use the `on`, as
- * <a href="https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#schedule">described in the spec</a>:
+ * <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#schedule">described in the spec</a>:
  * <p/>
  * "Schedule: Specifies the events that trigger the workflow execution."
  * <p/>
  * The "Schedule" implementation is not yet ready on our core CNCF engine. Once it does, we can rely on it instead of the
  * Application Lifecycle. See: <a href=
- * "https://github.com/serverlessworkflow/sdk-java/issues/847">https://github.com/serverlessworkflow/sdk-java/issues/847</a>
+ * "https://github.com/open-workflow-specification/sdk-java/issues/847">https://github.com/open-workflow-specification/sdk-java/issues/847</a>
  * <p/>
  * The example below, works great for functions/serverless environments where the system process once and terminates.
  */

--- a/messaging/integration-tests/src/main/java/io/quarkiverse/flow/messaging/it/HelloMessagingWorkflowStarter.java
+++ b/messaging/integration-tests/src/main/java/io/quarkiverse/flow/messaging/it/HelloMessagingWorkflowStarter.java
@@ -18,7 +18,8 @@ import io.quarkus.runtime.Quarkus;
  * It will keep listening to the event and once it does, it runs the workflow and exit gracefully.
  * <p/>
  * To keep creating workflow instances per event, we should use the `on`, as
- * <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#schedule">described in the spec</a>:
+ * <a href="https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#schedule">described in the
+ * spec</a>:
  * <p/>
  * "Schedule: Specifies the events that trigger the workflow execution."
  * <p/>

--- a/messaging/integration-tests/src/main/resources/application.properties
+++ b/messaging/integration-tests/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 # flow-out and flow-in channels are automatically registered in the classpath as long as `quarkus-messaging`
 # is included in the classpath and this property is set to true.
-# Alternatively, you may implement your own EventConsumer and EventProducer interfaces from the CNCF Java SDK
+# Alternatively, you may implement your own EventConsumer and EventProducer interfaces from the Open Workflow Java SDK
 # to customize your channel creation and messaging handling.
 quarkus.flow.messaging.defaults-enabled=true
 # optionally, you may enable lifecycle events from the engine.
-# see: https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#lifecycle-events
+# see: https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#lifecycle-events
 quarkus.flow.messaging.lifecycle-enabled=true
 
 # Configure channels (connector, topic/queue, codecs)

--- a/oidc/README.md
+++ b/oidc/README.md
@@ -6,7 +6,7 @@ Delegates OAuth2 / OIDC **token negotiation** in Quarkus Flow workflows to
 When a workflow call declares an OAuth2/OIDC authentication — inline on the call
 (`FlowDSL.oauth2(...)` / `FlowDSL.oidc(...)`) or once under
 `use(use -> use.authentications("name", auth -> auth.oauth2(...)))` and referenced by name — this
-extension obtains the access token through a Quarkus `OidcClient` and lets the Serverless Workflow
+extension obtains the access token through a Quarkus `OidcClient` and lets the Open Workflow
 engine attach it as `Authorization: Bearer <token>` to the downstream HTTP/OpenAPI call. Supported
 grants: **client credentials**, **password**, **refresh** and **token exchange** (the per-execution
 subject/actor tokens are resolved from the workflow context and passed as dynamic grant parameters).
@@ -26,7 +26,7 @@ pulled in and activated automatically as soon as `io.quarkus:quarkus-oidc-client
 
 When active, a `WorkflowApplicationBuilderCustomizer` installs an `AuthProviderFactory` backed by
 `OidcClient`. Basic, bearer and digest authentication — and OAuth2/OIDC policies the extension does not
-yet handle — fall back to the Serverless Workflow SDK's default provider.
+yet handle — fall back to the Open Workflow SDK's default provider.
 
 ## Configuration
 

--- a/oidc/runtime/src/main/java/io/quarkiverse/flow/oidc/FlowOidcConfig.java
+++ b/oidc/runtime/src/main/java/io/quarkiverse/flow/oidc/FlowOidcConfig.java
@@ -18,7 +18,7 @@ public interface FlowOidcConfig {
 
     /**
      * Whether OAuth2/OIDC token negotiation should be delegated to {@code quarkus-oidc-client}. When disabled, the
-     * Serverless Workflow SDK falls back to its own token negotiation.
+     * Open Workflow SDK falls back to its own token negotiation.
      */
     @WithDefault("true")
     boolean enabled();

--- a/oidc/runtime/src/main/java/io/quarkiverse/flow/oidc/impl/OidcAuthProviderFactory.java
+++ b/oidc/runtime/src/main/java/io/quarkiverse/flow/oidc/impl/OidcAuthProviderFactory.java
@@ -27,7 +27,7 @@ import io.serverlessworkflow.impl.auth.OAuthPolicyData;
  * <p>
  * <b>Lifecycle & Timing:</b>
  * <p>
- * This factory is called by the Serverless Workflow SDK <b>once at application startup</b> per workflow,
+ * This factory is called by the Open Workflow SDK <b>once at application startup</b> per workflow,
  * not per HTTP request. When {@link #getAuth} is called:
  * <ol>
  * <li>Static OIDC clients (policies without runtime expressions) are registered eagerly via

--- a/oidc/runtime/src/main/java/io/quarkiverse/flow/oidc/registry/EndpointKey.java
+++ b/oidc/runtime/src/main/java/io/quarkiverse/flow/oidc/registry/EndpointKey.java
@@ -69,13 +69,13 @@ public record EndpointKey(
         List<String> audiences) {
 
     /**
-     * Default OAuth2 token endpoint path per CNCF Serverless Workflow specification.
+     * Default OAuth2 token endpoint path per Open Workflow Specification.
      * Applied when endpoints.token is not explicitly specified.
      */
     private static final String DEFAULT_TOKEN_PATH = "/oauth2/token";
 
     /**
-     * Default OAuth2 revocation endpoint path per CNCF Serverless Workflow specification.
+     * Default OAuth2 revocation endpoint path per Open Workflow Specification.
      * Applied when endpoints.revocation is not explicitly specified.
      */
     private static final String DEFAULT_REVOCATION_PATH = "/oauth2/revoke";

--- a/oidc/runtime/src/main/java/io/quarkiverse/flow/oidc/registry/OidcClientConfigFactory.java
+++ b/oidc/runtime/src/main/java/io/quarkiverse/flow/oidc/registry/OidcClientConfigFactory.java
@@ -19,19 +19,19 @@ final class OidcClientConfigFactory {
     private static final Logger LOG = LoggerFactory.getLogger(OidcClientConfigFactory.class);
 
     /**
-     * Default OAuth2 token endpoint path per CNCF Serverless Workflow specification.
+     * Default OAuth2 token endpoint path per Open Workflow Specification.
      * Used when endpoints.token is not explicitly specified in OAuth2 authentication.
      */
     private static final String DEFAULT_TOKEN_PATH = "/oauth2/token";
 
     /**
-     * Default OAuth2 revocation endpoint path per CNCF Serverless Workflow specification.
+     * Default OAuth2 revocation endpoint path per Open Workflow Specification.
      * Used when endpoints.revocation is not explicitly specified in OAuth2 authentication.
      */
     private static final String DEFAULT_REVOCATION_PATH = "/oauth2/revoke";
 
     /**
-     * Default OAuth2 introspection endpoint path per CNCF Serverless Workflow specification.
+     * Default OAuth2 introspection endpoint path per Open Workflow Specification.
      * Not used - Quarkus OIDC Client does not support introspection configuration.
      */
     private static final String DEFAULT_INTROSPECTION_PATH = "/oauth2/introspect";
@@ -60,8 +60,8 @@ final class OidcClientConfigFactory {
     }
 
     /**
-     * Maps the policy's client authentication scheme to the way Quarkus sends the client credentials. The Serverless
-     * Workflow default is {@code client_secret_post} (credentials in the request body), so we default to {@code POST}
+     * Maps the policy's client authentication scheme to the way Quarkus sends the client credentials. The Open Workflow
+     * Specification default is {@code client_secret_post} (credentials in the request body), so we default to {@code POST}
      * rather than Quarkus' own {@code client_secret_basic} default. {@code PRIVATE_KEY_JWT} relies on an asymmetric signing
      * key (not a shared client secret) and cannot be honoured from a policy that only carries a {@code secret}, so it is
      * rejected explicitly instead of being silently downgraded to a {@code client_secret_jwt} (HMAC) assertion.

--- a/runner/app/src/main/k8s/README.md
+++ b/runner/app/src/main/k8s/README.md
@@ -140,4 +140,4 @@ Multiple ConfigMaps can be mounted to the same directory.
 
 - [Quarkus Flow Documentation](https://docs.quarkiverse.io/quarkus-flow/dev/)
 - [Durable Kubernetes Module](https://docs.quarkiverse.io/quarkus-flow/dev/durable-kubernetes.html)
-- [CNCF Serverless Workflow Spec](https://serverlessworkflow.io/)
+- [Open Workflow Spec](https://open-workflow-specification.org/)

--- a/runner/app/src/main/resources/META-INF/resources/index.html
+++ b/runner/app/src/main/resources/META-INF/resources/index.html
@@ -454,7 +454,7 @@
 
         <div class="section">
             <p style="color: var(--lumo-secondary-text-color); margin-bottom: 20px;">
-                Serverless Workflow Engine for Quarkus. This page provides real-time monitoring and access to workflow management APIs.
+                Open Workflow Engine for Quarkus. This page provides real-time monitoring and access to workflow management APIs.
             </p>
         </div>
 

--- a/runner/app/workflows/README.md
+++ b/runner/app/workflows/README.md
@@ -39,7 +39,7 @@ curl -X POST http://localhost:8080/q/flow/exec/examples/hello-world/1.0.0 \
 
 ## Workflow Format
 
-Workflows must follow the [CNCF Serverless Workflow DSL 1.0.0](https://serverlessworkflow.io/) specification.
+Workflows must follow the [Open Workflow DSL 1.0.0](https://open-workflow-specification.org/) specification.
 
 **Minimal example:**
 ```yaml
@@ -187,4 +187,4 @@ This will:
 - [DOCKER-COMPOSE.md](../DOCKER-COMPOSE.md) - Docker Compose deployment guide
 - [README.md](../README.md) - Runner documentation
 - [Quarkus Flow Documentation](https://docs.quarkiverse.io/quarkus-flow/dev/)
-- [CNCF Serverless Workflow Spec](https://serverlessworkflow.io/)
+- [Open Workflow Spec](https://open-workflow-specification.org/)


### PR DESCRIPTION
## Description

Rename-only PR to update our documentation and codebase to the new specification name. See: https://openworkflow.cloud/blog/general/announcing-rename-to-open-workflow-specification/

## Changes

<!-- List the main changes in this PR -->

- Documentation
- Codebase
- URLs

