### PR TITLE
Fix #864 - Add @Version and concurrency control to JPA persistence en…

### DIFF
--- a/docs/modules/ROOT/examples/persistence/V1__create_tables_h2.sql
+++ b/docs/modules/ROOT/examples/persistence/V1__create_tables_h2.sql
@@ -12,6 +12,7 @@ CREATE TABLE cloud_event_entity
     extensions        VARBINARY,
     processed_flag    BOOLEAN DEFAULT FALSE,
     version           TINYINT      NOT NULL CHECK (version BETWEEN 0 AND 1),
+    opt_lock_version  BIGINT       NOT NULL,
     PRIMARY KEY (id)
 );
 
@@ -25,6 +26,7 @@ CREATE TABLE workflow_instance_entity
     started_at         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
     status             TINYINT CHECK (status BETWEEN 0 AND 6),
     input              VARBINARY,
+    version             BIGINT                     NOT NULL,
     PRIMARY KEY (application_id, instance_id)
 );
 

--- a/docs/modules/ROOT/examples/persistence/V1__create_tables_mssql.sql
+++ b/docs/modules/ROOT/examples/persistence/V1__create_tables_mssql.sql
@@ -12,6 +12,7 @@ CREATE TABLE cloud_event_entity
     extensions        VARBINARY(MAX),
     processed_flag    BIT DEFAULT 0,
     version           TINYINT      NOT NULL CHECK (version BETWEEN 0 AND 1),
+    opt_lock_version  BIGINT       NOT NULL,
     PRIMARY KEY (id)
     );
 
@@ -25,6 +26,7 @@ CREATE TABLE workflow_instance_entity
     started_at         DATETIMEOFFSET(6) NOT NULL,
     status             TINYINT CHECK (status BETWEEN 0 AND 6),
     input              VARBINARY(MAX),
+    version             BIGINT           NOT NULL,
     PRIMARY KEY (application_id, instance_id)
 );
 

--- a/docs/modules/ROOT/examples/persistence/V1__create_tables_mysql.sql
+++ b/docs/modules/ROOT/examples/persistence/V1__create_tables_mysql.sql
@@ -12,6 +12,7 @@ CREATE TABLE cloud_event_entity
     extensions        LONGBLOB,
     processed_flag    BOOLEAN DEFAULT FALSE,
     version           TINYINT      NOT NULL CHECK (version BETWEEN 0 AND 1),
+    opt_lock_version  BIGINT       NOT NULL,
     PRIMARY KEY (id)
 );
 
@@ -25,6 +26,7 @@ CREATE TABLE workflow_instance_entity
     started_at         DATETIME(6)  NOT NULL,
     status             TINYINT CHECK (status BETWEEN 0 AND 6),
     input              LONGBLOB,
+    version             BIGINT      NOT NULL,
     PRIMARY KEY (application_id, instance_id)
 );
 

--- a/docs/modules/ROOT/examples/persistence/V1__create_tables_oracle.sql
+++ b/docs/modules/ROOT/examples/persistence/V1__create_tables_oracle.sql
@@ -12,6 +12,7 @@ CREATE TABLE cloud_event_entity
     extensions        BLOB,
     processed_flag    NUMBER(1, 0) DEFAULT 0,
     version           NUMBER(3, 0)  NOT NULL CHECK (version BETWEEN 0 AND 1),
+    opt_lock_version  NUMBER(19, 0) NOT NULL,
     PRIMARY KEY (id)
 );
 
@@ -25,6 +26,7 @@ CREATE TABLE workflow_instance_entity
     started_at         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
     status             NUMBER(3, 0) CHECK (status BETWEEN 0 AND 6),
     input              BLOB,
+    version             NUMBER(19, 0)               NOT NULL,
     PRIMARY KEY (application_id, instance_id)
 );
 

--- a/docs/modules/ROOT/examples/persistence/V1__create_tables_pg.sql
+++ b/docs/modules/ROOT/examples/persistence/V1__create_tables_pg.sql
@@ -12,6 +12,7 @@ CREATE TABLE cloud_event_entity
     extensions        BYTEA,
     processed_flag    BOOLEAN DEFAULT FALSE,
     version           SMALLINT     NOT NULL CHECK (version BETWEEN 0 AND 1),
+    opt_lock_version  BIGINT       NOT NULL,
     PRIMARY KEY (id)
 );
 
@@ -25,6 +26,7 @@ CREATE TABLE workflow_instance_entity
     started_at         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
     status             SMALLINT CHECK (status BETWEEN 0 AND 6),
     input              BYTEA,
