### PR TITLE
Fix #861 - Make security.type required and use constant-time key comparison

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-flow-durable-kubernetes.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-durable-kubernetes.adoc
@@ -114,6 +114,27 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-flow-durable-kubernetes_quarkus-flow[icon:question-circle[title=More information about the Duration format]]
 |`+++30S+++`
 
+a| [[quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-member-max-reacquire-attempts]] [.property-path]##link:#quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-member-max-reacquire-attempts[`+++quarkus.flow.durable.kube.lease.member.max-reacquire-attempts+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.durable.kube.lease.member.max-reacquire-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Maximum number of attempts to re-acquire the bound lease after it is lost. Once exhausted, the pod initiates a graceful shutdown to avoid split-brain (the applicationId is immutable and cannot match a different lease).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DURABLE_KUBE_LEASE_MEMBER_MAX_REACQUIRE_ATTEMPTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_DURABLE_KUBE_LEASE_MEMBER_MAX_REACQUIRE_ATTEMPTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++5+++`
+
 a| [[quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-leader-duration]] [.property-path]##link:#quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-leader-duration[`+++quarkus.flow.durable.kube.lease.leader.duration+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.durable.kube.lease.leader.duration+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-flow-durable-kubernetes_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-durable-kubernetes_quarkus.flow.adoc
@@ -114,6 +114,27 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-flow-durable-kubernetes_quarkus-flow[icon:question-circle[title=More information about the Duration format]]
 |`+++30S+++`
 
+a| [[quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-member-max-reacquire-attempts]] [.property-path]##link:#quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-member-max-reacquire-attempts[`+++quarkus.flow.durable.kube.lease.member.max-reacquire-attempts+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.durable.kube.lease.member.max-reacquire-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Maximum number of attempts to re-acquire the bound lease after it is lost. Once exhausted, the pod initiates a graceful shutdown to avoid split-brain (the applicationId is immutable and cannot match a different lease).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DURABLE_KUBE_LEASE_MEMBER_MAX_REACQUIRE_ATTEMPTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_DURABLE_KUBE_LEASE_MEMBER_MAX_REACQUIRE_ATTEMPTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++5+++`
+
 a| [[quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-leader-duration]] [.property-path]##link:#quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-leader-duration[`+++quarkus.flow.durable.kube.lease.leader.duration+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.durable.kube.lease.leader.duration+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-flow-runner.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-runner.adoc
@@ -165,7 +165,7 @@ Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_TYPE+++`
 endif::add-copy-button-to-env-var[]
 --
 a|`oidc`, `api-key`, `none`
-|`+++none+++`
+|required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-flow-runner_quarkus-flow-runner-security-namespace-claim]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-namespace-claim[`+++quarkus.flow.runner.security.namespace.claim+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-flow-runner_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-runner_quarkus.flow.adoc
@@ -165,7 +165,7 @@ Environment variable: `+++QUARKUS_FLOW_RUNNER_SECURITY_TYPE+++`
 endif::add-copy-button-to-env-var[]
 --
 a|`oidc`, `api-key`, `none`
-|`+++none+++`
+|required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-flow-runner_quarkus-flow-runner-security-namespace-claim]] [.property-path]##link:#quarkus-flow-runner_quarkus-flow-runner-security-namespace-claim[`+++quarkus.flow.runner.security.namespace.claim+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/runner/app/src/main/k8s/overlays/messaging/runner-messaging.yaml
+++ b/runner/app/src/main/k8s/overlays/messaging/runner-messaging.yaml
@@ -65,6 +65,9 @@ spec:
               name: http
               protocol: TCP
           env:
+            # Security (required — choose: none, api-key, oidc)
+            - name: QUARKUS_FLOW_RUNNER_SECURITY_TYPE
+              value: "none"
             # Database connection (required for JPA)
             - name: QUARKUS_DATASOURCE_JDBC_URL
               value: "jdbc:postgresql://postgresql:5432/flowdb"

--- a/runner/app/src/main/k8s/overlays/minimal/runner-minimal.yaml
+++ b/runner/app/src/main/k8s/overlays/minimal/runner-minimal.yaml
@@ -81,8 +81,10 @@ spec:
             - containerPort: 8080
               name: http
               protocol: TCP
