### PR TITLE
Add link to blog post "Quarkus Flow is now part of the Quarkus Platform"

### DIFF
--- a/docs/modules/ROOT/pages/community-resources.adoc
+++ b/docs/modules/ROOT/pages/community-resources.adoc
@@ -67,6 +67,12 @@ Wrote a blog post or gave a talk about Quarkus Flow? We'd love to feature it her
 |
 
 |Blog Post
+|https://sk.linkedin.com/in/tibor-zim%C3%A1nyi-a0bbb430[Tibor Zimányi]
+|https://baldimir.github.io/en/tech/quarkus-flow-is-in-quarkus-platform.html[Quarkus Flow is now part of the Quarkus Platform]
+|March 30, 2026
+|2 min read
+
+|Blog Post
 |https://www.linkedin.com/in/markuseisele/[Markus Eisele]
 |https://www.the-main-thread.com/p/quarkus-flow-ollama-kafka-cloudevents-java-workflow[Stop Gluing Scripts Together: Build a Real Java Workflow with Quarkus Flow, Kafka, and Ollama]
 |March 02, 2026


### PR DESCRIPTION
## Description

Adds link to a blog post I wrote about Quarkus Flow joining the Quarkus Platform. 

## Changes

Adds a link to the blog post to Community Resources