+    version             BIGINT                     NOT NULL,
     PRIMARY KEY (application_id, instance_id)
 );
 

--- a/langchain4j/integration-tests/src/main/resources/db/migration/V1__create_tables.sql
+++ b/langchain4j/integration-tests/src/main/resources/db/migration/V1__create_tables.sql
@@ -12,6 +12,7 @@ CREATE TABLE cloud_event_entity
     extensions        VARBINARY,
     processed_flag    BOOLEAN DEFAULT FALSE,
     version           TINYINT      NOT NULL CHECK (version BETWEEN 0 AND 1),
+    opt_lock_version  BIGINT       NOT NULL,
     PRIMARY KEY (id)
 );
 
@@ -25,6 +26,7 @@ CREATE TABLE workflow_instance_entity
     started_at         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
     status             TINYINT CHECK (status BETWEEN 0 AND 6),
     input              VARBINARY,
+    version             BIGINT                     NOT NULL,
     PRIMARY KEY (application_id, instance_id)
 );
 

--- a/langchain4j/integration-tests/src/main/resources/db/migration/h2/V1__create_tables.sql
+++ b/langchain4j/integration-tests/src/main/resources/db/migration/h2/V1__create_tables.sql
@@ -12,6 +12,7 @@ CREATE TABLE cloud_event_entity
     extensions        VARBINARY,
     processed_flag    BOOLEAN DEFAULT FALSE,
     version           TINYINT      NOT NULL CHECK (version BETWEEN 0 AND 1),
+    opt_lock_version  BIGINT       NOT NULL,
     PRIMARY KEY (id)
 );
 
@@ -25,6 +26,7 @@ CREATE TABLE workflow_instance_entity
     started_at         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
     status             TINYINT CHECK (status BETWEEN 0 AND 6),
     input              VARBINARY,
+    version             BIGINT                     NOT NULL,
     PRIMARY KEY (application_id, instance_id)
 );
 

--- a/langchain4j/integration-tests/src/main/resources/db/migration/mysql/V1__create_tables.sql
+++ b/langchain4j/integration-tests/src/main/resources/db/migration/mysql/V1__create_tables.sql
@@ -12,6 +12,7 @@ CREATE TABLE cloud_event_entity
     extensions        LONGBLOB,
     processed_flag    BOOLEAN DEFAULT FALSE,
     version           TINYINT      NOT NULL CHECK (version BETWEEN 0 AND 1),
+    opt_lock_version  BIGINT       NOT NULL,
     PRIMARY KEY (id)
 );
 
@@ -25,6 +26,7 @@ CREATE TABLE workflow_instance_entity
     started_at         DATETIME(6)  NOT NULL,
     status             TINYINT CHECK (status BETWEEN 0 AND 6),
     input              LONGBLOB,
+    version             BIGINT      NOT NULL,
     PRIMARY KEY (application_id, instance_id)
 );
 

--- a/langchain4j/integration-tests/src/main/resources/db/migration/oracle/V1__create_tables.sql
+++ b/langchain4j/integration-tests/src/main/resources/db/migration/oracle/V1__create_tables.sql
@@ -12,6 +12,7 @@ CREATE TABLE cloud_event_entity
     extensions        BLOB,
     processed_flag    NUMBER(1, 0) DEFAULT 0,
     version           NUMBER(3, 0)  NOT NULL CHECK (version BETWEEN 0 AND 1),
+    opt_lock_version  NUMBER(19, 0) NOT NULL,
     PRIMARY KEY (id)
 );
 
@@ -25,6 +26,7 @@ CREATE TABLE workflow_instance_entity
     started_at         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
     status             NUMBER(3, 0) CHECK (status BETWEEN 0 AND 6),
     input              BLOB,
+    version             NUMBER(19, 0)               NOT NULL,
     PRIMARY KEY (application_id, instance_id)
 );
 

--- a/langchain4j/integration-tests/src/main/resources/db/migration/postgresql/V1__create_tables.sql
+++ b/langchain4j/integration-tests/src/main/resources/db/migration/postgresql/V1__create_tables.sql
@@ -12,6 +12,7 @@ CREATE TABLE cloud_event_entity
     extensions        BYTEA,
     processed_flag    BOOLEAN DEFAULT FALSE,
     version           SMALLINT     NOT NULL CHECK (version BETWEEN 0 AND 1),
+    opt_lock_version  BIGINT       NOT NULL,
     PRIMARY KEY (id)
 );
 
