### PR TITLE
Refactor tests to remove CDI dependencies and use a plain test application provider

### DIFF
--- a/examples/resilient-task-orchestrator/src/test/java/org/acme/orchestrator/service/TaskExecutorTest.java
+++ b/examples/resilient-task-orchestrator/src/test/java/org/acme/orchestrator/service/TaskExecutorTest.java
@@ -1,7 +1,5 @@
 package org.acme.orchestrator.service;
 
-import io.quarkus.test.junit.QuarkusTest;
-import jakarta.inject.Inject;
 import org.acme.orchestrator.model.BuildTask;
 import org.acme.orchestrator.model.TaskResult;
 import org.acme.orchestrator.model.TaskState;
@@ -23,19 +21,21 @@ import static org.assertj.core.api.Assertions.assertThat;
  * - Retry behavior
  * - Phase-level resumption
  */
-@QuarkusTest
 class TaskExecutorTest {
     private static final Logger LOG = LoggerFactory.getLogger(TaskExecutorTest.class);
 
-    @Inject
-    TaskExecutor taskExecutor;
+    private TaskExecutor taskExecutor;
 
-    @Inject
-    TaskStateStore stateStore;
+    private TaskStateStore stateStore;
 
     @BeforeEach
     void setUp() {
-        stateStore.clear();
+        stateStore = new TaskStateStore();
+        taskExecutor = new TaskExecutor();
+        taskExecutor.stateStore = stateStore;
+        // Disable simulated failures and remove artificial delay for fast, deterministic unit tests
+        taskExecutor.failureRate = 0;
+        taskExecutor.delayMs = 0;
     }
 
     @Test


### PR DESCRIPTION
## Description

Converted 7 test classes from `@QuarkusTest` to plain JUnit, following the issue's
"Phase 2 (low-hanging fruit)" strategy: tests that don't need CDI injection, HTTP
endpoints, or Quarkus runtime features now run in milliseconds instead of requiring
a Quarkus boot.

Closes: #446 

## Changes

<!-- List the main changes in this PR -->

- `RuntimeSequentialAgenticFlowTest`
- `RuntimeParallelAgenticFlowTest`
- `RuntimeLoopAgenticFlowTest`
- `RuntimeConditionalAgenticFlowTest`
- `CollectionCallbackDuplicationRegressionTest`
- `FlowAgentServicesMockedTest`

A new test helper, `TestRuntimeWorkflowApplicationProvider`, replaces the CDI bean.
It builds a `WorkflowApplication` directly with the SDK builder, mirroring the two
factories the real runtime configures and that agentic workflow execution requires:

- `JavaModelFactory` as context factory (`WorkflowApplicationCreator`)
- `AgenticAwareModelFactory` as model factory
  (`FlowLangChain4jApplicationBuilderCustomizer`) — without it, Jackson cannot
  serialize `AgenticScope` and executions fail


**`examples/resilient-task-orchestrator` (1 class)**:

- `TaskExecutorTest` — was the **only** test in the module, so the conversion
  eliminates the module's entire Quarkus boot. The test lives in the same package
  as `TaskExecutor`, so it instantiates the beans with `new` and assigns the
  package-private fields directly (`failureRate = 0` mirrors the test
  `application.properties`, which already disabled simulated failures).

## What was intentionally kept as `@QuarkusTest` (27 classes)

| Group | Count | Why it must stay |
|---|---|---|
| `docs/modules/ROOT/examples/test/*` | 14 | These files **are** the documentation — they teach users how to test workflows with `@QuarkusTest` and inject `Flow` beans, events, and HTTP. |
| Example REST/gRPC tests (`agentic-http`, `http-basic-auth`, `auth-oauth2-oidc`, `grpc-client-routing`, `greeting-runner`, `opentelemetry`) | 6 | They validate the HTTP layer itself (routes, serialization, status codes, container-level auth). Testing the resource as a POJO would drop exactly the coverage that justifies the test. |
| `langchain4j/runtime` (remaining 3: `RuntimeWorkflowApplicationProviderTest`, `FlowAgentsBuilderServiceTest`, `WorkflowExecutionListenerBehaviourTest`) | 3 | They test the CDI wiring itself: synthetic/recorder-created beans (`WorkflowApplication`), build-time generated `AgenticFlow` beans via `Instance<...>`, and listener beans. |
| `runner/app` (2), `durable-kubernetes` (1), codestart template (1) | 4 | App smoke tests, Kubernetes client, and the scaffolding template generated for users. |

Quarkus already **reuses** the same running application across `@QuarkusTest`
classes in the same module when they share the same test profile/resources — it
does not restart per class. So the issue's estimate ("~100 boots × 3 s") was
overstated, and Phase 3 (grouping with `@Nested`/`@TestProfile`) would save no
boots in this repo. Real savings come from **zeroing out** `@QuarkusTest` in a
module (achieved in `resilient-task-orchestrator`) or reducing per-class work.
The remaining modules will always have at least one test that genuinely needs the
container, so one boot per module is the floor,  and the price of the integration
coverage.

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
