### PR TITLE
Add test to see OAuth2 token fetch on a non-blocking resource

### DIFF
--- a/core/integration-tests/src/main/java/io/quarkiverse/flow/it/OAuth2ClientCredentialsResource.java
+++ b/core/integration-tests/src/main/java/io/quarkiverse/flow/it/OAuth2ClientCredentialsResource.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.flow.it;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/oauth2-it")
+@ApplicationScoped
+public class OAuth2ClientCredentialsResource {
+
+    @Inject
+    OAuth2ClientCredentialsWorkflow workflow;
+
+    @GET
+    public Uni<Response> call() {
+        return workflow.startInstance()
+                .onItem()
+                .transform(model -> Response.ok(model.asJavaObject()).build());
+    }
+}

--- a/core/integration-tests/src/main/java/io/quarkiverse/flow/it/OAuth2ClientCredentialsWorkflow.java
+++ b/core/integration-tests/src/main/java/io/quarkiverse/flow/it/OAuth2ClientCredentialsWorkflow.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.flow.it;
+
+import static io.serverlessworkflow.api.types.OAuth2AuthenticationData.OAuth2AuthenticationDataGrant.CLIENT_CREDENTIALS;
+
+import java.net.URI;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkiverse.flow.Flow;
+import io.quarkiverse.flow.dsl.FlowDSL;
+import io.quarkiverse.flow.dsl.FlowWorkflowBuilder;
+import io.serverlessworkflow.api.types.Workflow;
+
+/**
+ * Calls an OAuth2 (client-credentials) protected HTTP service using the Open Workflow SDK's default token
+ * negotiation (no {@code quarkus-flow-oidc} extension on the classpath).
+ */
+@ApplicationScoped
+public class OAuth2ClientCredentialsWorkflow extends Flow {
+
+    @ConfigProperty(name = "oauth2.it.authority")
+    String authority;
+
+    @ConfigProperty(name = "oauth2.it.protected-resource-url")
+    String protectedResourceUrl;
+
+    @Override
+    public Workflow descriptor() {
+        return FlowWorkflowBuilder.workflow("oauth2-client-credentials-it", "quarkus-flow")
+                .tasks(
+                        FlowDSL.call(
+                                FlowDSL.http("call")
+                                        .get()
+                                        .uri(URI.create(protectedResourceUrl),
+                                                FlowDSL.oauth2(authority, CLIENT_CREDENTIALS, "quarkus-flow",
+                                                        "dummy-client-secret", e -> e.token("/oauth2/token")))))
+                .build();
+    }
+}

--- a/core/integration-tests/src/test/java/io/quarkiverse/flow/it/OAuth2ClientCredentialsNonBlockingTest.java
+++ b/core/integration-tests/src/test/java/io/quarkiverse/flow/it/OAuth2ClientCredentialsNonBlockingTest.java
@@ -1,0 +1,78 @@
+package io.quarkiverse.flow.it;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@QuarkusTestResource(OAuth2ClientCredentialsNonBlockingTest.WireMockTestResource.class)
+class OAuth2ClientCredentialsNonBlockingTest {
+
+    @Test
+    @DisplayName("test_oauth2_workflow_completes_when_started_from_a_non_blocking_resource_method")
+    void test_oauth2_workflow_completes_when_started_from_a_non_blocking_resource_method() {
+        when()
+                .get("/oauth2-it")
+                .then()
+                .statusCode(200)
+                .body("email", is("test@example.com"));
+    }
+
+    public static class WireMockTestResource implements QuarkusTestResourceLifecycleManager {
+
+        static WireMockServer server;
+
+        @Override
+        public Map<String, String> start() {
+            server = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+            server.start();
+
+            server.stubFor(post(urlPathEqualTo("/oauth2/token"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(
+                                    """
+                                            {
+                                                "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.KMUFsIDTnFmyG3nMiGM6H9FNFUROf3wh7SmqJp-QV30",
+                                                "token_type":"Bearer",
+                                                "expires_in":3600
+                                            }
+                                            """)));
+
+            server.stubFor(get(urlPathEqualTo("/protected"))
+                    .withHeader("Authorization", containing("Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("{\"email\":\"test@example.com\"}")));
+
+            return Map.of(
+                    "oauth2.it.authority", server.baseUrl(),
+                    "oauth2.it.protected-resource-url", server.baseUrl() + "/protected");
+        }
+
+        @Override
+        public void stop() {
+            if (server != null) {
+                server.stop();
+            }
+        }
+    }
+}


### PR DESCRIPTION


## Description

<!-- Provide a clear description of what this PR does -->

Fixes #923

## Changes

<!-- List the main changes in this PR -->

- Add test to ensure that workflows with oauth2/oidc that does not use quarkus-flow-oidc can execute in a non-blocking way.

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

### Manual Testing

<!-- If you tested manually, describe the steps -->

## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
