### PR TITLE
[NO-ISSUE] Rename References page to Community Resources

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -62,4 +62,4 @@
 ** xref:configuration.adoc[Extension Configuration Reference]
 ** xref:performance-benchmarks.adoc[Performance Benchmark]
 
-* xref:references.adoc[References]
+* xref:community-resources.adoc[Community Resources]

--- a/docs/modules/ROOT/pages/community-resources.adoc
+++ b/docs/modules/ROOT/pages/community-resources.adoc
@@ -1,4 +1,4 @@
-= References
+= Community Resources
 include::includes/attributes.adoc[]
 
 This page collects blog posts and talks from the community about Quarkus Flow.


### PR DESCRIPTION
## Description

It renames `References` to `Community Resources`.

## Changes

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
