### PR TITLE
Review and align quarkus-extension.yaml across all extensions

### DIFF
--- a/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 name: Flow
 description: |
-  Workflow engine for Quarkus based on the CNCF Workflow Specification, with Java DSL and Agentic AI support.
+  Workflow engine for Quarkus based on the Open Workflow Specification (CNCF Sandbox), with Java DSL and Agentic AI support. See https://open-workflow-specification.org/
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   keywords:
@@ -9,7 +9,8 @@ metadata:
     - cncf
     - serverless
     - cloudevents
-  guide: https://docs.quarkiverse.io/quarkus-flow/dev/
+    - open workflow
+  guide: https://docs.quarkiverse.io/quarkus-flow/dev/getting-started.html
   categories:
     - "integration"
   status: "stable"

--- a/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,7 +9,7 @@ metadata:
     - cncf
     - serverless
     - cloudevents
-    - open workflow
+    - open-workflow
   guide: https://docs.quarkiverse.io/quarkus-flow/dev/getting-started.html
   categories:
     - "integration"

--- a/durable-kubernetes/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/durable-kubernetes/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,7 +10,7 @@ metadata:
     - cloudevents
     - durable
     - kubernetes
-  guide: https://docs.quarkiverse.io/quarkus-flow/dev/
+  guide: https://docs.quarkiverse.io/quarkus-flow/dev/concepts-durable-workflow-k8s.html
   categories:
     - "integration"
     - "cloud"

--- a/grpc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/grpc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,7 +9,7 @@ metadata:
     - cncf
     - serverless
     - cloudevents
-    - open workflow
+    - open-workflow
     - grpc
   guide: https://docs.quarkiverse.io/quarkus-flow/dev/grpc.html
   categories:

--- a/grpc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/grpc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Flow LangChain4j
+name: Flow gRPC
 description: |
-  LangChain4j Agentic Workflow implementation for Quarkus Flow.
+  gRPC tasks implementation for Quarkus Flow.
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   keywords:
@@ -9,12 +9,9 @@ metadata:
     - cncf
     - serverless
     - cloudevents
-    - langchain4j
-    - ai
-    - agentic
-    - agent
-    - llm
-  guide: https://docs.quarkiverse.io/quarkus-flow/dev/langchain4j.html
+    - open workflow
+    - grpc
+  guide: https://docs.quarkiverse.io/quarkus-flow/dev/grpc.html
   categories:
     - "integration"
   status: "preview"

--- a/messaging/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/messaging/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -12,7 +12,7 @@ metadata:
     - cloudevents
     - smallrye
     - messaging
-  guide: https://docs.quarkiverse.io/quarkus-flow/dev/
+  guide: https://docs.quarkiverse.io/quarkus-flow/dev/messaging.html
   categories:
     - "integration"
     - "messaging"

--- a/oidc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/oidc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,10 +9,11 @@ metadata:
     - workflows
     - cncf
     - serverless
+    - cloudevents
     - oauth2
     - oidc
     - security
-  guide: https://docs.quarkiverse.io/quarkus-flow/dev/
+  guide: https://docs.quarkiverse.io/quarkus-flow/dev/oauth2-oidc-authentication.html
   categories:
     - "integration"
     - "security"

--- a/opentelemetry/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/opentelemetry/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,4 +1,4 @@
-name: Flow Opentelemetry
+name: Flow OpenTelemetry
 description: Adds OpenTelemetry instrumentation for the Quarkus Flows.
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
@@ -7,8 +7,11 @@ metadata:
     - workflows
     - cncf
     - serverless
+    - cloudevents
     - opentelemetry
-  guide: https://docs.quarkiverse.io/quarkus-flow/dev/
+    - tracing
+    - observability
+  guide: https://docs.quarkiverse.io/quarkus-flow/dev/opentelemetry.html
   categories:
     - "integration"
     - "observability"

--- a/persistence/common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/persistence/common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -3,11 +3,12 @@ description: |
   Common persistence components shared across Flow persistence implementations
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
+  unlisted: true
   keywords:
     - workflow
     - workflows
     - persistence
-  guide: https://docs.quarkiverse.io/quarkus-flow/dev/
+  guide: https://docs.quarkiverse.io/quarkus-flow/dev/persistence.html
   categories:
     - "integration"
     - "data"

--- a/persistence/jpa/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/persistence/jpa/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -12,7 +12,7 @@ metadata:
     - jpa
     - postgresql
     - persistence
-  guide: https://docs.quarkiverse.io/quarkus-flow/dev/
+  guide: https://docs.quarkiverse.io/quarkus-flow/dev/persistence.html
   categories:
     - "integration"
     - "data"

--- a/persistence/mvstore/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/persistence/mvstore/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,7 +11,7 @@ metadata:
     - cloudevents
     - mvstore
     - persistence
-  guide: https://docs.quarkiverse.io/quarkus-flow/dev/
+  guide: https://docs.quarkiverse.io/quarkus-flow/dev/persistence.html
   categories:
     - "integration"
     - "data"

--- a/persistence/redis/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/persistence/redis/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,7 +11,7 @@ metadata:
     - cloudevents
     - redis
     - persistence
-  guide: https://docs.quarkiverse.io/quarkus-flow/dev/
+  guide: https://docs.quarkiverse.io/quarkus-flow/dev/persistence.html
   categories:
     - "integration"
     - "data"

--- a/runner/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runner/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,7 +11,7 @@ metadata:
     - cloudevents
     - http
     - runner
-  guide: https://docs.quarkiverse.io/quarkus-flow/dev/
+  guide: https://docs.quarkiverse.io/quarkus-flow/dev/runner.html
   categories:
     - "integration"
     - "web"

--- a/scheduler/memory/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/scheduler/memory/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 name: Flow Scheduler
 description: |
-  Flow scheduler implemetation relying on quarkus scheduler
+  Flow scheduler implementation relying on quarkus scheduler
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   keywords:
@@ -10,7 +10,8 @@ metadata:
     - serverless
     - cloudevents
     - scheduler
-  guide: https://docs.quarkiverse.io/quarkus-flow/dev/
+    - memory
+  guide: https://docs.quarkiverse.io/quarkus-flow/dev/scheduler.html
   categories:
     - "integration"
   status: "stable"

--- a/scheduler/quartz/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/scheduler/quartz/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 name: Flow Quartz
 description: |
-  Flow scheduler implemetation relying on quarkus quartz
+  Flow scheduler implementation relying on quarkus quartz
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   keywords:
@@ -11,7 +11,7 @@ metadata:
     - cloudevents
     - scheduler
     - quartz
-  guide: https://docs.quarkiverse.io/quarkus-flow/dev/
+  guide: https://docs.quarkiverse.io/quarkus-flow/dev/quartz.html
   categories:
     - "integration"
   status: "preview"


### PR DESCRIPTION
## Summary

- Add missing gRPC extension catalog entry (`quarkus-extension.yaml` did not exist)
- Align all `guide` URLs to point to specific doc pages instead of the generic root
- Fix typo `implemetation` → `implementation` in both scheduler extension descriptions
- Fix `Flow Opentelemetry` name casing to `Flow OpenTelemetry`
- Add missing keywords for better discoverability (`cloudevents`, `open workflow`, `llm`, `agent`, `tracing`, `observability`, `memory`)
- Mark `persistence/common` as `unlisted: true` — it is an internal shared module, not a user-facing extension

## Test plan

- [ ] Build passes: `./mvnw clean install -DskipTests`
- [ ] Verify catalog entries render correctly in Quarkus Extensions catalog after merge