### PR TITLE
Update langchain4j to 1.13.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
         <io.quarkiverse.jackson-jq.version>2.5.2</io.quarkiverse.jackson-jq.version>
         <com.github.zafarkhaja.version>0.10.2</com.github.zafarkhaja.version>
-        <io.quarkiverse.langchain4j.version>1.12.2</io.quarkiverse.langchain4j.version>
+        <io.quarkiverse.langchain4j.version>1.13.0</io.quarkiverse.langchain4j.version>
 
         <!-- Tests and Docs -->
         <org.assertj.version>3.27.7</org.assertj.version>


### PR DESCRIPTION
## Description

Updates quarkiverse langchain4j to 1.13.0. 

## Testing

mvn clean install -DskipTests on the whole repo and then mvn test in the langchain4j modules. 
