### PR TITLE
docs: NO_ISSUE: Fixes for docs based on holistic review

### DIFF
--- a/docs/modules/ROOT/pages/dsl-cheatsheet.adoc
+++ b/docs/modules/ROOT/pages/dsl-cheatsheet.adoc
@@ -521,7 +521,7 @@ Workflow w = workflow("intelligent-newsletter")
 
 == See also
 
-- xref:specification.adoc[]
-- xref:getting-started.adoc[]
-- xref:langchain4j.adoc[]
-- xref:messaging.adoc[]
+- xref:specification.adoc[Open Workflow Specification mapping and concepts]
+- xref:getting-started.adoc[Getting started with Quarkus Flow]
+- xref:langchain4j.adoc[Orchestrate LangChain4j Agents and Patterns]
+- xref:messaging.adoc[Use messaging and events]

--- a/docs/modules/ROOT/pages/http-client.adoc
+++ b/docs/modules/ROOT/pages/http-client.adoc
@@ -27,6 +27,7 @@ For retry and circuit breaker configurations, see xref:fault-tolerance.adoc[Faul
 All Flow HTTP and OpenAPI tasks use a `jakarta.ws.rs.client.Client` managed by Quarkus Flow.
 
 At runtime, Quarkus Flow:
+
 * Builds a *default client* from `quarkus.flow.http.client.*`.
 * Optionally builds *named clients* from `quarkus.flow.http.client.named.<name>.*`.
 * Resolves *which client to use* for a given workflow or task using `quarkus.flow.http.client.workflow.*` routing.

--- a/docs/modules/ROOT/pages/oauth2-oidc-authentication.adoc
+++ b/docs/modules/ROOT/pages/oauth2-oidc-authentication.adoc
@@ -37,7 +37,7 @@ Add `quarkus-flow-oidc` to your project to enable OAuth2/OIDC authentication in 
 
 This extension brings `quarkus-oidc-client` as a transitive dependency and delegates token negotiation to it.
 
-To opt out, set `quarkus.flow.oidc.enabled=false` (see the <<configuration-reference>>).
+To opt out, set `quarkus.flow.oidc.enabled=false` (see the xref:configuration.adoc[configuration reference]).
 
 [NOTE]
 ====

--- a/docs/modules/ROOT/pages/quarkus-flow-cookbook.adoc
+++ b/docs/modules/ROOT/pages/quarkus-flow-cookbook.adoc
@@ -425,7 +425,7 @@ do:
 
 // TODO: add it later in the "OpenAPI" section
 
-== 6. gRPC
+== 14. gRPC
 
 Quarkus Flow supports gRPC via the `quarkus-flow-grpc` module.
 By default, it uses the `flowGrpc` Quarkus gRPC client if configured.

--- a/docs/modules/ROOT/pages/quarkus-flow-java-cookbook.adoc
+++ b/docs/modules/ROOT/pages/quarkus-flow-java-cookbook.adoc
@@ -183,4 +183,4 @@ include::{examples-dir}/org/acme/RaiseWorkflow.java[]
 :sectnums!:
 == See also
 
-* xref:dsl-cheatsheet.adoc[] — a quick cheatsheet to Java DSL.
+* xref:dsl-cheatsheet.adoc[Java DSL cheat sheet] — a quick cheatsheet to Java DSL.

--- a/docs/modules/ROOT/pages/specification.adoc
+++ b/docs/modules/ROOT/pages/specification.adoc
@@ -51,37 +51,37 @@ The CNCF 1.0.0 Specification organizes workflows around the `document` (metadata
 |**Task: `set`**
 |Evaluates an expression and updates the workflow data context.
 |Initialize fields, compute constants, or shape intermediate values.
-|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#settask[Reference]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#set[Reference]
 
 |**Task: `call`**
 |Invokes external endpoints or internal functions.
 |HTTP/OpenAPI calls, communicating with other microservices, or triggering LangChain4j AI agents.
-|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#calltask[Reference]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#call[Reference]
 
 |**Task: `emit`**
 |Publishes a CloudEvent to an external broker.
 |Notify other services, fan-out architectural patterns, or broadcast integration events.
-|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#emittask[Reference]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#emit[Reference]
 
 |**Task: `listen`**
 |Pauses execution and waits for one or more CloudEvents matching specific correlation rules.
 |Human-in-the-loop approvals, asynchronous callbacks, or waiting for external system signals.
-|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#listentask[Reference]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#listen[Reference]
 
 |**Task: `switch` (Branching)**
 |Evaluates conditions (`when`) and routes execution to specific paths (`then`).
 |Feature flags, guardrails, compliance checks, or routing "happy vs. error" paths.
-|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#switchtask[Reference]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#switch[Reference]
 
 |**Task: `for` (Loops)**
 |Iterates over a collection in the data context, executing a block of tasks for each item.
 |Batch processing, agentic revise-loops, or polling.
-|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#fortask[Reference]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#for[Reference]
 
 |**Task: `try` (Errors)**
 |Executes a block of tasks and catches specific errors to trigger compensations or retries.
 |Wrap unreliable network calls, steer to fallback paths, and surface clear failures without crashing the instance.
-|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#trytask[Reference]
+|link:https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#try[Reference]
 
 |**Task: `run` (Sub-workflows only)**
 |Executes external processes or nested workflows. **Only `run.workflow` (sub-workflow invocation) is supported.** Shell, script, and container execution are not supported. See xref:run-tasks.adoc[Run Tasks] for details.

--- a/docs/modules/ROOT/pages/specification.adoc
+++ b/docs/modules/ROOT/pages/specification.adoc
@@ -9,7 +9,7 @@ If you understand these concepts, you can read any Quarkus Flow example and know
 
 [TIP]
 ====
-Check out the xref:quarkus-flow-cookbook.adoc[] to see these concepts applied in real-world, contextualized YAML examples.
+Check out the xref:quarkus-flow-cookbook.adoc[Quarkus Flow & Open Workflow cookbook] to see these concepts applied in real-world, contextualized YAML examples.
 ====
 
 == What the spec gives you (in 30 seconds)

--- a/docs/modules/ROOT/pages/specification.adoc
+++ b/docs/modules/ROOT/pages/specification.adoc
@@ -117,7 +117,7 @@ Crucially, Quarkus Flow leans into the Quarkus "Ahead-of-Time" philosophy by dis
 
 Now that you understand the underlying specification, here is where you can see these concepts applied in Quarkus Flow:
 
-* xref:quarkus-flow-cookbook.adoc[]: A comprehensive collection of practical, copy-and-paste YAML examples for the Open Workflow DSL.
+* xref:quarkus-flow-cookbook.adoc[Quarkus Flow & Open Workflow cookbook]: A comprehensive collection of practical, copy-and-paste YAML examples for the Open Workflow DSL.
 * xref:workflow-definitions.adoc[Define workflows from YAML]: review the syntax for discovering and injecting YAML workflows.
 * xref:dsl-cheatsheet.adoc[Java DSL Cheatsheet]: A quick reference of all the Java methods that map directly to these CNCF tasks.
 * xref:data-flow.adoc[Data flow and context management]: A deep dive into how `input`, `output`, and `export` manipulate the workflow data context.

--- a/docs/modules/ROOT/pages/workflow-definitions.adoc
+++ b/docs/modules/ROOT/pages/workflow-definitions.adoc
@@ -177,7 +177,7 @@ curl "http://localhost:8080/echo?name=John"
 
 == See also
 
-* xref:quarkus-flow-cookbook.adoc[] — A comprehensive collection of practical, copy-and-paste YAML examples for the Open Workflow DSL.
+* xref:quarkus-flow-cookbook.adoc[Worflow Cookbook (YAML)] — A comprehensive collection of practical, copy-and-paste YAML examples for the Open Workflow DSL.
 * xref:specification.adoc[Open Workflow Spec mapping and concepts] — a quick orientation to the 1.x.x specification components.
 * xref:data-flow.adoc[Data flow and context management] — understand how data mutates across YAML tasks.
 * xref:test-debug.adoc[Test and debug workflows] — learn how to write unit tests for your injected `Flow` beans.


### PR DESCRIPTION
## Description

Fixes for docs based on holistic review I am conducting.

## Changes

- Fixes missing reference title in workflow-definitins.adoc, adds title to an `xref` in workflow-definitins.adoc. Sets it to `Worflow Cookbook (YAML)`

## Changed pages
https://quarkiverse-flow-pr-924-preview.surge.sh/quarkus-flow/dev/workflow-definitions.html

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [x] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [x] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [x] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

