### PR TITLE
Fix #859 - Prevent WorkflowFileWatcher CDI auto-discovery when watcher disabled

### DIFF
--- a/runner/deployment/src/main/java/io/quarkiverse/flow/runner/deployment/FlowRunnerProcessor.java
+++ b/runner/deployment/src/main/java/io/quarkiverse/flow/runner/deployment/FlowRunnerProcessor.java
@@ -15,6 +15,7 @@ import io.quarkiverse.flow.runner.security.NamespaceAuthorizationFilter;
 import io.quarkiverse.flow.runner.security.NamespaceAuthorizationService;
 import io.quarkiverse.flow.runner.security.PermitAllAuthenticationMechanism;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.ExcludedTypeBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -53,7 +54,8 @@ class FlowRunnerProcessor {
     @BuildStep
     void registerFileWatcher(FlowRunnerSourceWatchConfig watchConfig,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans,
-            BuildProducer<ForceStartSchedulerBuildItem> forceScheduler) {
+            BuildProducer<ForceStartSchedulerBuildItem> forceScheduler,
+            BuildProducer<ExcludedTypeBuildItem> excludedTypes) {
         if (watchConfig.enabled()) {
             additionalBeans.produce(AdditionalBeanBuildItem.builder()
                     .setUnremovable()
@@ -61,6 +63,8 @@ class FlowRunnerProcessor {
                     .addBeanClass(WorkflowFileWatcher.class)
                     .build());
             forceScheduler.produce(new ForceStartSchedulerBuildItem());
+        } else {
+            excludedTypes.produce(new ExcludedTypeBuildItem(WorkflowFileWatcher.class.getName()));
         }
     }
 

--- a/runner/deployment/src/main/java/io/quarkiverse/flow/runner/deployment/FlowRunnerProcessor.java
+++ b/runner/deployment/src/main/java/io/quarkiverse/flow/runner/deployment/FlowRunnerProcessor.java
@@ -1,5 +1,9 @@
 package io.quarkiverse.flow.runner.deployment;
 
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.jandex.DotName;
+
 import io.quarkiverse.flow.runner.FlowRunnerSourceWatchConfig;
 import io.quarkiverse.flow.runner.WorkflowFileWatcher;
 import io.quarkiverse.flow.runner.model.ExecutionResponse;
@@ -53,6 +57,7 @@ class FlowRunnerProcessor {
         if (watchConfig.enabled()) {
             additionalBeans.produce(AdditionalBeanBuildItem.builder()
                     .setUnremovable()
+                    .setDefaultScope(DotName.createSimple(ApplicationScoped.class))
                     .addBeanClass(WorkflowFileWatcher.class)
                     .build());
             forceScheduler.produce(new ForceStartSchedulerBuildItem());

--- a/runner/runtime/src/main/java/io/quarkiverse/flow/runner/WorkflowFileWatcher.java
+++ b/runner/runtime/src/main/java/io/quarkiverse/flow/runner/WorkflowFileWatcher.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 
 import jakarta.annotation.PreDestroy;
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
@@ -17,7 +16,6 @@ import org.slf4j.LoggerFactory;
 
 import io.quarkiverse.flow.internal.WorkflowApplicationReadyEvent;
 import io.quarkiverse.flow.internal.WorkflowRegistrarService;
-import io.quarkus.arc.Unremovable;
 import io.quarkus.scheduler.Scheduled;
 import io.quarkus.scheduler.Scheduler;
 import io.serverlessworkflow.api.WorkflowReader;
@@ -25,8 +23,6 @@ import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.impl.WorkflowApplication;
 import io.serverlessworkflow.impl.WorkflowDefinitionId;
 
-@ApplicationScoped
-@Unremovable
 public class WorkflowFileWatcher {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowFileWatcher.class.getName());

--- a/runner/runtime/src/test/java/io/quarkiverse/flow/runner/WorkflowFileWatcherTest.java
+++ b/runner/runtime/src/test/java/io/quarkiverse/flow/runner/WorkflowFileWatcherTest.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -313,20 +314,38 @@ class WorkflowFileWatcherTest {
     @DisplayName("Build-time registration guard")
     class BuildTimeRegistrationGuard {
 
+        private static final Set<String> CDI_META_ANNOTATIONS = Set.of(
+                "jakarta.inject.Scope",
+                "jakarta.enterprise.context.NormalScope",
+                "jakarta.enterprise.inject.Stereotype");
+
+        private static final String UNREMOVABLE = "io.quarkus.arc.Unremovable";
+
         @Test
         @DisplayName("test_watcher_has_no_bean_defining_annotations")
         void test_watcher_has_no_bean_defining_annotations() {
             for (Annotation annotation : WorkflowFileWatcher.class.getAnnotations()) {
-                String name = annotation.annotationType().getName();
-                assertThat(name)
-                        .as("WorkflowFileWatcher must not have bean-defining annotations — "
-                                + "registration is controlled by the deployment processor "
-                                + "so the bean only exists when watch is enabled")
-                        .doesNotContain("ApplicationScoped")
-                        .doesNotContain("Singleton")
-                        .doesNotContain("RequestScoped")
-                        .doesNotContain("Dependent")
-                        .doesNotContain("Unremovable");
+                Class<? extends Annotation> annotationType = annotation.annotationType();
+
+                for (String metaAnnotation : CDI_META_ANNOTATIONS) {
+                    boolean isBeanDefining = false;
+                    for (Annotation meta : annotationType.getAnnotations()) {
+                        if (meta.annotationType().getName().equals(metaAnnotation)) {
+                            isBeanDefining = true;
+                            break;
+                        }
+                    }
+                    assertThat(isBeanDefining)
+                            .as("WorkflowFileWatcher must not carry @%s (annotated with %s) — "
+                                    + "registration is controlled by the deployment processor",
+                                    annotationType.getSimpleName(), metaAnnotation)
+                            .isFalse();
+                }
+
+                assertThat(annotationType.getName())
+                        .as("WorkflowFileWatcher must not be @Unremovable — "
+                                + "the deployment processor sets unremovable when registering")
+                        .isNotEqualTo(UNREMOVABLE);
             }
         }
     }

--- a/runner/runtime/src/test/java/io/quarkiverse/flow/runner/WorkflowFileWatcherTest.java
+++ b/runner/runtime/src/test/java/io/quarkiverse/flow/runner/WorkflowFileWatcherTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -18,6 +19,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -305,5 +307,27 @@ class WorkflowFileWatcherTest {
         List<Path> files = loader.scanWorkflowFiles();
 
         assertThat(files).isEmpty();
+    }
+
+    @Nested
+    @DisplayName("Build-time registration guard")
+    class BuildTimeRegistrationGuard {
+
+        @Test
+        @DisplayName("test_watcher_has_no_bean_defining_annotations")
+        void test_watcher_has_no_bean_defining_annotations() {
+            for (Annotation annotation : WorkflowFileWatcher.class.getAnnotations()) {
+                String name = annotation.annotationType().getName();
+                assertThat(name)
+                        .as("WorkflowFileWatcher must not have bean-defining annotations — "
+                                + "registration is controlled by the deployment processor "
+                                + "so the bean only exists when watch is enabled")
+                        .doesNotContain("ApplicationScoped")
+                        .doesNotContain("Singleton")
+                        .doesNotContain("RequestScoped")
+                        .doesNotContain("Dependent")
+                        .doesNotContain("Unremovable");
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix #859 

## Summary

- Remove `@ApplicationScoped` and `@Unremovable` from `WorkflowFileWatcher` so the class is not auto-discovered by CDI
- The deployment processor's `AdditionalBeanBuildItem` is now the sole registration path — the bean only exists when `quarkus.flow.runner.source.watch.enabled=true`
- Add `.setDefaultScope(ApplicationScoped.class)` to the build step so the bean gets the correct scope when registered
- Add regression test verifying the class has no bean-defining annotations

## Root cause

`WorkflowFileWatcher` had `@ApplicationScoped` + `@Unremovable`, causing Quarkus to auto-discover it even when `quarkus.flow.runner.source.watch.enabled=false` (the default). The bean observed `WorkflowApplicationReadyEvent` and called `scheduler.newJob()`, but `ForceStartSchedulerBuildItem` was only produced when the watcher was enabled — resulting in `UnsupportedOperationException: Scheduler was not started`.

## Test plan

- [x] Unit test added: `BuildTimeRegistrationGuard.test_watcher_has_no_bean_defining_annotations`
- [x] All 122 runner runtime unit tests pass
- [x] Runner app integration tests pass
- [x] `greeting-runner` and `opentelemetry` examples compile successfully