-          # No env vars needed - defaults from classpath are safe
-          # Users can override via ConfigMap mounted to /deployments/config
+          env:
+            # Security (required — choose: none, api-key, oidc)
+            - name: QUARKUS_FLOW_RUNNER_SECURITY_TYPE
+              value: "none"
           volumeMounts:
             - name: data
               mountPath: /deployments/data

--- a/runner/app/src/main/k8s/overlays/standard/runner-standard.yaml
+++ b/runner/app/src/main/k8s/overlays/standard/runner-standard.yaml
@@ -91,6 +91,9 @@ spec:
               name: http
               protocol: TCP
           env:
+            # Security (required — choose: none, api-key, oidc)
+            - name: QUARKUS_FLOW_RUNNER_SECURITY_TYPE
+              value: "none"
             # Database connection (required for JPA)
             - name: QUARKUS_DATASOURCE_JDBC_URL
               value: "jdbc:postgresql://postgresql:5432/flowdb"

--- a/runner/app/src/main/resources/application-container.properties
+++ b/runner/app/src/main/resources/application-container.properties
@@ -18,6 +18,13 @@
 quarkus.flow.runner.source.path=/deployments/workflows
 
 # ----------------------------------------------------------------------------
+# Security
+# ----------------------------------------------------------------------------
+# Security type is required — override via QUARKUS_FLOW_RUNNER_SECURITY_TYPE env var
+# Default to none for quickstart; production deployments should use api-key or oidc
+quarkus.flow.runner.security.type=none
+
+# ----------------------------------------------------------------------------
 # Database Schema Management (JPA variants only)
 # ----------------------------------------------------------------------------
 # Auto-update database schema on startup (standard & messaging variants)

--- a/runner/app/src/main/resources/application-dev.properties
+++ b/runner/app/src/main/resources/application-dev.properties
@@ -41,3 +41,9 @@ quarkus.flow.persistence.mvstore.db-path=target/flowRunnerData.mv
 # Add your workflow YAML files to the workflows/ directory and they'll be
 # automatically loaded on startup. Changes require a restart (not hot-reloaded).
 quarkus.flow.runner.source.path=${user.dir}/workflows
+
+# ----------------------------------------------------------------------------
+# Security
+# ----------------------------------------------------------------------------
+# Disable authentication in dev mode
+quarkus.flow.runner.security.type=none

--- a/runner/app/src/test/java/io/quarkiverse/flow/runner/app/EmitEventWorkflowTest.java
+++ b/runner/app/src/test/java/io/quarkiverse/flow/runner/app/EmitEventWorkflowTest.java
@@ -93,7 +93,8 @@ class EmitEventWorkflowTest {
             String uniqueDbPath = "target/test-db-" + System.currentTimeMillis() + "-" +
                     System.nanoTime() + ".mv";
             return Map.of(
-                    "quarkus.flow.persistence.mvstore.db-path", uniqueDbPath);
+                    "quarkus.flow.persistence.mvstore.db-path", uniqueDbPath,
+                    "quarkus.flow.runner.security.type", "none");
         }
     }
 }

--- a/runner/app/src/test/java/io/quarkiverse/flow/runner/app/RunnerAppSmokeTest.java
+++ b/runner/app/src/test/java/io/quarkiverse/flow/runner/app/RunnerAppSmokeTest.java
@@ -54,7 +54,8 @@ class RunnerAppSmokeTest {
             String uniqueDbPath = "target/test-db-smoke-" + System.currentTimeMillis() + "-" +
                     System.nanoTime() + ".mv";
             return Map.of(
-                    "quarkus.flow.persistence.mvstore.db-path", uniqueDbPath);
+                    "quarkus.flow.persistence.mvstore.db-path", uniqueDbPath,
+                    "quarkus.flow.runner.security.type", "none");
         }
     }
 }

--- a/runner/app/src/test/resources/application.properties
+++ b/runner/app/src/test/resources/application.properties
@@ -16,3 +16,6 @@ quarkus.http.test-port=0
 quarkus.kubernetes-client.devservices.enabled=false
 
 quarkus.flow.persistence.mvstore.db-path=target/flowRunnerData.mv
