### PR TITLE
Use bean validation to validate workflow fields

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/WorkflowDiagramEditorRoundTripTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/flow/deployment/test/devui/WorkflowDiagramEditorRoundTripTest.java
@@ -46,6 +46,7 @@ import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.WaitForSelectorState;
 
 import io.quarkus.test.QuarkusDevModeTest;
 
@@ -184,7 +185,7 @@ public class WorkflowDiagramEditorRoundTripTest {
                 // emit task — covers the emit-node diagram element.
                 Arguments.of(
                         "emit-java",
-                        "diagramEditor-org-acme-emit-event-workflow-1-0",
+                        "diagramEditor-org-acme-emit-event-workflow-1-0-0",
                         "emit-node-/do/orderPlaced",
                         "orderPlaced"),
                 // listen task — covers the listen-node diagram element.
@@ -196,14 +197,14 @@ public class WorkflowDiagramEditorRoundTripTest {
                 // subflow task — mapped to run-node in the diagram editor.
                 Arguments.of(
                         "parent-java",
-                        "diagramEditor-org-acme-parent-workflow-with-children-1-0",
+                        "diagramEditor-org-acme-parent-workflow-with-children-1-0-0",
                         "run-node-/do/executeHttpWorkflow",
                         "executeHttpWorkflow"),
                 // standalone named HTTP call — dedicated call-node root-level case.
-                // org.acme namespace (dotted) → org-acme in diagramEditorId; version 1.0 → 1-0.
+                // org.acme namespace (dotted) → org-acme in diagramEditorId; version 1.0.0 → 1-0-0.
                 Arguments.of(
                         "http-call-java",
-                        "diagramEditor-org-acme-http-with-query-headers-1-0",
+                        "diagramEditor-org-acme-http-with-query-headers-1-0-0",
                         "call-node-/do/searchStarWarsCharacters",
                         "searchStarWarsCharacters"),
                 // cron-scheduled workflow — only case with a schedule block in the serialised JSON.
@@ -301,7 +302,7 @@ public class WorkflowDiagramEditorRoundTripTest {
         // After scrollToIndex the target row is rendered; wait for its button.
         page.waitForSelector(buttonSelector,
                 new Page.WaitForSelectorOptions()
-                        .setState(com.microsoft.playwright.options.WaitForSelectorState.ATTACHED)
+                        .setState(WaitForSelectorState.ATTACHED)
                         .setTimeout(10_000));
 
         // Step 2 — click eye button; wait for dialog to attach (it is inside a Vaadin
@@ -309,7 +310,7 @@ public class WorkflowDiagramEditorRoundTripTest {
         page.locator(buttonSelector).click();
         page.locator("vaadin-dialog[opened]")
                 .waitFor(new Locator.WaitForOptions()
-                        .setState(com.microsoft.playwright.options.WaitForSelectorState.ATTACHED));
+                        .setState(WaitForSelectorState.ATTACHED));
 
         // Step 3 — diagram container appears (loading completes)
         page.locator("[data-testid='diagram-container']").waitFor();
@@ -325,11 +326,11 @@ public class WorkflowDiagramEditorRoundTripTest {
         page.keyboard().press("Escape");
         page.locator("vaadin-dialog[opened]")
                 .waitFor(new Locator.WaitForOptions()
-                        .setState(com.microsoft.playwright.options.WaitForSelectorState.HIDDEN));
+                        .setState(WaitForSelectorState.HIDDEN));
         page.locator(buttonSelector).click();
         page.locator("vaadin-dialog[opened]")
                 .waitFor(new Locator.WaitForOptions()
-                        .setState(com.microsoft.playwright.options.WaitForSelectorState.ATTACHED));
+                        .setState(WaitForSelectorState.ATTACHED));
         page.locator("[data-testid='diagram-container']").waitFor();
 
         Locator taskNodeAfterReopen = page.locator("[data-testid='" + taskTestId + "']");

--- a/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FlowWorkflowBuilder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/dsl/FlowWorkflowBuilder.java
@@ -3,17 +3,27 @@ package io.quarkiverse.flow.dsl;
 import static io.serverlessworkflow.types.Defaults.DEFAULT_NAMESPACE;
 import static io.serverlessworkflow.types.Defaults.DEFAULT_VERSION;
 
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 
 import io.cloudevents.CloudEvent;
 import io.quarkiverse.flow.dsl.spi.FuncTransformations;
+import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.fluent.spec.BaseWorkflowBuilder;
 import io.serverlessworkflow.fluent.spec.ScheduleBuilder;
+import io.serverlessworkflow.impl.WorkflowDefinitionId;
 
 public class FlowWorkflowBuilder
         extends BaseWorkflowBuilder<FlowWorkflowBuilder, FuncDoTaskBuilder, FuncTaskItemListBuilder>
         implements FuncTransformations<FlowWorkflowBuilder> {
+
+    private static final Validator VALIDATOR = Validation.buildDefaultValidatorFactory().getValidator();
 
     protected FlowWorkflowBuilder(final String name, final String namespace, final String version) {
         super(name, namespace, version);
@@ -86,5 +96,19 @@ public class FlowWorkflowBuilder
     @Override
     protected FlowWorkflowBuilder self() {
         return this;
+    }
+
+    @Override
+    public Workflow build() {
+        Set<ConstraintViolation<Workflow>> violations = VALIDATOR.validate(this.workflow);
+        if (!violations.isEmpty()) {
+            String allErrors = violations.stream()
+                    .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+                    .collect(Collectors.joining(", "));
+            throw new IllegalArgumentException(
+                    "Invalid workflow definition [" + WorkflowDefinitionId.of(this.workflow) + "]. " +
+                            "See all errors: " + allErrors);
+        }
+        return this.workflow;
     }
 }

--- a/core/runtime/src/test/java/io/quarkiverse/flow/dsl/FlowWorkflowBuilderValidationTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/flow/dsl/FlowWorkflowBuilderValidationTest.java
@@ -1,0 +1,47 @@
+package io.quarkiverse.flow.dsl;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FlowWorkflowBuilderValidationTest {
+
+    @Test
+    @DisplayName("test_build_rejects_namespace_with_invalid_characters")
+    void test_build_rejects_namespace_with_invalid_characters() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> FlowWorkflowBuilder.workflow("processPhotoWorkflow", "guru.quarkus").build())
+                .withMessageContaining("document.namespace: must match \"^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$");
+    }
+
+    @Test
+    @DisplayName("test_build_rejects_name_with_invalid_characters")
+    void test_build_rejects_name_with_invalid_characters() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> FlowWorkflowBuilder.workflow("bad name!", "guru-quarkus").build())
+                .withMessageContaining("document.name");
+    }
+
+    @Test
+    @DisplayName("test_build_rejects_non_semver_version")
+    void test_build_rejects_non_semver_version() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> FlowWorkflowBuilder.workflow("processPhotoWorkflow", "guru-quarkus", "v1").build())
+                .withMessageContaining("document.version");
+    }
+
+    @Test
+    @DisplayName("test_build_does_not_validate_nested_task_fields")
+    void test_build_does_not_validate_nested_task_fields() {
+        // CallHTTP.with is left completely empty here: both "method" and "endpoint"
+        // are @NotNull on HTTPArguments (and required by the JSON Schema), but the
+        // cascade never reaches into task content, so build() succeeds anyway.
+        assertThatNoException()
+                .isThrownBy(() -> FlowWorkflowBuilder.workflow("processPhotoWorkflow", "guru-quarkus")
+                        .tasks(doTask -> doTask.http("callTask", httpTask -> {
+                        }))
+                        .build());
+    }
+}

