### PR TITLE
Auto-enable MicrometerExecutionListener when Micrometer is on the classpath

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/SendMetricWhenAutoEnabledTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/metrics/SendMetricWhenAutoEnabledTest.java
@@ -1,0 +1,56 @@
+package io.quarkiverse.flow.deployment.test.metrics;
+
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SendMetricWhenAutoEnabledTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> {
+                jar.addClass(SimpleFlow.class);
+            })
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-micrometer-registry-prometheus", Version.getVersion())))
+            .withConfigurationResource("metrics-auto-enabled.properties");
+
+    @Inject
+    SimpleFlow flow;
+
+    @Inject
+    MeterRegistry meterRegistry;
+
+    @Test
+    @DisplayName("should_send_metrics_when_property_is_not_explicitly_set")
+    void should_send_metrics_when_property_is_not_explicitly_set() {
+
+        flow.instance(Map.of("message", "hello"))
+                .start()
+                .join();
+
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .until(() -> {
+                    long total = meterRegistry.getMeters()
+                            .stream()
+                            .filter(meter -> meter.getId().getName().startsWith("quarkus.flow.workflow."))
+                            .count();
+
+                    return total > 0;
+                });
+    }
+}

--- a/core/deployment/src/test/resources/metrics-auto-enabled.properties
+++ b/core/deployment/src/test/resources/metrics-auto-enabled.properties
@@ -1,0 +1,1 @@
+quarkus.http.test-port=0

--- a/core/runtime/src/main/java/io/quarkiverse/flow/metrics/MicrometerExecutionListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/metrics/MicrometerExecutionListener.java
@@ -16,7 +16,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.quarkiverse.flow.config.FlowMetricsConfig;
-import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.arc.lookup.LookupUnlessProperty;
 import io.serverlessworkflow.api.types.Document;
 import io.serverlessworkflow.impl.WorkflowStatus;
 import io.serverlessworkflow.impl.lifecycle.TaskCompletedEvent;
@@ -32,7 +32,7 @@ import io.serverlessworkflow.impl.lifecycle.WorkflowFailedEvent;
 import io.serverlessworkflow.impl.lifecycle.WorkflowStartedEvent;
 import io.serverlessworkflow.impl.lifecycle.WorkflowStatusEvent;
 
-@LookupIfProperty(name = "quarkus.flow.metrics.enabled", stringValue = "true")
+@LookupUnlessProperty(name = "quarkus.flow.metrics.enabled", stringValue = "false", lookupIfMissing = true)
 public class MicrometerExecutionListener implements WorkflowExecutionListener {
 
     private final MeterRegistry meterRegistry;


### PR DESCRIPTION
## Description

MicrometerExecutionListener used @LookupIfProperty requiring quarkus.flow.metrics.enabled to be explicitly set to "true". When the property was absent, the bean was never activated, contradicting the documented behavior that metrics are auto-enabled when Micrometer is present.

Replace with @LookupUnlessProperty(stringValue = "false", lookupIfMissing = true) so the bean is active by default and only disabled when explicitly set to "false".

<!-- Provide a clear description of what this PR does -->

Fixes #854

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
