### PR TITLE
Remove programatically ProcessResult reflection config for native image

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowNativeProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/flow/deployment/FlowNativeProcessor.java
@@ -18,7 +18,6 @@ import io.serverlessworkflow.impl.events.CloudEventPredicateFactory;
 import io.serverlessworkflow.impl.events.EventConsumer;
 import io.serverlessworkflow.impl.events.EventPublisher;
 import io.serverlessworkflow.impl.executors.CallableTaskBuilder;
-import io.serverlessworkflow.impl.executors.ProcessResult;
 import io.serverlessworkflow.impl.executors.RunnableTaskBuilder;
 import io.serverlessworkflow.impl.executors.TaskExecutorFactory;
 import io.serverlessworkflow.impl.executors.http.HttpRequestDecorator;
@@ -58,13 +57,6 @@ final class FlowNativeProcessor {
             BuildProducer<LambdaCapturingTypeBuildItem> producer) {
         indexedClasses.getIndex().getAllKnownImplementations(Flowable.class).stream().map(ClassInfo::toString)
                 .map(LambdaCapturingTypeBuildItem::new).forEach(producer::produce);
-    }
-
-    // It should be removed after: https://github.com/open-workflow-specification/sdk-java/issues/1627
-    @BuildStep
-    ReflectiveClassBuildItem registerRecordForReflection() {
-        return ReflectiveClassBuildItem.builder(
-                ProcessResult.class).methods().fields().build();
     }
 
     @BuildStep


### PR DESCRIPTION
Closes #913 

After removing the programatically reflection configuration via `NativeImageBuildItem`, the `RunTaskIT` works correctly in native mode after: 

```shell
mvn clean install -pl opentelemetry/integration-tests -am -Dnative -DskipITs=false                
```

I got:

```shell
[INFO] Running io.quarkiverse.flow.opentelemetry.it.RunTaskIT
Executing run shell task

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.023 s -- in io.quarkiverse.flow.opentelemetry.it.RunTaskIT
```

Final report:

```shell
[INFO] Reactor Summary for Quarkus Flow :: Parent 2.0.0-SNAPSHOT:
[INFO] 
[INFO] Quarkus Flow :: Parent ............................. SUCCESS [  0.530 s]
[INFO] Quarkus Flow :: Messaging :: Parent ................ SUCCESS [  0.010 s]
[INFO] Quarkus Flow :: Messaging :: Runtime ............... SUCCESS [  1.625 s]
[INFO] Quarkus Flow :: Core :: Parent ..................... SUCCESS [  0.010 s]
[INFO] Quarkus Flow :: Core :: Runtime .................... SUCCESS [ 14.426 s]
[INFO] Quarkus Flow :: Opentelemetry :: Parent ............ SUCCESS [  0.007 s]
[INFO] Quarkus Flow :: Opentelemetry :: Runtime ........... SUCCESS [  0.424 s]
[INFO] Quarkus Flow :: Opentelemetry :: Deployment ........ SUCCESS [  0.159 s]
[INFO] Quarkus Flow :: Opentelemetry :: Integration Tests . SUCCESS [02:32 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:50 min
[INFO] Finished at: 2026-09-01T12:07:03-03:00
[INFO] ------------------------------------------------------------------------
```