### PR TITLE
Fix PoolController double-suffixing user-provided scheduler delays

### DIFF
--- a/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/PoolController.java
+++ b/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/PoolController.java
@@ -37,9 +37,10 @@ public abstract class PoolController implements Runnable {
     protected String computeSchedulerDelay() {
         String schedulerInitialDelay = schedulerConfig().initialDelay();
         if (SchedulerGroupConfig.SCHEDULER_INITIAL_DELAY_DEFAULT.equals(schedulerInitialDelay)) {
-            schedulerInitialDelay = String.format("%ds", ThreadLocalRandom.current().nextInt(5, 11));
-        } else {
-            schedulerInitialDelay = String.format("%ss", schedulerInitialDelay);
+            return String.format("%ds", ThreadLocalRandom.current().nextInt(5, 11));
+        }
+        if (schedulerInitialDelay.matches("\\d+")) {
+            return schedulerInitialDelay + "s";
         }
         return schedulerInitialDelay;
     }

--- a/durable-kubernetes/runtime/src/test/java/io/quarkiverse/flow/durable/kube/PoolControllerDelayTest.java
+++ b/durable-kubernetes/runtime/src/test/java/io/quarkiverse/flow/durable/kube/PoolControllerDelayTest.java
@@ -1,0 +1,82 @@
+package io.quarkiverse.flow.durable.kube;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.inject.Vetoed;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.flow.durable.kube.config.LeaseGroupConfig;
+import io.quarkiverse.flow.durable.kube.config.SchedulerGroupConfig;
+
+/**
+ * Tests for {@link PoolController#computeSchedulerDelay()}.
+ */
+class PoolControllerDelayTest {
+
+    @Vetoed
+    static class TestablePoolController extends PoolController {
+
+        private final SchedulerGroupConfig.SchedulerConfig schedulerConfig;
+
+        TestablePoolController(SchedulerGroupConfig.SchedulerConfig schedulerConfig) {
+            this.schedulerConfig = schedulerConfig;
+        }
+
+        @Override
+        protected String scheduledExecutorName() {
+            return "test";
+        }
+
+        @Override
+        protected String leaseName() {
+            return null;
+        }
+
+        @Override
+        protected SchedulerGroupConfig.SchedulerConfig schedulerConfig() {
+            return schedulerConfig;
+        }
+
+        @Override
+        protected LeaseGroupConfig.LeaseConfig leaseConfig() {
+            return null;
+        }
+
+        @Override
+        public void run() {
+        }
+    }
+
+    private static SchedulerGroupConfig.SchedulerConfig configWithDelay(String delay) {
+        return new SchedulerGroupConfig.SchedulerConfig() {
+            @Override
+            public String interval() {
+                return "30s";
+            }
+
+            @Override
+            public String initialDelay() {
+                return delay;
+            }
+        };
+    }
+
+    @Test
+    void computeSchedulerDelay_numeric_input_adds_suffix() {
+        TestablePoolController controller = new TestablePoolController(configWithDelay("10"));
+
+        String delay = controller.computeSchedulerDelay();
+
+        assertEquals("10s", delay);
+    }
+
+    @Test
+    void computeSchedulerDelay_suffixed_input_preserves_suffix() {
+        TestablePoolController controller = new TestablePoolController(configWithDelay("10s"));
+
+        String delay = controller.computeSchedulerDelay();
+
+        assertEquals("10s", delay);
+    }
+}


### PR DESCRIPTION
`computeSchedulerDelay()` unconditionally wrapped user input with `String.format("%ss", ...)`, producing invalid durations like "10ss" when the value already had a unit suffix. Only append "s" when the input is purely numeric; pass through values with existing suffixes.

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