+
+# Security type is required — set to none for tests
+quarkus.flow.runner.security.type=none

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/FlowRunnerConfig.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/FlowRunnerConfig.java
@@ -183,9 +183,8 @@ public interface FlowRunnerConfig {
          * <li>{@code NONE} - Endpoints are unprotected. Use only in development.</li>
          * </ul>
          *
-         * @return the authentication type (default: {@code NONE})
+         * @return the authentication type (required)
          */
-        @WithDefault("none")
         Type type();
 
         /**

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/security/ApiKeyAuthenticationMechanism.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/security/ApiKeyAuthenticationMechanism.java
@@ -2,6 +2,8 @@ package io.quarkiverse.flow.runner.security;
 
 import static io.quarkiverse.flow.runner.security.AuthzConsts.CLAIM_NAMESPACES;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -81,7 +83,8 @@ public class ApiKeyAuthenticationMechanism implements HttpAuthenticationMechanis
         // Find matching API key configuration
         Optional<Map.Entry<String, FlowRunnerConfig.Security.ApiKey>> matchingKey = config.security().apiKeys()
                 .entrySet().stream()
-                .filter(entry -> entry.getValue().secret().equals(apiKey))
+                .filter(entry -> MessageDigest.isEqual(entry.getValue().secret().getBytes(StandardCharsets.UTF_8),
+                        apiKey.getBytes(StandardCharsets.UTF_8)))
                 .findFirst();
 
         if (matchingKey.isPresent()) {

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/security/ApiKeyAuthenticationMechanism.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/security/ApiKeyAuthenticationMechanism.java
@@ -81,10 +81,11 @@ public class ApiKeyAuthenticationMechanism implements HttpAuthenticationMechanis
         }
 
         // Find matching API key configuration
+        final byte[] submittedKeyBytes = apiKey.getBytes(StandardCharsets.UTF_8);
         Optional<Map.Entry<String, FlowRunnerConfig.Security.ApiKey>> matchingKey = config.security().apiKeys()
                 .entrySet().stream()
                 .filter(entry -> MessageDigest.isEqual(entry.getValue().secret().getBytes(StandardCharsets.UTF_8),
-                        apiKey.getBytes(StandardCharsets.UTF_8)))
+                        submittedKeyBytes))
                 .findFirst();
 
         if (matchingKey.isPresent()) {

--- a/runner/runtime/src/test/java/io/quarkiverse/flow/runner/security/ApiKeyAuthenticationMechanismTest.java
+++ b/runner/runtime/src/test/java/io/quarkiverse/flow/runner/security/ApiKeyAuthenticationMechanismTest.java
@@ -1,0 +1,112 @@
+package io.quarkiverse.flow.runner.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.flow.runner.FlowRunnerConfig;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+
+@DisplayName("API Key authentication mechanism tests")
+class ApiKeyAuthenticationMechanismTest {
+
+    private ApiKeyAuthenticationMechanism mechanism;
+    private FlowRunnerConfig config;
+    private FlowRunnerConfig.Security security;
+    private RoutingContext routingContext;
+    private HttpServerRequest request;
+
+    private static final String VALID_KEY = "correct-api-key-secret";
+
+    @BeforeEach
+    void setUp() {
+        mechanism = new ApiKeyAuthenticationMechanism();
+
+        config = mock(FlowRunnerConfig.class);
+        security = mock(FlowRunnerConfig.Security.class);
+        routingContext = mock(RoutingContext.class);
+        request = mock(HttpServerRequest.class);
+
+        mechanism.config = config;
+
+        when(config.security()).thenReturn(security);
+        when(security.type()).thenReturn(FlowRunnerConfig.Security.Type.API_KEY);
+        when(routingContext.request()).thenReturn(request);
+
+        FlowRunnerConfig.Security.ApiKey apiKey = mock(FlowRunnerConfig.Security.ApiKey.class);
+        when(apiKey.secret()).thenReturn(VALID_KEY);
+        when(apiKey.roles()).thenReturn(Set.of(AuthzConsts.ROLE_INVOKER));
+        when(apiKey.namespaces()).thenReturn(Optional.of(Set.of("*")));
+        when(security.apiKeys()).thenReturn(Map.of("test-key", apiKey));
+    }
+
+    @Nested
+    @DisplayName("Constant-time API key comparison")
+    class TimingSafeComparison {
+
+        @Test
+        @DisplayName("valid_key_authenticates_successfully")
+        void valid_key_authenticates_successfully() {
+            when(request.getHeader("Authorization")).thenReturn("Bearer " + VALID_KEY);
+
+            SecurityIdentity identity = mechanism.authenticate(routingContext, null)
+                    .await().indefinitely();
+
+            assertThat(identity).isNotNull();
+            assertThat(identity.getPrincipal().getName()).isEqualTo("api-key:test-key");
+            assertThat(identity.getRoles()).contains(AuthzConsts.ROLE_INVOKER);
+        }
+
+        @Test
+        @DisplayName("wrong_key_with_same_length_must_be_rejected")
+        void wrong_key_with_same_length_must_be_rejected() {
+            String wrongKey = "x".repeat(VALID_KEY.length());
+            when(request.getHeader("Authorization")).thenReturn("Bearer " + wrongKey);
+
+            try {
+                mechanism.authenticate(routingContext, null).await().indefinitely();
+                assertThat(false).as("Should have thrown AuthenticationFailedException").isTrue();
+            } catch (Exception e) {
+                assertThat(e).hasMessageContaining("Invalid API key");
+            }
+        }
+
+        @Test
+        @DisplayName("wrong_key_with_different_length_must_be_rejected")
+        void wrong_key_with_different_length_must_be_rejected() {
+            when(request.getHeader("Authorization")).thenReturn("Bearer short");
+
+            try {
+                mechanism.authenticate(routingContext, null).await().indefinitely();
+                assertThat(false).as("Should have thrown AuthenticationFailedException").isTrue();
+            } catch (Exception e) {
+                assertThat(e).hasMessageContaining("Invalid API key");
+            }
+        }
+
+        @Test
+        @DisplayName("key_differing_only_in_last_character_must_be_rejected")
+        void key_differing_only_in_last_character_must_be_rejected() {
+            String almostRight = VALID_KEY.substring(0, VALID_KEY.length() - 1) + "X";
+            when(request.getHeader("Authorization")).thenReturn("Bearer " + almostRight);
+
+            try {
+                mechanism.authenticate(routingContext, null).await().indefinitely();
+                assertThat(false).as("Should have thrown AuthenticationFailedException").isTrue();
+            } catch (Exception e) {
+                assertThat(e).hasMessageContaining("Invalid API key");
+            }
+        }
+    }
+}

--- a/runner/runtime/src/test/java/io/quarkiverse/flow/runner/security/ApiKeyAuthenticationMechanismTest.java
+++ b/runner/runtime/src/test/java/io/quarkiverse/flow/runner/security/ApiKeyAuthenticationMechanismTest.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.flow.runner.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -74,25 +75,17 @@ class ApiKeyAuthenticationMechanismTest {
             String wrongKey = "x".repeat(VALID_KEY.length());
             when(request.getHeader("Authorization")).thenReturn("Bearer " + wrongKey);
 
-            try {
-                mechanism.authenticate(routingContext, null).await().indefinitely();
-                assertThat(false).as("Should have thrown AuthenticationFailedException").isTrue();
-            } catch (Exception e) {
-                assertThat(e).hasMessageContaining("Invalid API key");
-            }
+            assertThatThrownBy(() -> mechanism.authenticate(routingContext, null).await().indefinitely())
+                    .hasMessageContaining("Invalid API key");
         }
 
         @Test
         @DisplayName("wrong_key_with_different_length_must_be_rejected")
         void wrong_key_with_different_length_must_be_rejected() {
-            when(request.getHeader("Authorization")).thenReturn("Bearer short");
+            when(request.getHeader("Authorization")).thenReturn("Bearer short-key-wrong");
 
-            try {
-                mechanism.authenticate(routingContext, null).await().indefinitely();
-                assertThat(false).as("Should have thrown AuthenticationFailedException").isTrue();
-            } catch (Exception e) {
-                assertThat(e).hasMessageContaining("Invalid API key");
-            }
+            assertThatThrownBy(() -> mechanism.authenticate(routingContext, null).await().indefinitely())
+                    .hasMessageContaining("Invalid API key");
         }
 
         @Test
@@ -101,12 +94,8 @@ class ApiKeyAuthenticationMechanismTest {
             String almostRight = VALID_KEY.substring(0, VALID_KEY.length() - 1) + "X";
             when(request.getHeader("Authorization")).thenReturn("Bearer " + almostRight);
 
-            try {
-                mechanism.authenticate(routingContext, null).await().indefinitely();
-                assertThat(false).as("Should have thrown AuthenticationFailedException").isTrue();
-            } catch (Exception e) {
-                assertThat(e).hasMessageContaining("Invalid API key");
-            }
+            assertThatThrownBy(() -> mechanism.authenticate(routingContext, null).await().indefinitely())
+                    .hasMessageContaining("Invalid API key");
         }
     }
 }

--- a/runner/runtime/src/test/java/io/quarkiverse/flow/runner/security/PermitAllAuthenticationMechanismTest.java
+++ b/runner/runtime/src/test/java/io/quarkiverse/flow/runner/security/PermitAllAuthenticationMechanismTest.java
@@ -1,0 +1,76 @@
+package io.quarkiverse.flow.runner.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.flow.runner.FlowRunnerConfig;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.vertx.ext.web.RoutingContext;
+
+@DisplayName("Permit-all authentication mechanism tests")
+class PermitAllAuthenticationMechanismTest {
+
+    private PermitAllAuthenticationMechanism mechanism;
+    private FlowRunnerConfig config;
+    private FlowRunnerConfig.Security security;
+    private RoutingContext routingContext;
+
+    @BeforeEach
+    void setUp() {
+        mechanism = new PermitAllAuthenticationMechanism();
+
+        config = mock(FlowRunnerConfig.class);
+        security = mock(FlowRunnerConfig.Security.class);
+        routingContext = mock(RoutingContext.class);
+
+        mechanism.config = config;
+
+        when(config.security()).thenReturn(security);
+    }
+
+    @Test
+    @DisplayName("type_none_must_grant_admin_and_invoker_roles")
+    void type_none_must_grant_admin_and_invoker_roles() {
+        when(security.type()).thenReturn(FlowRunnerConfig.Security.Type.NONE);
+
+        SecurityIdentity identity = mechanism.authenticate(routingContext, null)
+                .await().indefinitely();
+
+        assertThat(identity).isNotNull();
+        assertThat(identity.isAnonymous()).isTrue();
+        assertThat(identity.getPrincipal().getName()).isEqualTo(AuthzConsts.USER_ANONYMOUS);
+        assertThat(identity.getRoles())
+                .containsExactlyInAnyOrder(AuthzConsts.ROLE_ADMIN, AuthzConsts.ROLE_INVOKER);
+    }
+
+    @Test
+    @DisplayName("type_api_key_must_not_activate_permit_all")
+    void type_api_key_must_not_activate_permit_all() {
+        when(security.type()).thenReturn(FlowRunnerConfig.Security.Type.API_KEY);
+
+        SecurityIdentity identity = mechanism.authenticate(routingContext, null)
+                .await().indefinitely();
+
+        assertThat(identity)
+                .as("API_KEY mode must not activate permit-all mechanism")
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("type_oidc_must_not_activate_permit_all")
+    void type_oidc_must_not_activate_permit_all() {
+        when(security.type()).thenReturn(FlowRunnerConfig.Security.Type.OIDC);
+
+        SecurityIdentity identity = mechanism.authenticate(routingContext, null)
+                .await().indefinitely();
+
+        assertThat(identity)
+                .as("OIDC mode must not activate permit-all mechanism")
+                .isNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Remove `@WithDefault("none")` from `security.type`, making it a **required** configuration property — users must explicitly choose `none`, `api-key`, or `oidc`; forgetting to configure it fails fast at startup
- Replace `String.equals()` with `MessageDigest.isEqual()` in `ApiKeyAuthenticationMechanism` for constant-time API key comparison, preventing timing side-channel attacks
- Update dev profile, test profiles, and test application.properties to set `security.type` explicitly

## Test plan

- [x] New `ApiKeyAuthenticationMechanismTest` — validates correct key authenticates, wrong keys (same length, different length, off-by-one) are rejected
- [x] New `PermitAllAuthenticationMechanismTest` — validates NONE grants roles, API_KEY/OIDC do not activate permit-all
- [x] All 128 runner/runtime unit tests pass
- [x] `make test-all` passes (full build including runner integration tests and all examples)

Closes #861