### PR TITLE
docs(cookbook): escape event source path placeholders

### DIFF
--- a/docs/modules/ROOT/pages/quarkus-flow-java-cookbook.adoc
+++ b/docs/modules/ROOT/pages/quarkus-flow-java-cookbook.adoc
@@ -95,7 +95,7 @@ Emitting an Event:
 include::{examples-dir}/org/acme/EmitWorkflow.java[]
 ----
 
-If no `source` is set on the emitted event, it defaults to `/{appId}/{namespace}/{name}/{version}`, resolved from the workflow application at runtime. Call `.source(...)` explicitly to override it.
+If no `source` is set on the emitted event, it defaults to `/\{appId}/\{namespace}/\{name}/\{version}`, resolved from the workflow application at runtime. Call `.source(...)` explicitly to override it.
 
 [#conditional_logic]
 == Conditional Logic


### PR DESCRIPTION
## Summary

The Java cookbook's emitted-event section writes the default source path as `/{appId}/{namespace}/{name}/{version}`. AsciiDoc parses each curly-brace segment as an attribute reference, so any toolchain that treats missing attributes as errors reports four undefined attributes (appId, namespace, name, version). This backslash-escapes each segment so the path renders literally, matching the escaping the runner page already uses for `/q/flow/exec/\{namespace}/\{name}`. Content-only; no behavior change.

## Files

- docs/modules/ROOT/pages/quarkus-flow-java-cookbook.adoc (1 line)