### PR TITLE
Exclude WorkflowFileWatcher type from discovery when quarkus.flow.runner.source.watch.enabled is false

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-flow-durable-kubernetes.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-durable-kubernetes.adoc
@@ -114,6 +114,27 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-flow-durable-kubernetes_quarkus-flow[icon:question-circle[title=More information about the Duration format]]
 |`+++30S+++`
 
+a| [[quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-member-max-reacquire-attempts]] [.property-path]##link:#quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-member-max-reacquire-attempts[`+++quarkus.flow.durable.kube.lease.member.max-reacquire-attempts+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.durable.kube.lease.member.max-reacquire-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Maximum number of attempts to re-acquire the bound lease after it is lost. Once exhausted, the pod initiates a graceful shutdown to avoid split-brain (the applicationId is immutable and cannot match a different lease).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DURABLE_KUBE_LEASE_MEMBER_MAX_REACQUIRE_ATTEMPTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_DURABLE_KUBE_LEASE_MEMBER_MAX_REACQUIRE_ATTEMPTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++5+++`
+
 a| [[quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-leader-duration]] [.property-path]##link:#quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-leader-duration[`+++quarkus.flow.durable.kube.lease.leader.duration+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.durable.kube.lease.leader.duration+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-flow-durable-kubernetes_quarkus.flow.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-flow-durable-kubernetes_quarkus.flow.adoc
@@ -114,6 +114,27 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-flow-durable-kubernetes_quarkus-flow[icon:question-circle[title=More information about the Duration format]]
 |`+++30S+++`
 
+a| [[quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-member-max-reacquire-attempts]] [.property-path]##link:#quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-member-max-reacquire-attempts[`+++quarkus.flow.durable.kube.lease.member.max-reacquire-attempts+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.flow.durable.kube.lease.member.max-reacquire-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Maximum number of attempts to re-acquire the bound lease after it is lost. Once exhausted, the pod initiates a graceful shutdown to avoid split-brain (the applicationId is immutable and cannot match a different lease).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_FLOW_DURABLE_KUBE_LEASE_MEMBER_MAX_REACQUIRE_ATTEMPTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_FLOW_DURABLE_KUBE_LEASE_MEMBER_MAX_REACQUIRE_ATTEMPTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++5+++`
+
 a| [[quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-leader-duration]] [.property-path]##link:#quarkus-flow-durable-kubernetes_quarkus-flow-durable-kube-lease-leader-duration[`+++quarkus.flow.durable.kube.lease.leader.duration+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.flow.durable.kube.lease.leader.duration+++[]

--- a/runner/deployment/src/main/java/io/quarkiverse/flow/runner/deployment/FlowRunnerProcessor.java
+++ b/runner/deployment/src/main/java/io/quarkiverse/flow/runner/deployment/FlowRunnerProcessor.java
@@ -11,6 +11,7 @@ import io.quarkiverse.flow.runner.security.NamespaceAuthorizationFilter;
 import io.quarkiverse.flow.runner.security.NamespaceAuthorizationService;
 import io.quarkiverse.flow.runner.security.PermitAllAuthenticationMechanism;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.ExcludedTypeBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -49,13 +50,16 @@ class FlowRunnerProcessor {
     @BuildStep
     void registerFileWatcher(FlowRunnerSourceWatchConfig watchConfig,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans,
-            BuildProducer<ForceStartSchedulerBuildItem> forceScheduler) {
+            BuildProducer<ForceStartSchedulerBuildItem> forceScheduler,
+            BuildProducer<ExcludedTypeBuildItem> excludedTypes) {
         if (watchConfig.enabled()) {
             additionalBeans.produce(AdditionalBeanBuildItem.builder()
                     .setUnremovable()
                     .addBeanClass(WorkflowFileWatcher.class)
                     .build());
             forceScheduler.produce(new ForceStartSchedulerBuildItem());
+        } else {
+            excludedTypes.produce(new ExcludedTypeBuildItem(WorkflowFileWatcher.class.getName()));
         }
     }
 


### PR DESCRIPTION
## Description

Fixes #859 

## Changes

I removed the type to be discovered by CDI because the method is annotated with `@Observes`, it does mean that Quarkus will generate a bean for us even removing the CDI annotation (`@ApplicationScoped`), see the [CDI reference](https://quarkus.io/guides/cdi-reference#bean_discovery).

> Bean classes that don’t have a [bean defining annotation](https://jakarta.ee/specifications/cdi/4.1/jakarta-cdi-spec-4.1.html#bean_defining_annotations) are not discovered. This behavior is defined by CDI. But producer methods and fields and observer methods are discovered even if the declaring class is not annotated with a bean defining annotation (this behavior is different to what is defined in CDI). In fact, the declaring bean classes are considered annotated with @Dependent.

Having it in mind the better option is to remove using the `WorkflowFileWatcher` to not be discovered by `ExcludedTypeBuildItem` build item.

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
