### PR TITLE
Add SEO page descriptions to key documentation pages

### DIFF
--- a/docs/modules/ROOT/pages/concepts-architecture.adoc
+++ b/docs/modules/ROOT/pages/concepts-architecture.adoc
@@ -1,5 +1,6 @@
 = Concepts & architecture
 :page-role: explanation
+:description: Understand the core concepts behind Quarkus Flow, its build-time engine paradigm, and how it maps to the Open Workflow Specification.
 
 This page explains the core concepts behind Quarkus Flow, its internal architecture, and how it maps to the Open Workflow Specification (CNCF sandbox project).
 

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -1,6 +1,6 @@
 = Getting started with Quarkus Flow
 :page-role: tutorial
-:description: Add Quarkus Flow to your Quarkus application and define your first workflow in minutes using YAML or the Java DSL.
+:description: Add Quarkus Flow to your Quarkus application and define your first workflow in minutes using the Java DSL, then explore it in the Dev UI.
 include::includes/attributes.adoc[]
 
 include::includes/status-stable.adoc[]

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -1,5 +1,6 @@
 = Getting started with Quarkus Flow
 :page-role: tutorial
+:description: Add Quarkus Flow to your Quarkus application and define your first workflow in minutes using YAML or the Java DSL.
 include::includes/attributes.adoc[]
 
 include::includes/status-stable.adoc[]

--- a/docs/modules/ROOT/pages/google494e2397ce0a45f5.adoc
+++ b/docs/modules/ROOT/pages/google494e2397ce0a45f5.adoc
@@ -1,0 +1,4 @@
+= Google Search Console Verification
+:noindex:
+
+google-site-verification: google494e2397ce0a45f5.html

--- a/docs/modules/ROOT/pages/langchain4j.adoc
+++ b/docs/modules/ROOT/pages/langchain4j.adoc
@@ -1,5 +1,6 @@
 = Orchestrate LangChain4j Agents and Patterns
 :page-role: howto
+:description: Learn how to orchestrate LangChain4j AI agents as workflow tasks in Quarkus Flow, with support for branching, retries, and human-in-the-loop patterns.
 include::includes/attributes.adoc[]
 
 include::includes/status-preview.adoc[]


### PR DESCRIPTION
Adds `:description:` attributes to the three high-traffic pages that were missing them (`getting-started`, `langchain4j`, `concepts-architecture`). The Quarkiverse Antora UI bundle renders these as HTML `<meta name="description">` tags when supported.