--- a/docs/modules/ROOT/examples/org/acme/EmitWorkflow.java
+++ b/docs/modules/ROOT/examples/org/acme/EmitWorkflow.java
@@ -12,7 +12,7 @@ import io.serverlessworkflow.api.types.Workflow;
 public class EmitWorkflow extends Flow {
     @Override
     public Workflow descriptor() {
-        return FlowWorkflowBuilder.workflow("emit-event-workflow", "org.acme", "1.0")
+        return FlowWorkflowBuilder.workflow("emit-event-workflow", "org-acme", "1.0.0")
                 .tasks(
                         emitJson("orderPlaced", "com.petstore.order.placed.v1", Message.class))
                 .build();

--- a/docs/modules/ROOT/examples/org/acme/HttpWorkflow.java
+++ b/docs/modules/ROOT/examples/org/acme/HttpWorkflow.java
@@ -20,7 +20,7 @@ public class HttpWorkflow extends Flow {
 
     @Override
     public Workflow descriptor() {
-        return FlowWorkflowBuilder.workflow("http-with-query-headers", "org.acme", "1.0")
+        return FlowWorkflowBuilder.workflow("http-with-query-headers", "org-acme", "1.0.0")
                 .tasks(
                         call("searchStarWarsCharacters",
                                 http()

--- a/docs/modules/ROOT/examples/org/acme/ParentWorkflow.java
+++ b/docs/modules/ROOT/examples/org/acme/ParentWorkflow.java
@@ -13,7 +13,7 @@ import io.serverlessworkflow.api.types.Workflow;
 public class ParentWorkflow extends Flow {
     @Override
     public Workflow descriptor() {
-        return FlowWorkflowBuilder.workflow("parent-workflow-with-children", "org.acme", "1.0")
+        return FlowWorkflowBuilder.workflow("parent-workflow-with-children", "org-acme", "1.0.0")
                 .tasks(
                         // Using workflow(...) shortcut to reference existing workflow
                         subflow("executeHttpWorkflow",
@@ -22,8 +22,8 @@ public class ParentWorkflow extends Flow {
                         subflow("emitEventSubflow",
                                 configurer -> configurer.workflow()
                                         .withName("emit-event-workflow")
-                                        .withNamespace("org.acme")
-                                        .withVersion("1.0")))
+                                        .withNamespace("org-acme")
+                                        .withVersion("1.0.0")))
                 .build();
     }
 }

--- a/durable-kubernetes/integration-tests/src/main/java/io/quarkiverse/flow/durable/kube/it/GreetingsFlow.java
+++ b/durable-kubernetes/integration-tests/src/main/java/io/quarkiverse/flow/durable/kube/it/GreetingsFlow.java
@@ -15,7 +15,7 @@ public class GreetingsFlow extends Flow {
 
     @Override
     public Workflow descriptor() {
-        return FlowWorkflowBuilder.workflow("greetings", "io.quarkiverse.flow.durable.kube")
+        return FlowWorkflowBuilder.workflow("greetings", "io-quarkiverse-flow-durable-kube")
                 .tasks(set(Map.of("message", "Hello Human!")))
                 .build();
     }


### PR DESCRIPTION
## Description

This pull request uses bean validation to validate the `Workflow` POJO. The `Workflow` POJO and all other POJOs contains bean validation annotation, which can be used to validate the final `Workflow`.  

Of course, we can do manual validation for each `FlowDSL` build's method, but with this way we have a centralized form and aligned with the specification schema (if the schema changes, the sdk-java changes and we already have a validation code running).

<!-- Provide a clear description of what this PR does -->

Fixes #922

## Changes

<!-- List the main changes in this PR -->

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
