### PR TITLE
Remove Google Search Console HTML verification page

### DIFF
--- a/docs/modules/ROOT/pages/google494e2397ce0a45f5.adoc
+++ b/docs/modules/ROOT/pages/google494e2397ce0a45f5.adoc
@@ -1,4 +1,0 @@
-= Google Search Console Verification
-:noindex:
-
-google-site-verification: google494e2397ce0a45f5.html


### PR DESCRIPTION
The HTML file verification method doesn't work through Antora — the page is wrapped in the full site template so Google rejects the content. Removing it in favour of the meta tag approach, which requires a small change to the Quarkiverse Antora UI bundle.