### PR TITLE
Fix #843 - Watch source path for new workflow definitions at runtime

### DIFF
--- a/adr/2026-08-14-runtime-file-watcher-new-workflows.md
+++ b/adr/2026-08-14-runtime-file-watcher-new-workflows.md
@@ -1,0 +1,189 @@
+# Runtime File Watcher for New Workflow Definitions - Design Specification
+
+**Date:** 2026-08-14  
+**Status:** Proposed  
+**Issue:** [#843](https://github.com/quarkiverse/quarkus-flow/issues/843)  
+**Related:** [#842](https://github.com/quarkiverse/quarkus-flow/issues/842) (update/remove — requires SDK changes)
+
+## Overview
+
+Add an opt-in polling-based file watcher to the `runner/runtime` module that monitors the `quarkus.flow.runner.source.path` directory for new workflow definition files and registers them automatically, without requiring a pod restart.
+
+This covers **new file detection only**. Updating or removing existing definitions requires upstream SDK changes to `WorkflowApplication` (tracked in #842).
+
+## Goals
+
+1. **Live detection:** Detect new workflow files added to the configured source path after application startup
+2. **Automatic registration:** Parse and register new workflows via existing `WorkflowRegistrarService`
+3. **Kubernetes-native:** Work correctly with ConfigMap volume mounts (symlink-based rotation)
+4. **Opt-in:** Disabled by default for library users; enabled by default in the runner container image
+5. **Error resilient:** Malformed files are skipped with a warning, never crash the watcher
+
+## Non-Goals
+
+- Detecting modified workflow files (requires SDK `replaceWorkflowDefinition` — see #842)
+- Detecting removed workflow files (requires SDK `removeWorkflowDefinition` — see #842)
+- Real-time / event-driven detection (inotify/WatchService unreliable with K8s symlinks)
+
+## Context
+
+### Current Behavior
+
+`WorkflowDefinitionRuntimeLoader` performs a one-time `Files.walk()` scan at startup, triggered by `WorkflowApplicationReadyEvent`. After startup, no further scanning occurs. In Kubernetes, when a new `LogicFlowDefinition` CR is created, the operator updates the ConfigMap, Kubernetes writes the new file to disk, but the runner never picks it up.
+
+### Why Polling Over WatchService
+
+Kubernetes ConfigMap volume mounts use a symlink-based rotation mechanism (`..data` -> `..2024_01_01_...` -> actual files). Java's `WatchService` (backed by `inotify` on Linux) does not reliably fire events when the symlink target rotates. The existing `followSymlinks` config property in the source config already acknowledges this constraint. Polling with `Files.walk()` is the reliable approach.
+
+### Why the SDK Supports New Registrations
+
+`WorkflowApplication.workflowDefinition(Workflow)` uses `computeIfAbsent` on a `ConcurrentHashMap`. Registering a new workflow ID works correctly — the method creates and returns a new `WorkflowDefinition`. Only replacing or removing an existing ID is unsupported (tracked in #842).
+
+## Configuration
+
+### Build-Time Property
+
+New build-time config class `FlowRunnerSourceWatchConfig` with its own prefix `quarkus.flow.runner.source.watch` (separate from the runtime `FlowRunnerConfig` prefix to avoid SmallRye Config conflicts between phases, following the same pattern as `durable-kubernetes` which uses `quarkus.flow.durable.kube.local` for build-time and `quarkus.flow.durable.kube` for runtime):
+
+| Property | Type | Default | Phase | Description |
+|---|---|---|---|---|
+| `quarkus.flow.runner.source.watch.enabled` | `boolean` | `false` | `BUILD_TIME` | Enable/disable the file watcher |
+
+### Runtime Property
+
+Added to existing `FlowRunnerConfig.Source` as a nested `Watch` interface. Note: this shares the `quarkus.flow.runner.source.watch` namespace with the build-time config above, but SmallRye Config handles this correctly when the prefixes are at different nesting levels — the build-time config owns `quarkus.flow.runner.source.watch.enabled` directly via its root prefix, while the runtime config reaches `quarkus.flow.runner.source.watch.interval` through the nested `Source.Watch` interface under the `quarkus.flow.runner` root:
+
+| Property | Type | Default | Phase | Description |
+|---|---|---|---|---|
+| `quarkus.flow.runner.source.watch.interval` | `String` | `5s` | `RUN_TIME` | Polling interval (Quarkus scheduler format) |
+
+### Runner App Defaults
+
+In `runner/app/src/main/resources/application.properties`:
+
+```properties
+quarkus.flow.runner.source.watch.enabled=true
+```
+
+The container image builds with watching enabled. Library users (adding the extension to their own app) get the default `false` and must opt in explicitly.
+
+## Architecture
+
+### Components
+
+**`WorkflowFileWatcher`** — new bean in `runner/runtime`:
+- `@ApplicationScoped`, `@Unremovable`
+- Only registered when `watch.enabled=true` (gated by `@IfBuildProperty` in the deployment processor)
+- Observes `WorkflowApplicationReadyEvent` to start watching after the initial load completes
+- Uses the Quarkus programmatic `Scheduler` API (same pattern as `PoolController` in `durable-kubernetes`)
+
+**`FlowRunnerSourceWatchConfig`** — new build-time config class in `runner/runtime`:
+- `@ConfigRoot(phase = BUILD_TIME)`, `@ConfigMapping(prefix = "quarkus.flow.runner.source.watch")`
+- Holds the `enabled` property
+
+**`FlowRunnerProcessor`** — updated deployment processor:
+- New `@BuildStep` gated with `@IfBuildProperty(name = "quarkus.flow.runner.source.watch.enabled", stringValue = "true")`
+- Registers `WorkflowFileWatcher` as an additional bean
+- Produces `ForceStartSchedulerBuildItem` to ensure the Quarkus scheduler infrastructure is started
+
+### Interaction with Existing Components
+
+The `WorkflowFileWatcher` is **decoupled** from `WorkflowDefinitionRuntimeLoader`. The watcher builds its own baseline `Set<Path>` of known files via an initial `Files.walk()` when it starts. This keeps the two beans independent — the watcher works even if someone uses a different loading mechanism at startup.
+
+Both beans share the same `WorkflowRegistrarService` for registration and read from the same `FlowRunnerConfig` for source path and symlink settings.
+
+### OpenAPI Integration
+
+No changes needed to `WorkflowOpenApiFilter`. The filter uses `RunStage.RUNTIME_PER_REQUEST`, meaning it reads from `WorkflowApplication.workflowDefinitions()` on every OpenAPI document request. Newly registered workflows are automatically included in the OpenAPI document the next time it is fetched (e.g., reloading Swagger UI).
+
+### Lifecycle
+
+```
+App starts
+  -> WorkflowDefinitionRuntimeLoader.onStart(WorkflowApplicationReadyEvent)
+       -> one-time Files.walk() + register all found workflows
+  -> WorkflowFileWatcher.onStart(WorkflowApplicationReadyEvent)
+       -> initial Files.walk() to build baseline Set<Path>
+       -> schedule periodic job via Scheduler API
+  -> [every interval]
+       -> WorkflowFileWatcher.poll()
+            -> Files.walk() -> find new paths not in knownFiles
+            -> for each new file: parse, validate, register, add to knownFiles
+  -> @PreDestroy
+       -> unschedule the job
+```
+
+## Watcher Logic
+
+Each poll cycle:
+
+1. `Files.walk(basePath)` with `FileVisitOption.FOLLOW_LINKS` if `followSymlinks` is enabled
+2. Filter for regular files with supported extensions (`.yaml`, `.yml`, `.json`)
+3. Compare against `knownFiles: Set<Path>` — any path not in the set is new
+4. For each new file:
+   a. Parse with `WorkflowReader.readWorkflow(path)`
+   b. Validate required fields (`namespace`, `name`, `version`)
+   c. Check for duplicate `WorkflowDefinitionId` against already-registered definitions via `WorkflowApplication.workflowDefinitions()`
+   d. Register via `WorkflowRegistrarService.register(workflow)`
+   e. Add path to `knownFiles`
+   f. Log at `INFO`: registered workflow `namespace:name:version` from `path`
+5. If parsing/validation fails: log at `WARN` and skip the file (do not add to `knownFiles` so it is retried next cycle)
+
+### Error Resilience
+
+- **Malformed files**: `WorkflowReader` throws `IOException` — caught, logged as WARN, file skipped. The file is NOT added to `knownFiles`, so the next poll retries it (handles partially-written files during ConfigMap rotation).
+- **Missing required fields**: caught, logged as WARN, file skipped (also retried).
+- **Duplicate workflow ID**: a new file with the same `namespace:name:version` as an already-registered workflow is skipped with a WARN (unlike the startup loader which throws `IllegalStateException`).
+- **Directory disappears**: `Files.walk()` throws `IOException` — caught, logged as WARN, poll cycle skipped. Watcher continues on next interval.
+
+### Scheduler Job Configuration
+
+- Job identity: `"flow-runner-file-watcher"`
+- Concurrent execution: `Scheduled.ConcurrentExecution.SKIP` (prevent stacking if a poll takes longer than the interval)
+- Interval: from runtime config `quarkus.flow.runner.source.watch.interval`
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `runner/runtime/pom.xml` | Add `quarkus-scheduler` dependency |
+| `runner/deployment/pom.xml` | Add `quarkus-scheduler-deployment` dependency |
+| `runner/runtime/.../FlowRunnerSourceWatchConfig.java` | **New** — build-time config with `source.watch.enabled` |
+| `runner/runtime/.../FlowRunnerConfig.java` | Add `Watch` interface inside `Source` with `interval` property |
+| `runner/runtime/.../WorkflowFileWatcher.java` | **New** — polling watcher bean |
+| `runner/deployment/.../FlowRunnerProcessor.java` | Add conditional build step for watcher + `ForceStartSchedulerBuildItem` |
+| `runner/app/.../application.properties` | Add `quarkus.flow.runner.source.watch.enabled=true` |
+| `runner/runtime/src/test/.../WorkflowFileWatcherTest.java` | **New** — unit tests |
+| `runner/integration-tests/...` | New integration test for end-to-end verification |
+
+## Testing Strategy
+
+### Unit Tests
+
+In `runner/runtime/src/test/java/`, following existing `WorkflowDefinitionRuntimeLoaderTest` patterns (Mockito + `@TempDir`):
+
+- `test_watcher_detects_new_yaml_file` — add a file after baseline, verify registration
+- `test_watcher_detects_new_files_in_subdirectory` — recursive scanning
+- `test_watcher_ignores_already_known_files` — baseline files not re-registered
+- `test_watcher_ignores_unsupported_extensions` — `.txt`, `.xml` skipped
+- `test_watcher_skips_malformed_files_without_crashing` — bad YAML logs warning, watcher continues
+- `test_watcher_skips_duplicate_workflow_id` — duplicate `namespace:name:version` skipped with warning
+- `test_watcher_detects_multiple_new_files_in_single_poll` — batch detection
+
+### Integration Test
+
+In `runner/integration-tests/`: verify the full lifecycle — app starts with watch enabled, a new workflow file is written to the source path after startup, and within the poll interval it becomes queryable via the `/q/flow/definitions` REST endpoint.
+
+## Alternatives Considered
+
+### ScheduledExecutorService (manual threading)
+
+Use `java.util.concurrent.ScheduledExecutorService` directly instead of Quarkus Scheduler. Zero new dependencies, but requires manual thread lifecycle management and doesn't integrate with Quarkus scheduler subsystem. Rejected because `quarkus-scheduler` is already used in other modules (`scheduler/memory`, `durable-kubernetes`).
+
+### Vert.x setPeriodic
+
+Use `Vertx.setPeriodic()` since Vert.x is transitively available. However, `Files.walk()` is blocking I/O and running it on a Vert.x event loop thread is incorrect — would require `executeBlocking()` adding unnecessary complexity.
+
+### Java WatchService
+
+Use `java.nio.file.WatchService` for event-driven file detection. More efficient (no polling), but unreliable with Kubernetes ConfigMap volume mounts due to symlink-based rotation not triggering `inotify` events consistently.

--- a/docs/modules/ROOT/pages/includes/quarkus-flow-runner.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-runner.adoc
@@ -7,6 +7,31 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-flow-runner_quarkus-flow-runner-source-watch-enabled]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-source-watch-enabled[`+++quarkus.flow.runner.source.watch.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.runner.source.watch.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable or disable the file watcher on the source path directory.
+
+When enabled, the runner periodically polls the configured `quarkus.flow.runner.source.path` directory for new workflow definition files and registers them automatically without requiring a pod restart.
+
+This is a build-time property. Changing it requires a rebuild.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SOURCE_WATCH_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_RUNNER_SOURCE_WATCH_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a| [[quarkus-flow-runner_quarkus-flow-runner-enabled]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-enabled[`+++quarkus.flow.runner.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.runner.enabled+++[]
@@ -90,6 +115,31 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
+a| [[quarkus-flow-runner_quarkus-flow-runner-source-watch-interval]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-source-watch-interval[`+++quarkus.flow.runner.source.watch.interval+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.runner.source.watch.interval+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Polling interval for detecting new workflow files.
+
+Uses Quarkus scheduler interval format (e.g., `"5s"`, `"10s"`, `"1m"`).
+
+This is a runtime property and can be changed without rebuilding the application.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SOURCE_WATCH_INTERVAL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_RUNNER_SOURCE_WATCH_INTERVAL+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++5s+++`
+
 a| [[quarkus-flow-runner_quarkus-flow-runner-security-type]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-type[`+++quarkus.flow.runner.security.type+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.runner.security.type+++[]
@@ -116,91 +166,6 @@ endif::add-copy-button-to-env-var[]
 --
 a|`oidc`, `api-key`, `none`
 |`+++none+++`
-
-a| [[quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-secret]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-secret[`+++quarkus.flow.runner.security.api-keys."api-keys".secret+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.runner.security.api-keys."api-keys".secret+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The API key secret value.
-
-Should be loaded from environment variables or Kubernetes Secrets:
-
-```
-quarkus.flow.runner.security.api-keys."my-key".secret=${FLOW_API_KEY}
-```
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__SECRET+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__SECRET+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|required icon:exclamation-circle[title=Configuration property is required]
-
-a| [[quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-roles]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-roles[`+++quarkus.flow.runner.security.api-keys."api-keys".roles+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.runner.security.api-keys."api-keys".roles+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Roles assigned to this API key.
-
-Predefined roles:
-
- - `flow-admin` - Full access (definition management {plus} execution)
- - `flow-invoker` - Execution only (POST/GET /runner/exec/++*++)
-
-
-
-Example:
-
-```
-quarkus.flow.runner.security.api-keys."admin-key".roles=flow-admin
-quarkus.flow.runner.security.api-keys."webhook-key".roles=flow-invoker
-```
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__ROLES+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__ROLES+++`
-endif::add-copy-button-to-env-var[]
---
-|list of string
-|required icon:exclamation-circle[title=Configuration property is required]
-
-a| [[quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-namespaces]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-namespaces[`+++quarkus.flow.runner.security.api-keys."api-keys".namespaces+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.runner.security.api-keys."api-keys".namespaces+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Namespaces authorized for this API key.
-
-The value `"++*++"` grants access to all namespaces. When omitted, this property defaults to `"++*++"` for backward compatibility.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__NAMESPACES+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__NAMESPACES+++`
-endif::add-copy-button-to-env-var[]
---
-|list of string
-|`+++*+++`
 
 a| [[quarkus-flow-runner_quarkus-flow-runner-security-namespace-claim]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-namespace-claim[`+++quarkus.flow.runner.security.namespace.claim+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -317,6 +282,91 @@ endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++true+++`
+
+a| [[quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-secret]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-secret[`+++quarkus.flow.runner.security.api-keys."api-keys".secret+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.runner.security.api-keys."api-keys".secret+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The API key secret value.
+
+Should be loaded from environment variables or Kubernetes Secrets:
+
+```
+quarkus.flow.runner.security.api-keys."my-key".secret=${FLOW_API_KEY}
+```
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__SECRET+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__SECRET+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-roles]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-roles[`+++quarkus.flow.runner.security.api-keys."api-keys".roles+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.runner.security.api-keys."api-keys".roles+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Roles assigned to this API key.
+
+Predefined roles:
+
+ - `flow-admin` - Full access (definition management {plus} execution)
+ - `flow-invoker` - Execution only (POST/GET /runner/exec/++*++)
+
+
+
+Example:
+
+```
+quarkus.flow.runner.security.api-keys."admin-key".roles=flow-admin
+quarkus.flow.runner.security.api-keys."webhook-key".roles=flow-invoker
+```
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__ROLES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__ROLES+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-namespaces]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-namespaces[`+++quarkus.flow.runner.security.api-keys."api-keys".namespaces+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.runner.security.api-keys."api-keys".namespaces+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Namespaces authorized for this API key.
+
+The value `"++*++"` grants access to all namespaces. When omitted, this property defaults to `"++*++"` for backward compatibility.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__NAMESPACES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__NAMESPACES+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|`+++*+++`
 
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-flow-runner_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-runner_quarkus.flow.adoc
@@ -7,6 +7,31 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-flow-runner_quarkus-flow-runner-source-watch-enabled]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-source-watch-enabled[`+++quarkus.flow.runner.source.watch.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.runner.source.watch.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable or disable the file watcher on the source path directory.
+
+When enabled, the runner periodically polls the configured `quarkus.flow.runner.source.path` directory for new workflow definition files and registers them automatically without requiring a pod restart.
+
+This is a build-time property. Changing it requires a rebuild.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SOURCE_WATCH_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_RUNNER_SOURCE_WATCH_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a| [[quarkus-flow-runner_quarkus-flow-runner-enabled]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-enabled[`+++quarkus.flow.runner.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.runner.enabled+++[]
@@ -90,6 +115,31 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
+a| [[quarkus-flow-runner_quarkus-flow-runner-source-watch-interval]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-source-watch-interval[`+++quarkus.flow.runner.source.watch.interval+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.runner.source.watch.interval+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Polling interval for detecting new workflow files.
+
+Uses Quarkus scheduler interval format (e.g., `"5s"`, `"10s"`, `"1m"`).
+
+This is a runtime property and can be changed without rebuilding the application.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SOURCE_WATCH_INTERVAL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_RUNNER_SOURCE_WATCH_INTERVAL+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++5s+++`
+
 a| [[quarkus-flow-runner_quarkus-flow-runner-security-type]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-type[`+++quarkus.flow.runner.security.type+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.runner.security.type+++[]
@@ -116,91 +166,6 @@ endif::add-copy-button-to-env-var[]
 --
 a|`oidc`, `api-key`, `none`
 |`+++none+++`
-
-a| [[quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-secret]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-secret[`+++quarkus.flow.runner.security.api-keys."api-keys".secret+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.runner.security.api-keys."api-keys".secret+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The API key secret value.
-
-Should be loaded from environment variables or Kubernetes Secrets:
-
-```
-quarkus.flow.runner.security.api-keys."my-key".secret=${FLOW_API_KEY}
-```
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__SECRET+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__SECRET+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|required icon:exclamation-circle[title=Configuration property is required]
-
-a| [[quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-roles]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-roles[`+++quarkus.flow.runner.security.api-keys."api-keys".roles+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.runner.security.api-keys."api-keys".roles+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Roles assigned to this API key.
-
-Predefined roles:
-
- - `flow-admin` - Full access (definition management {plus} execution)
- - `flow-invoker` - Execution only (POST/GET /runner/exec/++*++)
-
-
-
-Example:
-
-```
-quarkus.flow.runner.security.api-keys."admin-key".roles=flow-admin
-quarkus.flow.runner.security.api-keys."webhook-key".roles=flow-invoker
-```
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__ROLES+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__ROLES+++`
-endif::add-copy-button-to-env-var[]
---
-|list of string
-|required icon:exclamation-circle[title=Configuration property is required]
-
-a| [[quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-namespaces]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-namespaces[`+++quarkus.flow.runner.security.api-keys."api-keys".namespaces+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.flow.runner.security.api-keys."api-keys".namespaces+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Namespaces authorized for this API key.
-
-The value `"++*++"` grants access to all namespaces. When omitted, this property defaults to `"++*++"` for backward compatibility.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__NAMESPACES+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__NAMESPACES+++`
-endif::add-copy-button-to-env-var[]
---
-|list of string
-|`+++*+++`
 
 a| [[quarkus-flow-runner_quarkus-flow-runner-security-namespace-claim]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-namespace-claim[`+++quarkus.flow.runner.security.namespace.claim+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -317,6 +282,91 @@ endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++true+++`
+
+a| [[quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-secret]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-secret[`+++quarkus.flow.runner.security.api-keys."api-keys".secret+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.runner.security.api-keys."api-keys".secret+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The API key secret value.
+
+Should be loaded from environment variables or Kubernetes Secrets:
+
+```
+quarkus.flow.runner.security.api-keys."my-key".secret=${FLOW_API_KEY}
+```
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__SECRET+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__SECRET+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-roles]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-roles[`+++quarkus.flow.runner.security.api-keys."api-keys".roles+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.runner.security.api-keys."api-keys".roles+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Roles assigned to this API key.
+
+Predefined roles:
+
+ - `flow-admin` - Full access (definition management {plus} execution)
+ - `flow-invoker` - Execution only (POST/GET /runner/exec/++*++)
+
+
+
+Example:
+
+```
+quarkus.flow.runner.security.api-keys."admin-key".roles=flow-admin
+quarkus.flow.runner.security.api-keys."webhook-key".roles=flow-invoker
+```
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__ROLES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__ROLES+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-namespaces]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-api-keys-api-keys-namespaces[`+++quarkus.flow.runner.security.api-keys."api-keys".namespaces+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.runner.security.api-keys."api-keys".namespaces+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Namespaces authorized for this API key.
+
+The value `"++*++"` grants access to all namespaces. When omitted, this property defaults to `"++*++"` for backward compatibility.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__NAMESPACES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__API_KEYS__NAMESPACES+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|`+++*+++`
 
 |===
 

--- a/docs/modules/ROOT/pages/reference-runner-images.adoc
+++ b/docs/modules/ROOT/pages/reference-runner-images.adoc
@@ -487,6 +487,8 @@ volumes:
     name: my-workflows
 ----
 
+TIP: The pre-built Runner images have the **file watcher enabled by default** (`quarkus.flow.runner.source.watch.enabled=true`). When you add new workflow files to a mounted ConfigMap, the Runner detects and registers them automatically within the polling interval (default: 5s) — no pod restart required. See xref:runner.adoc#_file_watcher_for_live_workflow_loading[File watcher for live workflow loading] for details.
+
 **Multiple ConfigMaps** can be mounted to the same directory - create separate workflow ConfigMaps per team/namespace and mount them all:
 
 [source,yaml]

--- a/docs/modules/ROOT/pages/runner.adoc
+++ b/docs/modules/ROOT/pages/runner.adoc
@@ -72,6 +72,35 @@ NOTE: On Kubernetes, ConfigMap and Secret volume mounts use an internal symlink 
 By default, the Runner **skips symbolic links** during directory scanning to prevent duplicate workflow detection failures.
 If your workflow files are intentionally provided via symbolic links outside of a Kubernetes volume mount, set `quarkus.flow.runner.source.follow-symlinks=true`.
 
+=== File watcher for live workflow loading
+
+By default, the Runner loads workflow definitions once at startup. You can enable a **file watcher** that periodically polls the source path for new workflow files and registers them automatically — without requiring a pod restart.
+
+.application.properties
+[source,properties]
+----
+# Enable the file watcher (build-time property, default: false)
+quarkus.flow.runner.source.watch.enabled=true
+
+# Polling interval (runtime property, default: 5s)
+quarkus.flow.runner.source.watch.interval=5s
+----
+
+When enabled, the watcher:
+
+* Polls the configured `source.path` directory at the specified interval
+* Detects new `.yaml`, `.yml`, and `.json` files (including in subdirectories)
+* Parses and registers new workflow definitions via the same mechanism as startup loading
+* Caches already-processed files to avoid re-parsing on every poll cycle
+* Skips malformed files with a warning and retries them on the next cycle (handles partially-written files during ConfigMap rotation)
+* Respects the `follow-symlinks` setting
+
+NOTE: The `watch.enabled` property is a **build-time** property — changing it requires a rebuild. The `watch.interval` property is a **runtime** property and can be changed without rebuilding.
+
+IMPORTANT: The file watcher currently supports detecting **new** workflow files only. Updating or removing existing workflow definitions at runtime requires an application restart. See link:https://github.com/quarkiverse/quarkus-flow/issues/842[issue #842] for future support.
+
+TIP: The pre-built Runner container images (`quay.io/quarkiverse/quarkus-flow-runner`) have the file watcher **enabled by default**, since they target Kubernetes deployments where ConfigMap updates are common.
+
 **Local development setup:**
 
 Create a `workflows/` directory in your project:
@@ -719,7 +748,7 @@ document:
 ----
 
 2. Update the ConfigMap or volume with the new file
-3. Restart the Runner application (or implement hot-reload in future versions)
+3. If the file watcher is enabled, the new version is picked up automatically; otherwise restart the Runner
 4. New executions automatically use version `2.1.0`
 5. Old executions on version `2.0.0` continue running normally
 
@@ -809,13 +838,19 @@ quarkus.flow.runner.source.path=/deployments/workflows
 quarkus.flow.runner.security.type=API_KEY
 quarkus.flow.runner.security.api-keys.default.secret=${FLOW_API_KEY}
 quarkus.flow.runner.security.api-keys.default.roles=flow-admin
+
+# Enable file watcher to pick up new workflows without pod restart
+quarkus.flow.runner.source.watch.enabled=true
+quarkus.flow.runner.source.watch.interval=5s
 ----
+
+TIP: With the file watcher enabled, adding a new workflow definition to the ConfigMap does **not** require a pod restart — the Runner detects and registers the new file automatically within the configured polling interval.
 
 **GitOps workflow:**
 
 1. Store workflow definitions in a Git repository
 2. Use a GitOps operator (Flux, ArgoCD) to sync workflows to ConfigMaps
-3. ConfigMap changes trigger Rolling Update of the Runner deployment
+3. With the file watcher enabled, new workflow definitions are picked up automatically — no Rolling Update needed for additions
 4. New versions become available automatically
 
 == Troubleshooting

--- a/runner/app/src/main/resources/application.properties
+++ b/runner/app/src/main/resources/application.properties
@@ -32,6 +32,13 @@ quarkus.swagger-ui.always-include=true
 quarkus.flow.runner.openapi.expand-workflows=true
 
 # ----------------------------------------------------------------------------
+# File Watcher
+# ----------------------------------------------------------------------------
+# Watch the source path for new workflow definitions (e.g., from ConfigMap updates)
+# and register them without requiring a pod restart
+quarkus.flow.runner.source.watch.enabled=true
+
+# ----------------------------------------------------------------------------
 # Structured Logging
 # ----------------------------------------------------------------------------
 # Enable structured JSON logging for workflow events

--- a/runner/deployment/pom.xml
+++ b/runner/deployment/pom.xml
@@ -37,6 +37,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-swagger-ui-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-scheduler-deployment</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/runner/deployment/src/main/java/io/quarkiverse/flow/runner/deployment/FlowRunnerProcessor.java
+++ b/runner/deployment/src/main/java/io/quarkiverse/flow/runner/deployment/FlowRunnerProcessor.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.flow.runner.deployment;
 
+import io.quarkiverse.flow.runner.FlowRunnerSourceWatchConfig;
+import io.quarkiverse.flow.runner.WorkflowFileWatcher;
 import io.quarkiverse.flow.runner.model.ExecutionResponse;
 import io.quarkiverse.flow.runner.model.Link;
 import io.quarkiverse.flow.runner.model.Links;
@@ -9,9 +11,11 @@ import io.quarkiverse.flow.runner.security.NamespaceAuthorizationFilter;
 import io.quarkiverse.flow.runner.security.NamespaceAuthorizationService;
 import io.quarkiverse.flow.runner.security.PermitAllAuthenticationMechanism;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.scheduler.deployment.ForceStartSchedulerBuildItem;
 
 class FlowRunnerProcessor {
 
@@ -35,12 +39,24 @@ class FlowRunnerProcessor {
 
     @BuildStep
     ReflectiveClassBuildItem registerForReflection() {
-        // Register model classes for reflection (JSON serialization)
         return ReflectiveClassBuildItem.builder(
                 ExecutionResponse.class,
                 WorkflowDefinitionHeader.class,
                 Link.class,
                 Links.class).methods().fields().build();
+    }
+
+    @BuildStep
+    void registerFileWatcher(FlowRunnerSourceWatchConfig watchConfig,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            BuildProducer<ForceStartSchedulerBuildItem> forceScheduler) {
+        if (watchConfig.enabled()) {
+            additionalBeans.produce(AdditionalBeanBuildItem.builder()
+                    .setUnremovable()
+                    .addBeanClass(WorkflowFileWatcher.class)
+                    .build());
+            forceScheduler.produce(new ForceStartSchedulerBuildItem());
+        }
     }
 
 }

--- a/runner/runtime/pom.xml
+++ b/runner/runtime/pom.xml
@@ -38,6 +38,10 @@
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-scheduler</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/FlowRunnerConfig.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/FlowRunnerConfig.java
@@ -119,6 +119,37 @@ public interface FlowRunnerConfig {
          */
         @WithDefault("false")
         Boolean followSymlinks();
+
+        /**
+         * File watcher runtime configuration.
+         *
+         * @return the watch configuration
+         */
+        Watch watch();
+
+        /**
+         * Runtime configuration for the file watcher polling interval.
+         * <p>
+         * The watcher itself is enabled/disabled at build time via
+         * {@code quarkus.flow.runner.source.watch.enabled} (see
+         * {@link FlowRunnerSourceWatchConfig}).
+         */
+        interface Watch {
+
+            /**
+             * Polling interval for detecting new workflow files.
+             * <p>
+             * Uses Quarkus scheduler interval format (e.g., {@code "5s"},
+             * {@code "10s"}, {@code "1m"}).
+             * <p>
+             * This is a runtime property and can be changed without rebuilding
+             * the application.
+             *
+             * @return the polling interval (default: 5s)
+             */
+            @WithDefault("5s")
+            String interval();
+        }
     }
 
     /**

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/FlowRunnerSourceWatchConfig.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/FlowRunnerSourceWatchConfig.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.flow.runner;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+@ConfigMapping(prefix = "quarkus.flow.runner.source.watch")
+public interface FlowRunnerSourceWatchConfig {
+
+    /**
+     * Enable or disable the file watcher on the source path directory.
+     * <p>
+     * When enabled, the runner periodically polls the configured
+     * {@code quarkus.flow.runner.source.path} directory for new workflow
+     * definition files and registers them automatically without requiring
+     * a pod restart.
+     * <p>
+     * This is a build-time property. Changing it requires a rebuild.
+     *
+     * @return {@code true} to enable file watching, {@code false} to disable (default)
+     */
+    @WithDefault("false")
+    boolean enabled();
+}

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/WorkflowDefinitionRuntimeLoader.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/WorkflowDefinitionRuntimeLoader.java
@@ -74,26 +74,43 @@ public class WorkflowDefinitionRuntimeLoader {
         }
 
         final List<WorkflowDefinitionId> workflowDefinitionIds = new ArrayList<>();
-        try (Stream<Path> paths = config.source().followSymlinks() ? Files.walk(basePath, FileVisitOption.FOLLOW_LINKS).sorted()
+        for (Path path : scanWorkflowFiles()) {
+            final WorkflowDefinitionId defId = loadWorkflow(path);
+            workflowDefinitionIds.stream().filter(addedId -> addedId.equals(defId)).findFirst().ifPresent(duplicatedId -> {
+                throw new IllegalStateException(
+                        String.format("Duplicated workflow definition (%s) found in path %s", defId.toString(":"), path));
+            });
+            workflowDefinitionIds.add(defId);
+        }
+        return workflowDefinitionIds;
+    }
+
+    /**
+     * Scans the configured source path and returns all supported workflow file paths.
+     * Respects the {@code followSymlinks} configuration.
+     *
+     * @return list of workflow file paths, or empty list if the path is not configured or invalid
+     */
+    List<Path> scanWorkflowFiles() {
+        if (config.source().path().isEmpty()) {
+            return List.of();
+        }
+        Path basePath = Path.of(config.source().path().get());
+        if (!Files.exists(basePath) || !Files.isDirectory(basePath)) {
+            return List.of();
+        }
+        try (Stream<Path> paths = config.source().followSymlinks()
+                ? Files.walk(basePath, FileVisitOption.FOLLOW_LINKS).sorted()
                 : Files.walk(basePath).sorted()) {
-            var workflows = paths
+            return paths
                     .filter(Files::isRegularFile)
                     .filter(this::isSupportedWorkflowFile)
                     .filter(f -> !Files.isSymbolicLink(f) || config.source().followSymlinks())
                     .toList();
-
-            for (Path path : workflows) {
-                final WorkflowDefinitionId defId = loadWorkflow(path);
-                workflowDefinitionIds.stream().filter(addedId -> addedId.equals(defId)).findFirst().ifPresent(duplicatedId -> {
-                    throw new IllegalStateException(
-                            String.format("Duplicated workflow definition (%s) found in path %s", defId.toString(":"), path));
-                });
-                workflowDefinitionIds.add(defId);
-            }
         } catch (IOException e) {
-            throw new UncheckedIOException("Flow Runner: Failed to scan workflow directory: " + basePath, e);
+            LOGGER.warn("Flow Runner: Failed to scan workflow directory {}: {}", basePath, e.getMessage());
+            return List.of();
         }
-        return workflowDefinitionIds;
     }
 
     private boolean isSupportedWorkflowFile(Path path) {
@@ -104,10 +121,8 @@ public class WorkflowDefinitionRuntimeLoader {
 
     private WorkflowDefinitionId loadWorkflow(Path path) {
         try {
-            // WorkflowReader auto-detects format from file extension
             Workflow workflow = WorkflowReader.readWorkflow(path);
 
-            // Validate required fields
             if (workflow.getDocument().getNamespace() == null || workflow.getDocument().getName() == null
                     || workflow.getDocument().getVersion() == null) {
                 throw new IllegalStateException(
@@ -115,7 +130,6 @@ public class WorkflowDefinitionRuntimeLoader {
                                 path));
             }
 
-            // Register with WorkflowApplication - creates WorkflowDefinition
             registrarService.register(workflow);
 
             LOGGER.debug("Flow Runner: Registered workflow {}:{}:{} from {}",

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/WorkflowDefinitionRuntimeLoader.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/WorkflowDefinitionRuntimeLoader.java
@@ -108,8 +108,7 @@ public class WorkflowDefinitionRuntimeLoader {
                     .filter(f -> !Files.isSymbolicLink(f) || config.source().followSymlinks())
                     .toList();
         } catch (IOException e) {
-            LOGGER.warn("Flow Runner: Failed to scan workflow directory {}: {}", basePath, e.getMessage());
-            return List.of();
+            throw new UncheckedIOException("Flow Runner: Failed to scan workflow directory: " + basePath, e);
         }
     }
 

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/WorkflowFileWatcher.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/WorkflowFileWatcher.java
@@ -1,0 +1,128 @@
+package io.quarkiverse.flow.runner;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkiverse.flow.internal.WorkflowApplicationReadyEvent;
+import io.quarkiverse.flow.internal.WorkflowRegistrarService;
+import io.quarkus.arc.Unremovable;
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.Scheduler;
+import io.serverlessworkflow.api.WorkflowReader;
+import io.serverlessworkflow.api.types.Workflow;
+import io.serverlessworkflow.impl.WorkflowApplication;
+import io.serverlessworkflow.impl.WorkflowDefinitionId;
+
+@ApplicationScoped
+@Unremovable
+public class WorkflowFileWatcher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowFileWatcher.class.getName());
+    static final String JOB_IDENTITY = "flow-runner-file-watcher";
+
+    @Inject
+    WorkflowRegistrarService registrarService;
+
+    @Inject
+    WorkflowApplication application;
+
+    @Inject
+    WorkflowDefinitionRuntimeLoader loader;
+
+    @Inject
+    FlowRunnerConfig config;
+
+    @Inject
+    Scheduler scheduler;
+
+    final Map<Path, WorkflowDefinitionId> registeredFiles = new HashMap<>();
+    private volatile boolean active = false;
+
+    void onStart(@Observes WorkflowApplicationReadyEvent ev) {
+        if (config.source().path().isEmpty()) {
+            LOGGER.debug("Flow Runner: File watcher skipped — source path not configured");
+            return;
+        }
+
+        buildBaseline();
+
+        scheduler.newJob(JOB_IDENTITY)
+                .setInterval(config.source().watch().interval())
+                .setConcurrentExecution(Scheduled.ConcurrentExecution.SKIP)
+                .setTask(executionContext -> poll())
+                .schedule();
+
+        active = true;
+        LOGGER.info("Flow Runner: File watcher started — monitoring {} with interval {} ({} files in baseline)",
+                config.source().path().get(), config.source().watch().interval(), registeredFiles.size());
+    }
+
+    @PreDestroy
+    void stop() {
+        if (active) {
+            scheduler.unscheduleJob(JOB_IDENTITY);
+            LOGGER.debug("Flow Runner: File watcher stopped");
+        }
+    }
+
+    void buildBaseline() {
+        for (Path path : loader.scanWorkflowFiles()) {
+            registeredFiles.put(path, null);
+        }
+    }
+
+    void poll() {
+        List<Path> currentFiles = loader.scanWorkflowFiles();
+
+        for (Path path : currentFiles) {
+            if (!registeredFiles.containsKey(path)) {
+                tryRegisterNewFile(path);
+            }
+        }
+    }
+
+    private void tryRegisterNewFile(Path path) {
+        try {
+            Workflow workflow = WorkflowReader.readWorkflow(path);
+
+            if (workflow.getDocument().getNamespace() == null || workflow.getDocument().getName() == null
+                    || workflow.getDocument().getVersion() == null) {
+                LOGGER.warn("Flow Runner: File watcher — skipping {} — missing required fields (namespace, name, or version)",
+                        path);
+                return;
+            }
+
+            WorkflowDefinitionId defId = WorkflowDefinitionId.of(workflow);
+
+            if (application.workflowDefinitions().containsKey(defId)) {
+                LOGGER.warn("Flow Runner: File watcher — skipping {} — workflow {} is already registered",
+                        path, defId.toString(":"));
+                registeredFiles.put(path, defId);
+                return;
+            }
+
+            registrarService.register(workflow);
+            registeredFiles.put(path, defId);
+
+            LOGGER.info("Flow Runner: File watcher — registered new workflow {} from {}",
+                    defId.toString(":"), path);
+        } catch (IOException e) {
+            LOGGER.warn("Flow Runner: File watcher — failed to parse {} — will retry next cycle: {}",
+                    path, e.getMessage());
+        } catch (Exception e) {
+            LOGGER.warn("Flow Runner: File watcher — unexpected error processing {}: {}",
+                    path, e.getMessage());
+        }
+    }
+}

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/WorkflowFileWatcher.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/WorkflowFileWatcher.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.flow.runner;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
@@ -50,6 +51,10 @@ public class WorkflowFileWatcher {
     private volatile boolean active = false;
 
     void onStart(@Observes WorkflowApplicationReadyEvent ev) {
+        if (!config.enabled()) {
+            LOGGER.debug("Flow Runner: File watcher skipped — runner is disabled");
+            return;
+        }
         if (config.source().path().isEmpty()) {
             LOGGER.debug("Flow Runner: File watcher skipped — source path not configured");
             return;
@@ -83,7 +88,13 @@ public class WorkflowFileWatcher {
     }
 
     void poll() {
-        List<Path> currentFiles = loader.scanWorkflowFiles();
+        List<Path> currentFiles;
+        try {
+            currentFiles = loader.scanWorkflowFiles();
+        } catch (UncheckedIOException e) {
+            LOGGER.warn("Flow Runner: File watcher — failed to scan directory: {}", e.getMessage());
+            return;
+        }
 
         for (Path path : currentFiles) {
             if (!registeredFiles.containsKey(path)) {

--- a/runner/runtime/src/test/java/io/quarkiverse/flow/runner/WorkflowFileWatcherTest.java
+++ b/runner/runtime/src/test/java/io/quarkiverse/flow/runner/WorkflowFileWatcherTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -20,10 +21,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import io.quarkiverse.flow.internal.WorkflowApplicationReadyEvent;
 import io.quarkiverse.flow.internal.WorkflowRegistrarService;
+import io.quarkus.scheduler.Scheduler;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.impl.WorkflowApplication;
 import io.serverlessworkflow.impl.WorkflowDefinition;
+import io.serverlessworkflow.impl.WorkflowDefinitionId;
 
 @DisplayName("WorkflowFileWatcher Tests")
 class WorkflowFileWatcherTest {
@@ -235,6 +239,38 @@ class WorkflowFileWatcherTest {
         watcher.poll();
 
         verify(mockRegistrar, never()).register(any(Workflow.class));
+    }
+
+    @Test
+    @DisplayName("test_watcher_skips_already_registered_workflow_id")
+    void test_watcher_skips_already_registered_workflow_id() throws IOException {
+        Files.writeString(tempDir.resolve("duplicate.yaml"),
+                WORKFLOW_YAML_TEMPLATE.formatted("test-ns", "already-registered", "1.0.0"));
+
+        WorkflowDefinitionId existingId = new WorkflowDefinitionId("test-ns", "already-registered", "1.0.0");
+        when(mockApplication.workflowDefinitions()).thenReturn(Map.of(existingId, mock(WorkflowDefinition.class)));
+
+        watcher.poll();
+
+        verify(mockRegistrar, never()).register(any(Workflow.class));
+        assertThat(watcher.registeredFiles).containsKey(tempDir.resolve("duplicate.yaml"));
+    }
+
+    @Test
+    @DisplayName("test_watcher_does_not_start_when_runner_disabled")
+    void test_watcher_does_not_start_when_runner_disabled() throws IOException {
+        when(mockConfig.enabled()).thenReturn(false);
+
+        Scheduler mockScheduler = mock(Scheduler.class);
+        watcher.scheduler = mockScheduler;
+
+        Files.writeString(tempDir.resolve("new-workflow.yaml"),
+                WORKFLOW_YAML_TEMPLATE.formatted("test-ns", "new-workflow", "1.0.0"));
+
+        watcher.onStart(new WorkflowApplicationReadyEvent("test"));
+
+        verify(mockScheduler, never()).newJob(any());
+        assertThat(watcher.registeredFiles).isEmpty();
     }
 
     @Test

--- a/runner/runtime/src/test/java/io/quarkiverse/flow/runner/WorkflowFileWatcherTest.java
+++ b/runner/runtime/src/test/java/io/quarkiverse/flow/runner/WorkflowFileWatcherTest.java
@@ -1,0 +1,273 @@
+package io.quarkiverse.flow.runner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkiverse.flow.internal.WorkflowRegistrarService;
+import io.serverlessworkflow.api.types.Workflow;
+import io.serverlessworkflow.impl.WorkflowApplication;
+import io.serverlessworkflow.impl.WorkflowDefinition;
+
+@DisplayName("WorkflowFileWatcher Tests")
+class WorkflowFileWatcherTest {
+
+    @TempDir
+    Path tempDir;
+
+    private WorkflowFileWatcher watcher;
+    private WorkflowDefinitionRuntimeLoader loader;
+    private WorkflowRegistrarService mockRegistrar;
+    private WorkflowApplication mockApplication;
+    private FlowRunnerConfig mockConfig;
+    private FlowRunnerConfig.Source mockSource;
+
+    private static final String WORKFLOW_YAML_TEMPLATE = """
+            document:
+              dsl: '1.0.0'
+              namespace: %s
+              name: %s
+              version: '%s'
+            do:
+              - setMessage:
+                  set:
+                    message: "Hello"
+            """;
+
+    @BeforeEach
+    void setUp() {
+        watcher = new WorkflowFileWatcher();
+        loader = new WorkflowDefinitionRuntimeLoader();
+        mockRegistrar = mock(WorkflowRegistrarService.class);
+        mockApplication = mock(WorkflowApplication.class);
+        mockConfig = mock(FlowRunnerConfig.class);
+        mockSource = mock(FlowRunnerConfig.Source.class);
+
+        loader.registrarService = mockRegistrar;
+        loader.config = mockConfig;
+
+        watcher.registrarService = mockRegistrar;
+        watcher.application = mockApplication;
+        watcher.loader = loader;
+        watcher.config = mockConfig;
+
+        when(mockConfig.source()).thenReturn(mockSource);
+        when(mockConfig.enabled()).thenReturn(true);
+        when(mockSource.path()).thenReturn(Optional.of(tempDir.toString()));
+        when(mockSource.followSymlinks()).thenReturn(false);
+        when(mockApplication.workflowDefinitions()).thenReturn(Collections.emptyMap());
+
+        WorkflowDefinition mockDefinition = mock(WorkflowDefinition.class);
+        when(mockRegistrar.register(any(Workflow.class))).thenReturn(mockDefinition);
+    }
+
+    @Test
+    @DisplayName("test_watcher_detects_new_yaml_file")
+    void test_watcher_detects_new_yaml_file() throws IOException {
+        Files.writeString(tempDir.resolve("new-workflow.yaml"),
+                WORKFLOW_YAML_TEMPLATE.formatted("test-ns", "new-workflow", "1.0.0"));
+
+        watcher.poll();
+
+        verify(mockRegistrar, times(1)).register(any(Workflow.class));
+        assertThat(watcher.registeredFiles).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("test_watcher_detects_new_yml_file")
+    void test_watcher_detects_new_yml_file() throws IOException {
+        Files.writeString(tempDir.resolve("new-workflow.yml"),
+                WORKFLOW_YAML_TEMPLATE.formatted("test-ns", "yml-workflow", "1.0.0"));
+
+        watcher.poll();
+
+        verify(mockRegistrar, times(1)).register(any(Workflow.class));
+    }
+
+    @Test
+    @DisplayName("test_watcher_detects_new_json_file")
+    void test_watcher_detects_new_json_file() throws IOException {
+        String workflowJson = """
+                {
+                  "document": {
+                    "dsl": "1.0.0",
+                    "namespace": "test-ns",
+                    "name": "json-workflow",
+                    "version": "1.0.0"
+                  },
+                  "do": [
+                    {
+                      "setMessage": {
+                        "set": {
+                          "message": "Hello from JSON"
+                        }
+                      }
+                    }
+                  ]
+                }
+                """;
+        Files.writeString(tempDir.resolve("new-workflow.json"), workflowJson);
+
+        watcher.poll();
+
+        verify(mockRegistrar, times(1)).register(any(Workflow.class));
+    }
+
+    @Test
+    @DisplayName("test_watcher_detects_new_files_in_subdirectory")
+    void test_watcher_detects_new_files_in_subdirectory() throws IOException {
+        Path subDir = tempDir.resolve("subdir");
+        Files.createDirectories(subDir);
+        Files.writeString(subDir.resolve("sub-workflow.yaml"),
+                WORKFLOW_YAML_TEMPLATE.formatted("test-ns", "sub-workflow", "1.0.0"));
+
+        watcher.poll();
+
+        verify(mockRegistrar, times(1)).register(any(Workflow.class));
+    }
+
+    @Test
+    @DisplayName("test_watcher_does_not_reparse_already_registered_files")
+    void test_watcher_does_not_reparse_already_registered_files() throws IOException {
+        Files.writeString(tempDir.resolve("existing.yaml"),
+                WORKFLOW_YAML_TEMPLATE.formatted("test-ns", "existing", "1.0.0"));
+
+        watcher.poll();
+        verify(mockRegistrar, times(1)).register(any(Workflow.class));
+
+        watcher.poll();
+        // Still only 1 call — file is in the cache, never re-parsed
+        verify(mockRegistrar, times(1)).register(any(Workflow.class));
+    }
+
+    @Test
+    @DisplayName("test_baseline_prevents_parsing_startup_files")
+    void test_baseline_prevents_parsing_startup_files() throws IOException {
+        Files.writeString(tempDir.resolve("startup.yaml"),
+                WORKFLOW_YAML_TEMPLATE.formatted("test-ns", "startup", "1.0.0"));
+
+        watcher.buildBaseline();
+        assertThat(watcher.registeredFiles).hasSize(1);
+
+        watcher.poll();
+        // File was in baseline — never parsed or registered by the watcher
+        verify(mockRegistrar, never()).register(any(Workflow.class));
+    }
+
+    @Test
+    @DisplayName("test_watcher_ignores_unsupported_extensions")
+    void test_watcher_ignores_unsupported_extensions() throws IOException {
+        Files.writeString(tempDir.resolve("readme.txt"), "Not a workflow");
+        Files.writeString(tempDir.resolve("config.xml"), "<config/>");
+        Files.writeString(tempDir.resolve("data.csv"), "a,b,c");
+
+        watcher.poll();
+
+        verify(mockRegistrar, never()).register(any(Workflow.class));
+        assertThat(watcher.registeredFiles).isEmpty();
+    }
+
+    @Test
+    @DisplayName("test_watcher_skips_malformed_files_without_crashing")
+    void test_watcher_skips_malformed_files_without_crashing() throws IOException {
+        Files.writeString(tempDir.resolve("bad.yaml"), "this is not valid workflow yaml");
+
+        watcher.poll();
+
+        verify(mockRegistrar, never()).register(any(Workflow.class));
+        assertThat(watcher.registeredFiles).doesNotContainKey(tempDir.resolve("bad.yaml"));
+    }
+
+    @Test
+    @DisplayName("test_watcher_detects_multiple_new_files_in_single_poll")
+    void test_watcher_detects_multiple_new_files_in_single_poll() throws IOException {
+        Files.writeString(tempDir.resolve("workflow-1.yaml"),
+                WORKFLOW_YAML_TEMPLATE.formatted("test-ns", "workflow-1", "1.0.0"));
+        Files.writeString(tempDir.resolve("workflow-2.yaml"),
+                WORKFLOW_YAML_TEMPLATE.formatted("test-ns", "workflow-2", "1.0.0"));
+        Files.writeString(tempDir.resolve("workflow-3.yml"),
+                WORKFLOW_YAML_TEMPLATE.formatted("test-ns", "workflow-3", "1.0.0"));
+
+        watcher.poll();
+
+        verify(mockRegistrar, times(3)).register(any(Workflow.class));
+        assertThat(watcher.registeredFiles).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("test_watcher_retries_malformed_file_on_next_poll")
+    void test_watcher_retries_malformed_file_on_next_poll() throws IOException {
+        Path workflowFile = tempDir.resolve("fixing.yaml");
+        Files.writeString(workflowFile, "invalid yaml content");
+
+        watcher.poll();
+        verify(mockRegistrar, never()).register(any(Workflow.class));
+
+        Files.writeString(workflowFile,
+                WORKFLOW_YAML_TEMPLATE.formatted("test-ns", "fixed-workflow", "1.0.0"));
+
+        watcher.poll();
+        verify(mockRegistrar, times(1)).register(any(Workflow.class));
+        assertThat(watcher.registeredFiles).containsKey(workflowFile);
+    }
+
+    @Test
+    @DisplayName("test_watcher_handles_empty_source_path_gracefully")
+    void test_watcher_handles_empty_source_path_gracefully() {
+        when(mockSource.path()).thenReturn(Optional.empty());
+
+        watcher.poll();
+
+        verify(mockRegistrar, never()).register(any(Workflow.class));
+    }
+
+    @Test
+    @DisplayName("test_scanner_returns_supported_files_only")
+    void test_scanner_returns_supported_files_only() throws IOException {
+        Files.writeString(tempDir.resolve("valid.yaml"),
+                WORKFLOW_YAML_TEMPLATE.formatted("test-ns", "valid", "1.0.0"));
+        Files.writeString(tempDir.resolve("also-valid.json"), "{}");
+        Files.writeString(tempDir.resolve("not-valid.txt"), "text");
+
+        List<Path> files = loader.scanWorkflowFiles();
+
+        assertThat(files).hasSize(2);
+        assertThat(files).allMatch(p -> p.toString().endsWith(".yaml") || p.toString().endsWith(".json"));
+    }
+
+    @Test
+    @DisplayName("test_scanner_returns_empty_for_missing_path")
+    void test_scanner_returns_empty_for_missing_path() {
+        when(mockSource.path()).thenReturn(Optional.of("/nonexistent/path"));
+
+        List<Path> files = loader.scanWorkflowFiles();
+
+        assertThat(files).isEmpty();
+    }
+
+    @Test
+    @DisplayName("test_scanner_returns_empty_when_path_not_configured")
+    void test_scanner_returns_empty_when_path_not_configured() {
+        when(mockSource.path()).thenReturn(Optional.empty());
+
+        List<Path> files = loader.scanWorkflowFiles();
+
+        assertThat(files).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a polling-based file watcher (`WorkflowFileWatcher`) that detects new workflow files dropped into the configured source path without requiring a pod restart
- Uses Quarkus Scheduler for polling instead of `WatchService`, which is unreliable on Kubernetes where ConfigMap volume mounts rotate via symlinks
- Build-time config `quarkus.flow.runner.source.watch.enabled` (default `false`) controls bean registration; runtime config `quarkus.flow.runner.source.watch.interval` (default `5s`) controls poll frequency
- Maintains a `Map<Path, WorkflowDefinitionId>` cache to avoid re-parsing files on every poll cycle; malformed files are not cached and retried on subsequent polls
- Extracts `scanWorkflowFiles()` from `WorkflowDefinitionRuntimeLoader` so both the loader and watcher share a single scanning implementation
- Runner app (`runner/app`) enables the watcher by default for pre-built images
- Includes ADR documenting design decisions and 14 unit tests covering detection, caching, baseline, error resilience, and retry behavior
- Documentation updated in `runner.adoc` and `reference-runner-images.adoc`

Closes #843

## Test plan

- [x] 14 unit tests in `WorkflowFileWatcherTest` covering:
  - New YAML/YML/JSON file detection
  - Subdirectory scanning
  - Cache prevents re-parsing registered files
  - Baseline prevents re-registration of startup files
  - Unsupported file extensions ignored
  - Malformed files skipped without crashing
  - Multiple files detected in a single poll
  - Malformed files retried after being fixed
  - Empty/missing source path handled gracefully
  - Scanner filtering and edge cases
- [x] Full build (`make test-all`) passes all 63 modules including integration tests
- [ ] Manual verification: drop a new workflow YAML into a running runner app and confirm it becomes available via the REST API without restart