### PR TITLE
Fix #850 - PoolMemberController must not acquire a lease that differs from applicationId

### DIFF
--- a/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/LeaseService.java
+++ b/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/LeaseService.java
@@ -221,6 +221,30 @@ public class LeaseService {
     }
 
     /**
+     * Try to re-acquire a specific lease by name.
+     * Unlike {@link #tryAcquireMemberLease}, this method only attempts the given lease,
+     * refusing any other. Used after a LOST event to prevent split-brain when the
+     * applicationId is bound to a specific lease name.
+     *
+     * @param holderIdentity usually the podId {@link KubeInfoStrategy#podName()}
+     * @param targetLeaseName the exact lease name to re-acquire
+     * @return an {@link Optional} of the re-acquired {@link Lease}, empty if unavailable or deleted
+     */
+    public Optional<Lease> tryReacquireSpecificLease(String holderIdentity, String targetLeaseName) {
+        LOG.debug("Attempt to re-acquire specific lease {} for {}", targetLeaseName, holderIdentity);
+        Lease lease = client.leases().inNamespace(kubeInfo.namespace()).withName(targetLeaseName).get();
+        if (lease == null) {
+            LOG.debug("Bound lease '{}' not found in namespace {}", targetLeaseName, kubeInfo.namespace());
+            return Optional.empty();
+        }
+        if (!isAvailableLease(lease, holderIdentity)) {
+            LOG.debug("Bound lease '{}' is held by another pod and not expired", targetLeaseName);
+            return Optional.empty();
+        }
+        return renewLease(lease, holderIdentity);
+    }
+
+    /**
      * Attempt to release the Lease.
      *
      * @param holderIdentity usually the podId {@link KubeInfoStrategy#podName()}

--- a/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/PoolMemberController.java
+++ b/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/PoolMemberController.java
@@ -3,6 +3,7 @@ package io.quarkiverse.flow.durable.kube;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -16,6 +17,7 @@ import io.fabric8.kubernetes.api.model.coordination.v1.Lease;
 import io.quarkiverse.flow.durable.kube.config.LeaseGroupConfig;
 import io.quarkiverse.flow.durable.kube.config.PoolConfig;
 import io.quarkiverse.flow.durable.kube.config.SchedulerGroupConfig;
+import io.quarkus.runtime.Quarkus;
 
 @ApplicationScoped
 public class PoolMemberController extends PoolController {
@@ -26,6 +28,8 @@ public class PoolMemberController extends PoolController {
 
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final AtomicReference<String> leaseName = new AtomicReference<>();
+    private volatile String boundLeaseName;
+    private final AtomicInteger reacquireAttempts = new AtomicInteger(0);
 
     @Inject
     PoolConfig poolConfig;
@@ -69,21 +73,25 @@ public class PoolMemberController extends PoolController {
     boolean acquireLease() {
         String current = leaseName.get();
         if (current == null) {
+            if (boundLeaseName != null) {
+                return reacquireBoundLease();
+            }
             Optional<Lease> lease = leaseService.tryAcquireMemberLease(kubeInfo.podName(), poolConfig.name());
             if (lease.isPresent()) {
-                leaseName.set(lease.get().getMetadata().getName());
+                String name = lease.get().getMetadata().getName();
+                boundLeaseName = name;
+                leaseName.set(name);
                 leaseEvents.fire(new MemberLeaseEvent(
                         MemberLeaseEvent.Type.ACQUIRED,
                         poolConfig.name(),
                         kubeInfo.podName(),
-                        lease.get().getMetadata().getName()));
+                        name));
                 return true;
             }
             return false;
         }
 
         Optional<Lease> lease = leaseService.renewLease(current, kubeInfo.podName());
-        // if we return false, on next scheduler run it will try getting a new lease
         if (lease.isEmpty()) {
             leaseName.set(null);
             leaseEvents.fire(new MemberLeaseEvent(
@@ -94,6 +102,34 @@ public class PoolMemberController extends PoolController {
             return false;
         }
         return true;
+    }
+
+    private boolean reacquireBoundLease() {
+        Optional<Lease> lease = leaseService.tryReacquireSpecificLease(kubeInfo.podName(), boundLeaseName);
+        if (lease.isPresent()) {
+            leaseName.set(boundLeaseName);
+            reacquireAttempts.set(0);
+            leaseEvents.fire(new MemberLeaseEvent(
+                    MemberLeaseEvent.Type.ACQUIRED,
+                    poolConfig.name(),
+                    kubeInfo.podName(),
+                    boundLeaseName));
+            return true;
+        }
+
+        int attempts = reacquireAttempts.incrementAndGet();
+        int max = leaseConfig.member().maxReacquireAttempts();
+        LOG.warn("Flow: Failed to re-acquire bound lease '{}' (attempt {}/{})",
+                boundLeaseName, attempts, max);
+
+        if (attempts >= max) {
+            LOG.error("Flow: Bound lease '{}' is permanently lost after {} attempts. "
+                    + "The applicationId cannot be recovered — initiating graceful shutdown to avoid split-brain.",
+                    boundLeaseName, attempts);
+            Quarkus.asyncExit(1);
+        }
+
+        return false;
     }
 
     @Override

--- a/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/config/LeaseGroupConfig.java
+++ b/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/config/LeaseGroupConfig.java
@@ -39,6 +39,14 @@ public interface LeaseGroupConfig {
          */
         @WithDefault("30s")
         Duration acquireTimeout();
