### PR TITLE
Fix native image build failure in examples caused by langchain4j version mismatch

### DIFF
--- a/examples/agentic-http/pom.xml
+++ b/examples/agentic-http/pom.xml
@@ -18,7 +18,7 @@
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
 
         <quarkus.flow.version>2.0.0-SNAPSHOT</quarkus.flow.version>
-        <io.quarkiverse.langchain4j.version>1.12.2</io.quarkiverse.langchain4j.version>
+        <io.quarkiverse.langchain4j.version>1.13.0</io.quarkiverse.langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/langchain4j-agentic-workflow/pom.xml
+++ b/examples/langchain4j-agentic-workflow/pom.xml
@@ -17,7 +17,7 @@
         <quarkus.flow.version>2.0.0-SNAPSHOT</quarkus.flow.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <io.quarkiverse.langchain4j.version>1.12.2</io.quarkiverse.langchain4j.version>
+        <io.quarkiverse.langchain4j.version>1.13.0</io.quarkiverse.langchain4j.version>
         <version.assertj>3.27.7</version.assertj>
         <org.wiremock.version>3.13.2</org.wiremock.version>
     </properties>

--- a/examples/newsletter-drafter/pom.xml
+++ b/examples/newsletter-drafter/pom.xml
@@ -21,7 +21,7 @@
         <failsafe-plugin.version>3.5.4</failsafe-plugin.version>
 
         <quarkus.flow.version>2.0.0-SNAPSHOT</quarkus.flow.version>
-        <io.quarkiverse.langchain4j.version>1.12.2</io.quarkiverse.langchain4j.version>
+        <io.quarkiverse.langchain4j.version>1.13.0</io.quarkiverse.langchain4j.version>
         <org.assertj.version>3.27.7</org.assertj.version>
     </properties>
 


### PR DESCRIPTION
## Summary

- Bump `io.quarkiverse.langchain4j.version` from `1.12.2` to `1.13.0` in three examples: `newsletter-drafter`, `agentic-http`, `langchain4j-agentic-workflow`

## Root cause

After #881 bumped `quarkus-langchain4j` to `1.13.0` in the root POM, `quarkus-flow-langchain4j` now pulls in `quarkus-langchain4j-agentic:1.13.0`. The three examples above still pinned `quarkus-langchain4j-ollama` to `1.12.2`, creating a mixed classpath:

- `langchain4j-agentic` (via 1.13.0) references `ToolService.onCompensableToolExecution(BiConsumer)`
- `langchain4j` stable JAR (via 1.12.2 pin) does not have that method

GraalVM points-to analysis fails at build time with `UnresolvedElementException` when parsing `AgentInvocationHandler`.

## Test plan

- [ ] `./mvnw clean install -pl examples/newsletter-drafter -Pnative -DskipITs` completes without native image error
- [ ] CI Build and Examples jobs pass