@@ -25,6 +26,7 @@ CREATE TABLE workflow_instance_entity
     started_at         TIMESTAMP(6) WITH TIME ZONE NOT NULL,
     status             SMALLINT CHECK (status BETWEEN 0 AND 6),
     input              BYTEA,
+    version             BIGINT                     NOT NULL,
     PRIMARY KEY (application_id, instance_id)
 );
 

--- a/persistence/jpa/integration-tests/src/test/java/io/quarkiverse/flow/persistence/jpa/test/WorkflowInstanceOptimisticLockIT.java
+++ b/persistence/jpa/integration-tests/src/test/java/io/quarkiverse/flow/persistence/jpa/test/WorkflowInstanceOptimisticLockIT.java
@@ -1,0 +1,64 @@
+package io.quarkiverse.flow.persistence.jpa.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.OptimisticLockException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkiverse.flow.persistence.jpa.WorkflowInstanceEntity;
+import io.quarkiverse.flow.persistence.jpa.WorkflowInstanceKey;
+import io.quarkiverse.flow.persistence.jpa.WorkflowInstanceRepository;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import io.serverlessworkflow.impl.WorkflowDefinitionId;
+import io.serverlessworkflow.impl.WorkflowStatus;
+
+/**
+ * Reproduces #864: without a @Version column, two concurrent readers of the same
+ * WorkflowInstanceEntity row can each write back their changes and the second write
+ * silently overwrites the first (lost update). With @Version in place, the stale
+ * writer must fail with OptimisticLockException instead of clobbering the other write.
+ */
+@QuarkusTest
+@DisabledOnOs(OS.WINDOWS)
+public class WorkflowInstanceOptimisticLockIT {
+
+    @Inject
+    WorkflowInstanceRepository repository;
+
+    @Test
+    @DisplayName("test_concurrent_updates_to_same_instance_fail_fast_instead_of_losing_a_write")
+    void concurrent_updates_to_same_instance_fail_fast_instead_of_losing_a_write() {
+        String applicationId = "app-864";
+        String instanceId = "instance-864";
+        WorkflowInstanceKey key = new WorkflowInstanceKey(instanceId, applicationId);
+        WorkflowDefinitionId definitionId = new WorkflowDefinitionId("ns", "hello", "1.0");
+
+        QuarkusTransaction.requiringNew().run(() -> repository
+                .persist(new WorkflowInstanceEntity(applicationId, definitionId, instanceId, Instant.now(), null)));
+
+        WorkflowInstanceEntity readerA = QuarkusTransaction.requiringNew().call(() -> repository.findById(key));
+        WorkflowInstanceEntity readerB = QuarkusTransaction.requiringNew().call(() -> repository.findById(key));
+
+        QuarkusTransaction.requiringNew().run(() -> {
+            readerB.setStatus(WorkflowStatus.RUNNING);
+            repository.getEntityManager().merge(readerB);
+        });
+
+        assertThatThrownBy(() -> QuarkusTransaction.requiringNew().run(() -> {
+            readerA.setStatus(WorkflowStatus.COMPLETED);
+            repository.getEntityManager().merge(readerA);
+        })).isInstanceOf(OptimisticLockException.class);
+
+        WorkflowInstanceEntity persisted = QuarkusTransaction.requiringNew().call(() -> repository.findById(key));
+        assertThat(persisted.getStatus()).isEqualTo(WorkflowStatus.RUNNING);
+    }
+}

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/CloudEventEntity.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/CloudEventEntity.java
@@ -19,7 +19,6 @@ public class CloudEventEntity {
     private String id;
 
     @Version
-    @Column(name = "opt_lock_version")
     private Long optLockVersion;
 
     @Column(nullable = false)

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/CloudEventEntity.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/CloudEventEntity.java
@@ -6,6 +6,7 @@ import java.time.OffsetDateTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Version;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
@@ -16,6 +17,10 @@ public class CloudEventEntity {
 
     @Id
     private String id;
+
+    @Version
+    @Column(name = "opt_lock_version")
+    private Long optLockVersion;
 
     @Column(nullable = false)
     private String regId;
@@ -161,6 +166,14 @@ public class CloudEventEntity {
 
     public void setExtensions(byte[] extensions) {
         this.extensions = extensions;
+    }
+
+    public Long getOptLockVersion() {
+        return optLockVersion;
+    }
+
+    public void setOptLockVersion(Long optLockVersion) {
+        this.optLockVersion = optLockVersion;
     }
 
 }

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/CloudEventRepository.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/CloudEventRepository.java
@@ -3,6 +3,7 @@ package io.quarkiverse.flow.persistence.jpa;
 import java.util.Collection;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.LockModeType;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 
@@ -10,7 +11,7 @@ import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 public class CloudEventRepository implements PanacheRepositoryBase<CloudEventEntity, String> {
 
     public Collection<CloudEventEntity> findByRegId(Collection<String> regIds) {
-        return list("regId in ?1 and processedFlag != true", regIds);
+        return find("regId in ?1 and processedFlag != true", regIds).withLock(LockModeType.PESSIMISTIC_WRITE).list();
     }
 
     public void setProcessed(Collection<String> ids) {

--- a/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/WorkflowInstanceEntity.java
+++ b/persistence/jpa/runtime/src/main/java/io/quarkiverse/flow/persistence/jpa/WorkflowInstanceEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Version;
 
 import org.hibernate.annotations.DynamicUpdate;
 
@@ -22,6 +23,9 @@ import io.serverlessworkflow.impl.WorkflowStatus;
 @DynamicUpdate
 @IdClass(WorkflowInstanceKey.class)
 public class WorkflowInstanceEntity {
+
+    @Version
+    private Long version;
 
     @Id
     private String instanceId;
@@ -102,5 +106,13 @@ public class WorkflowInstanceEntity {
 
     public void setTasks(Collection<TaskInfoEntity> tasks) {
         this.tasks = tasks;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
     }
 }


### PR DESCRIPTION
## Description
Fixes #864
This pull request addresses concurrency and data consistency issues in the JPA persistence layer (`persistence/jpa`):
1. **Lost updates on workflow state transitions:**
   - State writes occur asynchronously in `REQUIRES_NEW` transactions via `ManagedExecutor`. Without optimistic locking, out-of-order transaction commits could silently overwrite newer state changes (*last-writer-wins*).
   - **Fix:** Added `@Version private Long version;` to `WorkflowInstanceEntity`.
2. **Duplicate CloudEvent processing (TOCTOU race condition):**
   - In a multi-node/clustered setup, multiple nodes could query the same pending `CloudEventEntity` concurrently, both process it and both mark it as processed, resulting in duplicate workflow instances.
   - **Fix:** 
     - Added `@Version @Column(name = "opt_lock_version") private Long optLockVersion;` to `CloudEventEntity` (named `optLockVersion` to avoid collision with the CNCF CloudEvents spec version field `SpecVersion version`).
     - Added `LockModeType.PESSIMISTIC_WRITE` (`SELECT ... FOR UPDATE`) to `CloudEventRepository.findByRegId(...)` to prevent concurrent reads of uncommitted/unprocessed events across nodes.
## Changes
- `WorkflowInstanceEntity.java`: Added JPA `@Version private Long version;` with getters/setters for optimistic locking.
- `CloudEventEntity.java`: Added JPA `@Version @Column(name = "opt_lock_version") private Long optLockVersion;` with getters/setters.
- `CloudEventRepository.java`: Updated `findByRegId` to query with `.withLock(LockModeType.PESSIMISTIC_WRITE)`.
## Testing
### Test Plan
- [x] Unit tests executed
- [x] JPA module compilation and packaging verified: `mvn clean install -pl persistence/jpa/runtime,persistence/jpa/deployment`
- [x] Code formatting verified with project plugins (`formatter:format` & `impsort:sort`)
### Manual Testing
Tested locally using Maven on Java 21 to verify that JPA entity models and Panache repository queries compile and pass cleanly without breaking changes.

## Additional Notes
This is my **first contribution** to the Quarkus Flow project! 🎉
### Visual Concurrency Flow
```mermaid
sequenceDiagram
    autonumber
    participant Node1 as Node 1
    participant DB as JPA Database
    participant Node2 as Node 2
    Note over Node1, Node2: Pessimistic Lock on findByRegId prevents duplicate processing
    Node1->>DB: findByRegId (SELECT ... FOR UPDATE)
    activate DB
    Note over DB: Locks CloudEvent row
    Node2-->>DB: findByRegId (SELECT ... FOR UPDATE)
    Note over Node2: Waits for lock release...
    Node1->>DB: Process event & set processedFlag = true (COMMIT)
    deactivate DB
    Note over DB: Lock released
    DB-->>Node2: Event already processed (ignored)
    Note over Node1, DB: Optimistic Lock on WorkflowInstanceEntity
    Node1->>DB: UPDATE WorkflowInstanceEntity SET status = 'RUNNING', version = 2 WHERE id = 1 AND version = 1
    Note over DB: Detected and verified via @Version
```
---
Please let me know if any changes, adjustments, or additional details are needed. I would be glad to update the PR accordingly!