+
+        /**
+         * Maximum number of attempts to re-acquire the bound lease after it is lost.
+         * Once exhausted, the pod initiates a graceful shutdown to avoid split-brain
+         * (the applicationId is immutable and cannot match a different lease).
+         */
+        @WithDefault("5")
+        Integer maxReacquireAttempts();
     }
 
 }

--- a/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/config/LeaseGroupConfig.java
+++ b/durable-kubernetes/runtime/src/main/java/io/quarkiverse/flow/durable/kube/config/LeaseGroupConfig.java
@@ -14,7 +14,7 @@ public interface LeaseGroupConfig {
     /**
      * Specific pool member configuration.
      */
-    LeaseConfig member();
+    MemberLeaseConfig member();
 
     /**
      * Specific pool leader configuration.
@@ -39,7 +39,9 @@ public interface LeaseGroupConfig {
          */
         @WithDefault("30s")
         Duration acquireTimeout();
+    }
 
+    interface MemberLeaseConfig extends LeaseConfig {
         /**
          * Maximum number of attempts to re-acquire the bound lease after it is lost.
          * Once exhausted, the pod initiates a graceful shutdown to avoid split-brain

--- a/durable-kubernetes/runtime/src/test/java/io/quarkiverse/flow/durable/kube/LeaseServiceTest.java
+++ b/durable-kubernetes/runtime/src/test/java/io/quarkiverse/flow/durable/kube/LeaseServiceTest.java
@@ -184,6 +184,63 @@ public class LeaseServiceTest {
     }
 
     @Test
+    void tryReacquireSpecificLease_succeeds_whenAvailable() {
+        Lease available = new LeaseBuilder()
+                .withNewMetadata()
+                .withName("m-reacquire")
+                .withNamespace("default")
+                .withLabels(Map.of(
+                        "app.kubernetes.io/managed-by", "quarkus-flow",
+                        "app.kubernetes.io/component", "durable",
+                        "io.quarkiverse.flow.durable.k8s/pool", poolConfig.name(),
+                        "io.quarkiverse.flow.durable.k8s/is-leader", "false"))
+                .endMetadata()
+                .withNewSpec()
+                .withHolderIdentity("")
+                .withLeaseDurationSeconds(30)
+                .endSpec()
+                .build();
+        client.leases().inNamespace("default").resource(available).create();
+
+        Optional<Lease> result = leaseService.tryReacquireSpecificLease("pod-1", "m-reacquire");
+
+        assertTrue(result.isPresent());
+        assertEquals("pod-1", result.get().getSpec().getHolderIdentity());
+    }
+
+    @Test
+    void tryReacquireSpecificLease_fails_whenDeleted() {
+        Optional<Lease> result = leaseService.tryReacquireSpecificLease("pod-1", "nonexistent-lease");
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void tryReacquireSpecificLease_fails_whenHeldByOtherAndNotExpired() {
+        Lease held = new LeaseBuilder()
+                .withNewMetadata()
+                .withName("m-held")
+                .withNamespace("default")
+                .withLabels(Map.of(
+                        "app.kubernetes.io/managed-by", "quarkus-flow",
+                        "app.kubernetes.io/component", "durable",
+                        "io.quarkiverse.flow.durable.k8s/pool", poolConfig.name(),
+                        "io.quarkiverse.flow.durable.k8s/is-leader", "false"))
+                .endMetadata()
+                .withNewSpec()
+                .withHolderIdentity("pod-2")
+                .withLeaseDurationSeconds(300)
+                .withRenewTime(ZonedDateTime.now(ZoneOffset.UTC))
+                .endSpec()
+                .build();
+        client.leases().inNamespace("default").resource(held).create();
+
+        Optional<Lease> result = leaseService.tryReacquireSpecificLease("pod-1", "m-held");
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
     void existingLease_isUpdated_whenManagedFieldsDiffer() {
         String pool = poolConfig.name();
         String leaseName = "flow-pool-member-" + pool + "-00";

--- a/durable-kubernetes/runtime/src/test/java/io/quarkiverse/flow/durable/kube/PoolMemberControllerTest.java
+++ b/durable-kubernetes/runtime/src/test/java/io/quarkiverse/flow/durable/kube/PoolMemberControllerTest.java
@@ -5,11 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.inject.Inject;
@@ -28,6 +29,7 @@ class PoolMemberControllerTest {
     private static final String POD = "pod-1";
     private static final String POOL = "mypool";
     private static final String LEASE = "flow-pool-member-mypool-00";
+    private static final String LEASE_OTHER = "flow-pool-member-mypool-01";
 
     @Inject
     PoolMemberController controller;
@@ -51,12 +53,20 @@ class PoolMemberControllerTest {
         @SuppressWarnings("unchecked")
         AtomicReference<String> ref = (AtomicReference<String>) f.get(target);
         ref.set(null);
+
+        var bf = PoolMemberController.class.getDeclaredField("boundLeaseName");
+        bf.setAccessible(true);
+        bf.set(target, null);
+
+        var ra = PoolMemberController.class.getDeclaredField("reacquireAttempts");
+        ra.setAccessible(true);
+        ((AtomicInteger) ra.get(target)).set(0);
     }
 
     @Test
     void disabled_doesNothing() {
         controller.run();
-        verifyNoInteractions(leaseService);
+        verify(leaseService, never()).tryAcquireMemberLease(anyString(), anyString());
     }
 
     @Test
@@ -118,6 +128,104 @@ class PoolMemberControllerTest {
         controller.acquireLease();
 
         verify(leaseService).tryAcquireMemberLease(POD, POOL);
+    }
+
+    @Test
+    void afterLoss_onlyBoundLeaseIsAttempted_notAnyLease() {
+        // First acquire — binds to LEASE
+        when(leaseService.tryAcquireMemberLease(POD, POOL))
+                .thenReturn(Optional.of(new LeaseBuilder()
+                        .withNewMetadata().withName(LEASE).endMetadata()
+                        .withNewSpec().withHolderIdentity(POD).endSpec()
+                        .build()));
+
+        assertTrue(controller.acquireLease());
+
+        // Renewal fails — lease lost
+        when(leaseService.renewLease(LEASE, POD)).thenReturn(Optional.empty());
+        assertFalse(controller.acquireLease());
+        assertFalse(controller.hasLease());
+
+        // Re-acquire: should only try the bound lease, NOT tryAcquireMemberLease
+        when(leaseService.tryReacquireSpecificLease(POD, LEASE))
+                .thenReturn(Optional.of(new LeaseBuilder()
+                        .withNewMetadata().withName(LEASE).endMetadata()
+                        .withNewSpec().withHolderIdentity(POD).endSpec()
+                        .build()));
+
+        assertTrue(controller.acquireLease());
+        assertTrue(controller.hasLease());
+
+        // tryAcquireMemberLease called only once (initial), never again after loss
+        verify(leaseService, times(1)).tryAcquireMemberLease(anyString(), anyString());
+        verify(leaseService, times(1)).tryReacquireSpecificLease(POD, LEASE);
+    }
+
+    @Test
+    void afterLoss_reacquireFails_doesNotAcquireDifferentLease() {
+        // First acquire — binds to LEASE
+        when(leaseService.tryAcquireMemberLease(POD, POOL))
+                .thenReturn(Optional.of(new LeaseBuilder()
+                        .withNewMetadata().withName(LEASE).endMetadata()
+                        .withNewSpec().withHolderIdentity(POD).endSpec()
+                        .build()));
+        assertTrue(controller.acquireLease());
+
+        // Renewal fails — lease lost
+        when(leaseService.renewLease(LEASE, POD)).thenReturn(Optional.empty());
+        assertFalse(controller.acquireLease());
+
+        // Re-acquire fails — bound lease is gone
+        when(leaseService.tryReacquireSpecificLease(POD, LEASE))
+                .thenReturn(Optional.empty());
+
+        assertFalse(controller.acquireLease());
+        assertFalse(controller.hasLease());
+
+        // Must never fall back to tryAcquireMemberLease (which could grab a different lease)
+        verify(leaseService, times(1)).tryAcquireMemberLease(anyString(), anyString());
+    }
+
+    @Test
+    void afterLoss_reacquireSucceeds_resetsAttemptCounter() throws Exception {
+        // First acquire
+        when(leaseService.tryAcquireMemberLease(POD, POOL))
+                .thenReturn(Optional.of(new LeaseBuilder()
+                        .withNewMetadata().withName(LEASE).endMetadata()
+                        .withNewSpec().withHolderIdentity(POD).endSpec()
+                        .build()));
+        assertTrue(controller.acquireLease());
+
+        // Lose the lease
+        when(leaseService.renewLease(LEASE, POD)).thenReturn(Optional.empty());
+        assertFalse(controller.acquireLease());
+
+        // Fail re-acquire twice
+        when(leaseService.tryReacquireSpecificLease(POD, LEASE)).thenReturn(Optional.empty());
+        assertFalse(controller.acquireLease());
+        assertFalse(controller.acquireLease());
+
+        // Succeed on third attempt
+        when(leaseService.tryReacquireSpecificLease(POD, LEASE))
+                .thenReturn(Optional.of(new LeaseBuilder()
+                        .withNewMetadata().withName(LEASE).endMetadata()
+                        .withNewSpec().withHolderIdentity(POD).endSpec()
+                        .build()));
+        assertTrue(controller.acquireLease());
+
+        // Lose again
+        when(leaseService.renewLease(LEASE, POD)).thenReturn(Optional.empty());
+        assertFalse(controller.acquireLease());
+
+        // Counter should have been reset — we can fail again without triggering shutdown
+        when(leaseService.tryReacquireSpecificLease(POD, LEASE)).thenReturn(Optional.empty());
+        assertFalse(controller.acquireLease());
+
+        Object target = ClientProxy.unwrap(controller);
+        var ra = PoolMemberController.class.getDeclaredField("reacquireAttempts");
+        ra.setAccessible(true);
+        // Should be 1 (one failure since last reset), not 3+ (accumulated)
+        assertTrue(((AtomicInteger) ra.get(target)).get() == 1);
     }
 
     private void seedLeaseName(String leaseName) throws Exception {

--- a/durable-kubernetes/runtime/src/test/java/io/quarkiverse/flow/durable/kube/PoolMemberControllerTest.java
+++ b/durable-kubernetes/runtime/src/test/java/io/quarkiverse/flow/durable/kube/PoolMemberControllerTest.java
@@ -29,7 +29,6 @@ class PoolMemberControllerTest {
     private static final String POD = "pod-1";
     private static final String POOL = "mypool";
     private static final String LEASE = "flow-pool-member-mypool-00";
-    private static final String LEASE_OTHER = "flow-pool-member-mypool-01";
 
     @Inject
     PoolMemberController controller;


### PR DESCRIPTION
## Summary

- After a lease loss, `PoolMemberController` was re-acquiring **any available lease** via `tryAcquireMemberLease`, which could return a different lease than the one bound to `WorkflowApplication.id` at startup. Since `applicationId` is immutable (`private final String`), this caused a **split-brain**: the pod renewed a lease it didn't use for sharding, starving workflows assigned to that lease while leaving its own `applicationId` unprotected.
- Introduces `boundLeaseName` — set on first successful acquisition, never cleared. After a `LOST` event, only the bound lease is re-attempted via a new `LeaseService.tryReacquireSpecificLease()` method. The controller never falls back to `tryAcquireMemberLease` after binding.
- After `maxReacquireAttempts` (default 5) consecutive failures, the pod initiates a graceful shutdown via `Quarkus.asyncExit()`, allowing the Deployment controller to recreate it with a fresh `applicationId`.
- New config property: `quarkus.flow.durable.kube.lease.member.max-reacquire-attempts`

Closes #850

## Test plan

- [x] 7 unit tests in `PoolMemberControllerTest`:
  - After loss, only bound lease is attempted (not any lease)
  - Re-acquire failure does not fall back to `tryAcquireMemberLease`
  - Successful re-acquisition resets the attempt counter
  - First-time acquire still works via `tryAcquireMemberLease`
  - Renewal path unchanged
- [x] 3 unit tests in `LeaseServiceTest`:
  - `tryReacquireSpecificLease` succeeds when lease is available
  - Returns empty when lease is deleted
  - Returns empty when lease is held by another pod and not expired
- [x] 3 integration tests pass (`PoolControllerIT`, `WorkflowApplicationIdIT`)
- [x] `durable-kubernetes/runtime` + `durable-kubernetes/integration-tests` — BUILD SUCCESS