### PR TITLE
Upgrade serverlessworkflow to 7.32.0.Final

### DIFF
--- a/docs-rag/pom.xml
+++ b/docs-rag/pom.xml
@@ -23,6 +23,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
                 <executions>
                     <execution>
                         <id>generate-extension-descriptor</id>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
         <quarkus.version>3.39.0</quarkus.version>
         <jandex.version>3.6.0</jandex.version>
-        <io.serverlessworkflow.version>7.30.0.Final</io.serverlessworkflow.version>
+        <io.serverlessworkflow.version>7.32.0.Final</io.serverlessworkflow.version>
         <io.cloudevents.version>5.0.0</io.cloudevents.version>
 
         <io.quarkiverse.jackson-jq.version>2.6.0</io.quarkiverse.jackson-jq.version>


### PR DESCRIPTION
## Summary

Upgrade serverlessworkflow SDK from 7.30.0.Final to 7.32.0.Final

## Changes

- `io.serverlessworkflow.version`: 7.30.0.Final → 7.32.0.Final

## What's included in 7.32.0.Final

- jackson-jq 1.6.4 with Jandex 3.x support (fixes reindexing warnings)
- Jackson 2.22.2
- classgraph 4.8.194
- protobuf-java-util 4.36.1
- grpc-java 1.84.0
- com.networknt 2.0.7
- spotless 3.10.1
- Other dependency updates

This completes the fix for Jandex reindexing warnings in quarkus-flow build (jackson-jq 2.6.0 already merged in #928).

## Testing

- [x] Build successful: `mvn clean install -DskipTests`
- [x] SDK 7.32.0.Final published on Maven Central

Related: #928