### PR TITLE
Correlate flow lifecycle logs with the active OpenTelemetry trace

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -44,6 +44,11 @@
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.flow</groupId>
+        <artifactId>quarkus-flow-spi</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.flow</groupId>
         <artifactId>quarkus-flow-deployment</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,6 +12,7 @@
     <name>Quarkus Flow :: Core :: Parent</name>
 
     <modules>
+        <module>spi</module>
         <module>runtime</module>
         <module>deployment</module>
         <module>runtime-dev</module>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -11,15 +11,14 @@
     <name>Quarkus Flow :: Core :: Runtime</name>
 
     <dependencies>
-
-        <!-- CNCF Java SDK -->
         <dependency>
-            <groupId>io.serverlessworkflow</groupId>
-            <artifactId>serverlessworkflow-api</artifactId>
+            <groupId>io.quarkiverse.flow</groupId>
+            <artifactId>quarkus-flow-spi</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.serverlessworkflow</groupId>
-            <artifactId>serverlessworkflow-impl-core</artifactId>
+            <artifactId>serverlessworkflow-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.serverlessworkflow</groupId>

--- a/core/runtime/src/main/java/io/quarkiverse/flow/recorders/WorkflowApplicationCreator.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/recorders/WorkflowApplicationCreator.java
@@ -27,6 +27,7 @@ import io.quarkiverse.flow.providers.HttpClientProvider;
 import io.quarkiverse.flow.providers.JQScopeSupplier;
 import io.quarkiverse.flow.providers.QuarkusManagedExecutorServiceFactory;
 import io.quarkiverse.flow.providers.WorkflowTaskContext;
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider;
 import io.quarkiverse.flow.tracing.TraceLoggerExecutionListener;
 import io.quarkus.runtime.LaunchMode;
 import io.serverlessworkflow.api.types.CallHTTP;
@@ -93,6 +94,9 @@ public class WorkflowApplicationCreator {
     Instance<MicrometerExecutionListener> micrometerListeners;
 
     @Inject
+    Instance<TraceCorrelationProvider> traceCorrelationProviders;
+
+    @Inject
     @Any
     Instance<WorkflowApplicationBuilderCustomizer> customizers;
 
@@ -112,7 +116,7 @@ public class WorkflowApplicationCreator {
         final Builder builder = WorkflowApplication.builder();
         if (tracingConfig.enabled().orElse(launchMode.isDevOrTest())) {
             LOG.debug("Flow: Tracing enabled");
-            builder.withListener(new TraceLoggerExecutionListener());
+            builder.withListener(new TraceLoggerExecutionListener(resolveTraceCorrelationProvider()));
         }
 
         builder.withContextFactory(new JavaModelFactory()).withModelFactory(new JacksonModelFactory());
@@ -241,6 +245,17 @@ public class WorkflowApplicationCreator {
         if (micrometerListeners.isResolvable()) {
             builder.withListener(micrometerListeners.get());
         }
+    }
+
+    /**
+     * Resolves the optional {@link TraceCorrelationProvider} contributed by the OpenTelemetry
+     * extension, falling back to {@link TraceCorrelationProvider#NOOP} when tracing is not
+     * installed so that flow logs still emit (just without trace identifiers).
+     */
+    private TraceCorrelationProvider resolveTraceCorrelationProvider() {
+        return traceCorrelationProviders.isResolvable()
+                ? traceCorrelationProviders.get()
+                : TraceCorrelationProvider.NOOP;
     }
 
     private void injectJQExpressionFactory(Builder builder) {

--- a/core/runtime/src/main/java/io/quarkiverse/flow/structuredlogging/EventFormatter.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/structuredlogging/EventFormatter.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkiverse.flow.config.FlowStructuredLoggingConfig;
 import io.quarkiverse.flow.config.TimestampFormat;
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider;
 import io.serverlessworkflow.impl.WorkflowDefinitionData;
 import io.serverlessworkflow.impl.WorkflowError;
 import io.serverlessworkflow.impl.WorkflowStatus;
@@ -80,15 +81,28 @@ public class EventFormatter {
     private static final String FIELD_TRUNCATED = "__truncated__";
     private static final String FIELD_ORIGINAL_SIZE = "__originalSize__";
     private static final String FIELD_PREVIEW = "__preview__";
+    // Trace-correlation fields, named to match the SLF4J MDC keys Quarkus' own OpenTelemetry
+    // logging instrumentation uses, so dashboards can rely on a single set of names.
+    private static final String FIELD_TRACE_ID = "traceId";
+    private static final String FIELD_SPAN_ID = "spanId";
+    private static final String FIELD_SAMPLED = "sampled";
+    private static final String FIELD_PARENT_ID = "parentId";
 
     private final FlowStructuredLoggingConfig config;
     private final ObjectMapper objectMapper;
+    private final TraceCorrelationProvider traceCorrelation;
 
     private final DateTimeFormatter customDateFormat;
 
     public EventFormatter(FlowStructuredLoggingConfig config, ObjectMapper objectMapper) {
+        this(config, objectMapper, TraceCorrelationProvider.NOOP);
+    }
+
+    public EventFormatter(FlowStructuredLoggingConfig config, ObjectMapper objectMapper,
+            TraceCorrelationProvider traceCorrelation) {
         this.config = config;
         this.objectMapper = objectMapper;
+        this.traceCorrelation = traceCorrelation == null ? TraceCorrelationProvider.NOOP : traceCorrelation;
 
         // Validate custom pattern if CUSTOM format is selected
         customDateFormat = config.timestampFormat() == TimestampFormat.CUSTOM
@@ -254,6 +268,12 @@ public class EventFormatter {
         json.put(FIELD_EVENT_TYPE, StructuredLoggingEventTypes.toCloudEventType(filterKey));
         json.put(FIELD_TIMESTAMP, formatTimestamp(event.eventDate()));
         json.put(FIELD_INSTANCE_ID, event.workflowContext().instanceData().id());
+        traceCorrelation.traceContextFor(event).ifPresent(tc -> {
+            json.put(FIELD_TRACE_ID, tc.traceId());
+            json.put(FIELD_SPAN_ID, tc.spanId());
+            json.put(FIELD_SAMPLED, tc.sampled());
+            json.put(FIELD_PARENT_ID, tc.parentId());
+        });
         return json;
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/flow/structuredlogging/StructuredLoggingListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/structuredlogging/StructuredLoggingListener.java
@@ -17,6 +17,7 @@ import static io.quarkiverse.flow.structuredlogging.StructuredLoggingEventTypes.
 
 import java.util.logging.Handler;
 
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -27,6 +28,7 @@ import org.jboss.logmanager.formatters.PatternFormatter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkiverse.flow.config.FlowStructuredLoggingConfig;
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider;
 import io.quarkus.arc.lookup.LookupIfProperty;
 import io.serverlessworkflow.impl.lifecycle.TaskCancelledEvent;
 import io.serverlessworkflow.impl.lifecycle.TaskCompletedEvent;
@@ -61,9 +63,13 @@ public class StructuredLoggingListener implements WorkflowExecutionListener {
     private volatile boolean formatterOverridden = false;
 
     @Inject
-    public StructuredLoggingListener(FlowStructuredLoggingConfig config, ObjectMapper objectMapper) {
+    public StructuredLoggingListener(FlowStructuredLoggingConfig config, ObjectMapper objectMapper,
+            Instance<TraceCorrelationProvider> traceCorrelationProviders) {
         this.config = config;
-        this.formatter = new EventFormatter(config, objectMapper);
+        TraceCorrelationProvider traceCorrelation = traceCorrelationProviders.isResolvable()
+                ? traceCorrelationProviders.get()
+                : TraceCorrelationProvider.NOOP;
+        this.formatter = new EventFormatter(config, objectMapper, traceCorrelation);
     }
 
     // Workflow Instance Events

--- a/core/runtime/src/main/java/io/quarkiverse/flow/tracing/TraceLoggerExecutionListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/flow/tracing/TraceLoggerExecutionListener.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider;
 import io.serverlessworkflow.impl.jackson.JsonUtils;
 import io.serverlessworkflow.impl.lifecycle.TaskCancelledEvent;
 import io.serverlessworkflow.impl.lifecycle.TaskCompletedEvent;
@@ -61,6 +62,23 @@ public final class TraceLoggerExecutionListener implements WorkflowExecutionList
     private static final String K_TASK_POS = "quarkus.flow.taskPos";
     private static final String K_TASK_NAME = "quarkus.flow.task";
 
+    // Trace-correlation MDC keys, matching the names Quarkus' own logging instrumentation uses
+    // so existing log formats and dashboards pick them up unchanged.
+    private static final String K_TRACE_ID = "traceId";
+    private static final String K_SPAN_ID = "spanId";
+    private static final String K_SAMPLED = "sampled";
+    private static final String K_PARENT_ID = "parentId";
+
+    private final TraceCorrelationProvider traceCorrelation;
+
+    public TraceLoggerExecutionListener() {
+        this(TraceCorrelationProvider.NOOP);
+    }
+
+    public TraceLoggerExecutionListener(TraceCorrelationProvider traceCorrelation) {
+        this.traceCorrelation = traceCorrelation == null ? TraceCorrelationProvider.NOOP : traceCorrelation;
+    }
+
     private static String pos(TaskEvent ev) {
         return ev.taskContext().position().jsonPointer();
     }
@@ -68,7 +86,7 @@ public final class TraceLoggerExecutionListener implements WorkflowExecutionList
     /**
      * Wraps log emission with MDC population; preserves upstream MDC.
      */
-    private static void withMdc(WorkflowEvent ev, String eventName, Runnable r) {
+    private void withMdc(WorkflowEvent ev, String eventName, Runnable r) {
         if (!log.isInfoEnabled()) {
             return;
         }
@@ -81,6 +99,12 @@ public final class TraceLoggerExecutionListener implements WorkflowExecutionList
                 MDC.put(K_TASK_POS, taskEv.taskContext().position().jsonPointer());
                 MDC.put(K_TASK_NAME, taskEv.taskContext().taskName());
             }
+            traceCorrelation.traceContextFor(ev).ifPresent(tc -> {
+                MDC.put(K_TRACE_ID, tc.traceId());
+                MDC.put(K_SPAN_ID, tc.spanId());
+                MDC.put(K_SAMPLED, tc.sampled());
+                MDC.put(K_PARENT_ID, tc.parentId());
+            });
             r.run();
         } finally {
             if (snapshot == null)

--- a/core/runtime/src/test/java/io/quarkiverse/flow/structuredlogging/EventFormatterTraceCorrelationTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/flow/structuredlogging/EventFormatterTraceCorrelationTest.java
@@ -1,0 +1,112 @@
+package io.quarkiverse.flow.structuredlogging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkiverse.flow.config.FlowStructuredLoggingConfig;
+import io.quarkiverse.flow.config.TimestampFormat;
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider;
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider.TraceContext;
+import io.serverlessworkflow.impl.lifecycle.TaskStartedEvent;
+import io.serverlessworkflow.impl.lifecycle.WorkflowStartedEvent;
+
+@DisplayName("EventFormatter trace correlation fields")
+class EventFormatterTraceCorrelationTest {
+
+    private static final String TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
+    private static final String SPAN_ID = "b7ad6b7169203331";
+    private static final String PARENT_ID = "1100dd0d1d001111";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private FlowStructuredLoggingConfig config;
+
+    @BeforeEach
+    void setUp() {
+        config = mock(FlowStructuredLoggingConfig.class);
+        when(config.timestampFormat()).thenReturn(TimestampFormat.ISO8601);
+        when(config.enabled()).thenReturn(true);
+        when(config.includeWorkflowPayloads()).thenReturn(false);
+        when(config.includeTaskPayloads()).thenReturn(false);
+    }
+
+    private static WorkflowStartedEvent workflowStartedEvent() {
+        WorkflowStartedEvent ev = mock(WorkflowStartedEvent.class, RETURNS_DEEP_STUBS);
+        when(ev.eventDate()).thenReturn(OffsetDateTime.now());
+        when(ev.workflowContext().instanceData().id()).thenReturn("instance-1");
+        return ev;
+    }
+
+    private static TaskStartedEvent taskStartedEvent() {
+        TaskStartedEvent ev = mock(TaskStartedEvent.class, RETURNS_DEEP_STUBS);
+        when(ev.eventDate()).thenReturn(OffsetDateTime.now());
+        when(ev.workflowContext().instanceData().id()).thenReturn("instance-1");
+        when(ev.taskContext().position().jsonPointer()).thenReturn("do/0/greet");
+        when(ev.taskContext().taskName()).thenReturn("greet");
+        return ev;
+    }
+
+    private JsonNode parse(String json) throws Exception {
+        return objectMapper.readTree(json);
+    }
+
+    @Test
+    @DisplayName("adds traceId/spanId/sampled/parentId to a workflow event when a span is active")
+    void workflow_event_carries_trace_fields() throws Exception {
+        TraceCorrelationProvider provider = ev -> Optional.of(new TraceContext(TRACE_ID, SPAN_ID, "true", PARENT_ID));
+        EventFormatter formatter = new EventFormatter(config, objectMapper, provider);
+
+        JsonNode json = parse(formatter.formatWorkflowStarted(workflowStartedEvent()));
+
+        assertThat(json.get("traceId").asText()).isEqualTo(TRACE_ID);
+        assertThat(json.get("spanId").asText()).isEqualTo(SPAN_ID);
+        assertThat(json.get("sampled").asText()).isEqualTo("true");
+        assertThat(json.get("parentId").asText()).isEqualTo(PARENT_ID);
+    }
+
+    @Test
+    @DisplayName("adds trace fields to a task event too")
+    void task_event_carries_trace_fields() throws Exception {
+        TraceCorrelationProvider provider = ev -> Optional.of(new TraceContext(TRACE_ID, SPAN_ID, "true", PARENT_ID));
+        EventFormatter formatter = new EventFormatter(config, objectMapper, provider);
+
+        JsonNode json = parse(formatter.formatTaskStarted(taskStartedEvent()));
+
+        assertThat(json.get("traceId").asText()).isEqualTo(TRACE_ID);
+        assertThat(json.get("spanId").asText()).isEqualTo(SPAN_ID);
+    }
+
+    @Test
+    @DisplayName("omits trace fields when the NOOP provider is used")
+    void noop_provider_omits_trace_fields() throws Exception {
+        EventFormatter formatter = new EventFormatter(config, objectMapper);
+
+        JsonNode json = parse(formatter.formatWorkflowStarted(workflowStartedEvent()));
+
+        assertThat(json.has("traceId")).isFalse();
+        assertThat(json.has("spanId")).isFalse();
+        assertThat(json.has("sampled")).isFalse();
+        assertThat(json.has("parentId")).isFalse();
+    }
+
+    @Test
+    @DisplayName("omits trace fields when the provider reports no active span")
+    void empty_provider_result_omits_trace_fields() throws Exception {
+        EventFormatter formatter = new EventFormatter(config, objectMapper, ev -> Optional.empty());
+
+        JsonNode json = parse(formatter.formatWorkflowStarted(workflowStartedEvent()));
+
+        assertThat(json.has("traceId")).isFalse();
+    }
+}

--- a/core/runtime/src/test/java/io/quarkiverse/flow/structuredlogging/StructuredLoggingListenerTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/flow/structuredlogging/StructuredLoggingListenerTest.java
@@ -9,6 +9,8 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.stream.Stream;
 
+import jakarta.enterprise.inject.Instance;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkiverse.flow.config.FlowStructuredLoggingConfig;
 import io.quarkiverse.flow.config.TimestampFormat;
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider;
 import io.serverlessworkflow.impl.TaskContext;
 import io.serverlessworkflow.impl.WorkflowContext;
 import io.serverlessworkflow.impl.WorkflowInstance;
@@ -92,7 +95,7 @@ public class StructuredLoggingListenerTest {
     @DisplayName("shouldLog should correctly match event patterns")
     void testPatternMatching(String pattern, String eventType, boolean shouldMatch) throws Exception {
         when(config.events()).thenReturn(List.of(pattern));
-        listener = new StructuredLoggingListener(config, objectMapper);
+        listener = new StructuredLoggingListener(config, objectMapper, noProviders());
 
         boolean result = invokeShouldLog(listener, eventType);
 
@@ -104,7 +107,7 @@ public class StructuredLoggingListenerTest {
     void testShouldLogWhenDisabled() throws Exception {
         when(config.enabled()).thenReturn(false);
         when(config.events()).thenReturn(List.of("workflow.*"));
-        listener = new StructuredLoggingListener(config, objectMapper);
+        listener = new StructuredLoggingListener(config, objectMapper, noProviders());
 
         boolean result = invokeShouldLog(listener, "workflow.instance.started");
 
@@ -115,7 +118,7 @@ public class StructuredLoggingListenerTest {
     @DisplayName("shouldLog should match against multiple patterns")
     void testMultiplePatterns() throws Exception {
         when(config.events()).thenReturn(List.of("workflow.instance.faulted", "workflow.task.faulted"));
-        listener = new StructuredLoggingListener(config, objectMapper);
+        listener = new StructuredLoggingListener(config, objectMapper, noProviders());
 
         assertThat(invokeShouldLog(listener, "workflow.instance.faulted")).isTrue();
         assertThat(invokeShouldLog(listener, "workflow.task.faulted")).isTrue();
@@ -127,7 +130,7 @@ public class StructuredLoggingListenerTest {
     @DisplayName("shouldLog should match if any pattern matches")
     void testAnyPatternMatches() throws Exception {
         when(config.events()).thenReturn(List.of("workflow.instance.*", "workflow.task.faulted"));
-        listener = new StructuredLoggingListener(config, objectMapper);
+        listener = new StructuredLoggingListener(config, objectMapper, noProviders());
 
         // Matches first pattern
         assertThat(invokeShouldLog(listener, "workflow.instance.started")).isTrue();
@@ -145,7 +148,7 @@ public class StructuredLoggingListenerTest {
     @DisplayName("shouldLog should handle empty pattern list")
     void testEmptyPatternList() throws Exception {
         when(config.events()).thenReturn(List.of());
-        listener = new StructuredLoggingListener(config, objectMapper);
+        listener = new StructuredLoggingListener(config, objectMapper, noProviders());
 
         boolean result = invokeShouldLog(listener, "workflow.instance.started");
 
@@ -191,6 +194,14 @@ public class StructuredLoggingListenerTest {
         Method method = StructuredLoggingListener.class.getDeclaredMethod("shouldLog", String.class);
         method.setAccessible(true);
         return (boolean) method.invoke(listener, eventType);
+    }
+
+    // An unsatisfied TraceCorrelationProvider Instance - the listener falls back to NOOP
+    @SuppressWarnings("unchecked")
+    private static Instance<TraceCorrelationProvider> noProviders() {
+        Instance<TraceCorrelationProvider> providers = mock(Instance.class);
+        when(providers.isResolvable()).thenReturn(false);
+        return providers;
     }
 
     @Test

--- a/core/runtime/src/test/java/io/quarkiverse/flow/structuredlogging/StructuredLoggingListenerTraceCorrelationTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/flow/structuredlogging/StructuredLoggingListenerTraceCorrelationTest.java
@@ -1,0 +1,119 @@
+package io.quarkiverse.flow.structuredlogging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkiverse.flow.config.FlowStructuredLoggingConfig;
+import io.quarkiverse.flow.config.TimestampFormat;
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider;
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider.TraceContext;
+import io.serverlessworkflow.impl.lifecycle.WorkflowStartedEvent;
+
+@DisplayName("StructuredLoggingListener trace correlation")
+class StructuredLoggingListenerTraceCorrelationTest {
+
+    private static final String LOG_CATEGORY = "io.quarkiverse.flow.structuredlogging";
+    private static final String TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
+    private static final String SPAN_ID = "b7ad6b7169203331";
+
+    private final List<LogRecord> records = new ArrayList<>();
+    private Logger julLogger;
+    private Handler handler;
+    private FlowStructuredLoggingConfig config;
+
+    @BeforeEach
+    void setUp() {
+        records.clear();
+        handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record);
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        julLogger = Logger.getLogger(LOG_CATEGORY);
+        julLogger.addHandler(handler);
+        julLogger.setLevel(Level.ALL);
+
+        config = mock(FlowStructuredLoggingConfig.class);
+        when(config.enabled()).thenReturn(true);
+        when(config.events()).thenReturn(List.of("*"));
+        when(config.logLevel()).thenReturn("INFO");
+        when(config.timestampFormat()).thenReturn(TimestampFormat.ISO8601);
+        when(config.includeWorkflowPayloads()).thenReturn(false);
+    }
+
+    @AfterEach
+    void tearDown() {
+        julLogger.removeHandler(handler);
+    }
+
+    private static WorkflowStartedEvent workflowStartedEvent() {
+        WorkflowStartedEvent ev = mock(WorkflowStartedEvent.class, RETURNS_DEEP_STUBS);
+        when(ev.eventDate()).thenReturn(OffsetDateTime.now());
+        when(ev.workflowContext().instanceData().id()).thenReturn("instance-1");
+        return ev;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Instance<TraceCorrelationProvider> instanceOf(TraceCorrelationProvider provider) {
+        Instance<TraceCorrelationProvider> instance = mock(Instance.class);
+        when(instance.isResolvable()).thenReturn(provider != null);
+        when(instance.get()).thenReturn(provider);
+        return instance;
+    }
+
+    @Test
+    @DisplayName("emitted JSON carries traceId/spanId when a provider resolves a span")
+    void emits_trace_fields() {
+        TraceCorrelationProvider provider = ev -> Optional.of(new TraceContext(TRACE_ID, SPAN_ID, "true", ""));
+        StructuredLoggingListener listener = new StructuredLoggingListener(config, new ObjectMapper(),
+                instanceOf(provider));
+
+        listener.onWorkflowStarted(workflowStartedEvent());
+
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).getMessage())
+                .contains("\"traceId\":\"" + TRACE_ID + "\"")
+                .contains("\"spanId\":\"" + SPAN_ID + "\"");
+    }
+
+    @Test
+    @DisplayName("emitted JSON has no trace fields when no provider is resolvable")
+    void no_provider_no_trace_fields() {
+        StructuredLoggingListener listener = new StructuredLoggingListener(config, new ObjectMapper(),
+                instanceOf(null));
+
+        listener.onWorkflowStarted(workflowStartedEvent());
+
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).getMessage()).doesNotContain("traceId");
+    }
+}

--- a/core/runtime/src/test/java/io/quarkiverse/flow/tracing/TraceLoggerExecutionListenerTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/flow/tracing/TraceLoggerExecutionListenerTest.java
@@ -1,0 +1,131 @@
+package io.quarkiverse.flow.tracing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider;
+import io.serverlessworkflow.impl.lifecycle.TaskStartedEvent;
+
+@DisplayName("TraceLoggerExecutionListener trace correlation")
+class TraceLoggerExecutionListenerTest {
+
+    private static final String TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
+    private static final String SPAN_ID = "b7ad6b7169203331";
+    private static final String PARENT_ID = "1100dd0d1d001111";
+
+    private final List<ExtLogRecord> records = new ArrayList<>();
+    private Logger julLogger;
+    private Handler handler;
+
+    @BeforeEach
+    void setUp() {
+        MDC.clear();
+        records.clear();
+        handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(ExtLogRecord.wrap(record));
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        julLogger = Logger.getLogger(TraceLoggerExecutionListener.class.getName());
+        julLogger.addHandler(handler);
+        julLogger.setLevel(Level.ALL);
+    }
+
+    @AfterEach
+    void tearDown() {
+        julLogger.removeHandler(handler);
+        MDC.clear();
+    }
+
+    private static TaskStartedEvent taskStartedEvent() {
+        TaskStartedEvent ev = mock(TaskStartedEvent.class, RETURNS_DEEP_STUBS);
+        when(ev.workflowContext().instanceData().id()).thenReturn("instance-1");
+        when(ev.eventDate()).thenReturn(OffsetDateTime.now());
+        when(ev.taskContext().position().jsonPointer()).thenReturn("do/1/greet");
+        when(ev.taskContext().taskName()).thenReturn("greet");
+        return ev;
+    }
+
+    @Test
+    @DisplayName("adds trace_id, span_id, sampled and parent_id to the MDC of the emitted log line when a span is active")
+    void adds_trace_and_span_id_to_log_line() {
+        TraceCorrelationProvider provider = ev -> Optional
+                .of(new TraceCorrelationProvider.TraceContext(TRACE_ID, SPAN_ID, "true", PARENT_ID));
+
+        new TraceLoggerExecutionListener(provider).onTaskStarted(taskStartedEvent());
+
+        assertThat(records).hasSize(1);
+        ExtLogRecord record = records.get(0);
+        assertThat(record.getMdc("traceId")).isEqualTo(TRACE_ID);
+        assertThat(record.getMdc("spanId")).isEqualTo(SPAN_ID);
+        assertThat(record.getMdc("sampled")).isEqualTo("true");
+        assertThat(record.getMdc("parentId")).isEqualTo(PARENT_ID);
+        assertThat(record.getMdc("quarkus.flow.instanceId")).isEqualTo("instance-1");
+    }
+
+    @Test
+    @DisplayName("does not leak trace correlation keys into the MDC after the log line is emitted")
+    void does_not_leak_trace_ids_into_surrounding_mdc() {
+        TraceCorrelationProvider provider = ev -> Optional
+                .of(new TraceCorrelationProvider.TraceContext(TRACE_ID, SPAN_ID, "true", PARENT_ID));
+
+        new TraceLoggerExecutionListener(provider).onTaskStarted(taskStartedEvent());
+
+        assertThat(MDC.get("traceId")).isNull();
+        assertThat(MDC.get("spanId")).isNull();
+        assertThat(MDC.get("sampled")).isNull();
+        assertThat(MDC.get("parentId")).isNull();
+    }
+
+    @Test
+    @DisplayName("emits no trace_id or span_id when the NOOP provider is used")
+    void noop_provider_adds_no_trace_ids() {
+        new TraceLoggerExecutionListener().onTaskStarted(taskStartedEvent());
+
+        assertThat(records).hasSize(1);
+        ExtLogRecord record = records.get(0);
+        assertThat(record.getMdc("traceId")).isNull();
+        assertThat(record.getMdc("spanId")).isNull();
+        assertThat(record.getMdc("quarkus.flow.instanceId")).isEqualTo("instance-1");
+    }
+
+    @Test
+    @DisplayName("emits no trace correlation keys when the provider reports no active span")
+    void empty_provider_result_adds_no_trace_ids() {
+        TraceCorrelationProvider provider = ev -> Optional.empty();
+
+        new TraceLoggerExecutionListener(provider).onTaskStarted(taskStartedEvent());
+
+        assertThat(records).hasSize(1);
+        ExtLogRecord record = records.get(0);
+        assertThat(record.getMdc("traceId")).isNull();
+        assertThat(record.getMdc("spanId")).isNull();
+    }
+}

--- a/core/spi/pom.xml
+++ b/core/spi/pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkiverse.flow</groupId>
+        <artifactId>quarkus-flow-core-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-flow-spi</artifactId>
+    <name>Quarkus Flow :: Core :: SPI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.serverlessworkflow</groupId>
+            <artifactId>serverlessworkflow-impl-core</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/spi/src/main/java/io/quarkiverse/flow/spi/observability/TraceCorrelationProvider.java
+++ b/core/spi/src/main/java/io/quarkiverse/flow/spi/observability/TraceCorrelationProvider.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.flow.spi.observability;
+
+import java.util.Optional;
+
+import io.serverlessworkflow.impl.lifecycle.WorkflowEvent;
+
+/**
+ * Neutral bridge that lets flow-level logging correlate with an active distributed trace
+ * without {@code core} depending on any tracing library.
+ */
+public interface TraceCorrelationProvider {
+
+    /**
+     * Returns the trace/span identifiers of the span the tracing integration is currently
+     * tracking for the given lifecycle event (the workflow-instance span for workflow events,
+     * the task span for task events), or {@link Optional#empty()} when no span is being
+     * tracked (tracing disabled, or the event fires outside any span's lifetime).
+     */
+    Optional<TraceContext> traceContextFor(WorkflowEvent workflowEvent);
+
+    /**
+     * Plain-string view of an active span, deliberately free of any tracing-library types so it
+     * can be written straight to the SLF4J MDC or a JSON log field. Every component is non-null;
+     * {@code parentId} is an empty string when the span has no recorded parent.
+     */
+    record TraceContext(String traceId, String spanId, String sampled, String parentId) {
+    }
+
+    /** Used when no tracing implementation is installed. */
+    TraceCorrelationProvider NOOP = ev -> Optional.empty();
+}

--- a/opentelemetry/deployment/src/main/java/io/quarkiverse/flow/opentelemetry/deployment/FlowOTelProcessor.java
+++ b/opentelemetry/deployment/src/main/java/io/quarkiverse/flow/opentelemetry/deployment/FlowOTelProcessor.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.quarkiverse.flow.opentelemetry.runtime.OTelTraceCorrelationProvider;
 import io.quarkiverse.flow.opentelemetry.runtime.OTelWorkflowExecutionListener;
 import io.quarkiverse.flow.opentelemetry.runtime.SpanBuilderFactory;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -38,6 +39,7 @@ class FlowOTelProcessor {
             additionalBeans.produce(AdditionalBeanBuildItem.builder()
                     .addBeanClass(SpanBuilderFactory.class)
                     .addBeanClass(OTelWorkflowExecutionListener.class)
+                    .addBeanClass(OTelTraceCorrelationProvider.class)
                     .setDefaultScope(SINGLETON)
                     .setUnremovable()
                     .build());

--- a/opentelemetry/integration-tests/src/test/java/io/quarkiverse/flow/opentelemetry/it/LogTraceCorrelationTest.java
+++ b/opentelemetry/integration-tests/src/test/java/io/quarkiverse/flow/opentelemetry/it/LogTraceCorrelationTest.java
@@ -1,0 +1,114 @@
+package io.quarkiverse.flow.opentelemetry.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider;
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider.TraceContext;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.serverlessworkflow.impl.ServicePriority;
+import io.serverlessworkflow.impl.lifecycle.TaskCompletedEvent;
+import io.serverlessworkflow.impl.lifecycle.WorkflowCompletedEvent;
+import io.serverlessworkflow.impl.lifecycle.WorkflowExecutionListener;
+
+@QuarkusTest
+@DisplayName("flow lifecycle events correlate with the active OpenTelemetry trace")
+class LogTraceCorrelationTest {
+
+    private static final AttributeKey<String> WF_NAME = AttributeKey.stringKey("flow.workflow.name");
+    private static final AttributeKey<String> TASK_NAME = AttributeKey.stringKey("flow.task.name");
+
+    @Inject
+    InMemorySpanExporter exporter;
+
+    @Inject
+    CapturingListener capturingListener;
+
+    @BeforeEach
+    void setUp() {
+        exporter.reset();
+        capturingListener.captured.clear();
+    }
+
+    @Test
+    void terminal_events_resolve_the_matching_trace_and_span_ids() {
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body("{}")
+                .post("/otel-workflows/otel-set-task")
+                .then()
+                .statusCode(200);
+
+        await().atMost(30, TimeUnit.SECONDS).until(() -> exporter.getFinishedSpanItems().size() >= 2);
+        List<SpanData> spans = exporter.getFinishedSpanItems();
+
+        SpanData workflowSpan = spans.stream()
+                .filter(s -> "otel-set-task".equals(s.getAttributes().get(WF_NAME)))
+                .filter(s -> s.getAttributes().get(TASK_NAME) == null)
+                .findFirst().orElseThrow(() -> new AssertionError("workflow span not exported: " + spans));
+        SpanData taskSpan = spans.stream()
+                .filter(s -> "setTask".equals(s.getAttributes().get(TASK_NAME)))
+                .findFirst().orElseThrow(() -> new AssertionError("task span not exported: " + spans));
+
+        await().atMost(10, TimeUnit.SECONDS).until(() -> capturingListener.captured.containsKey("task.completed:setTask")
+                && capturingListener.captured.containsKey("workflow.completed"));
+
+        TraceContext taskCompleted = capturingListener.captured.get("task.completed:setTask");
+        assertThat(taskCompleted.traceId()).isEqualTo(workflowSpan.getTraceId());
+        assertThat(taskCompleted.spanId()).isEqualTo(taskSpan.getSpanId());
+        assertThat(taskCompleted.sampled()).isEqualTo("true");
+
+        TraceContext workflowCompleted = capturingListener.captured.get("workflow.completed");
+        assertThat(workflowCompleted.traceId()).isEqualTo(workflowSpan.getTraceId());
+        assertThat(workflowCompleted.spanId()).isEqualTo(workflowSpan.getSpanId());
+    }
+
+    /**
+     * A {@link WorkflowExecutionListener} that runs after every other listener (highest priority
+     * value) and records what the {@link TraceCorrelationProvider} resolves for each terminal
+     * event - i.e. exactly what the flow loggers would put on their log line.
+     */
+    @Singleton
+    static class CapturingListener implements WorkflowExecutionListener {
+
+        final Map<String, TraceContext> captured = new ConcurrentHashMap<>();
+
+        @Inject
+        Instance<TraceCorrelationProvider> providers;
+
+        @Override
+        public void onTaskCompleted(TaskCompletedEvent ev) {
+            providers.get().traceContextFor(ev)
+                    .ifPresent(tc -> captured.put("task.completed:" + ev.taskContext().taskName(), tc));
+        }
+
+        @Override
+        public void onWorkflowCompleted(WorkflowCompletedEvent ev) {
+            providers.get().traceContextFor(ev).ifPresent(tc -> captured.put("workflow.completed", tc));
+        }
+
+        @Override
+        public int priority() {
+            return ServicePriority.DEFAULT_PRIORITY + 1000;
+        }
+    }
+}

--- a/opentelemetry/runtime/pom.xml
+++ b/opentelemetry/runtime/pom.xml
@@ -25,10 +25,6 @@
         </dependency>
         <dependency>
             <groupId>io.serverlessworkflow</groupId>
-            <artifactId>serverlessworkflow-impl-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.serverlessworkflow</groupId>
             <artifactId>serverlessworkflow-impl-http</artifactId>
         </dependency>
         <dependency>
@@ -38,6 +34,26 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.flow</groupId>
+            <artifactId>quarkus-flow-spi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/opentelemetry/runtime/src/main/java/io/quarkiverse/flow/opentelemetry/runtime/OTelTraceCorrelationProvider.java
+++ b/opentelemetry/runtime/src/main/java/io/quarkiverse/flow/opentelemetry/runtime/OTelTraceCorrelationProvider.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.flow.opentelemetry.runtime;
+
+import static io.quarkiverse.flow.opentelemetry.runtime.WorkflowInstrumentationContext.getWorkflowInstrumentationContext;
+
+import java.util.Optional;
+
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider;
+import io.serverlessworkflow.impl.lifecycle.TaskEvent;
+import io.serverlessworkflow.impl.lifecycle.WorkflowEvent;
+
+/**
+ * OpenTelemetry-backed {@link TraceCorrelationProvider}.
+ * <p>
+ * Quarkus Flow's OpenTelemetry integration never makes its spans "current"
+ * ({@code Span.makeCurrent()}); spans are held in the per-instance
+ * {@link WorkflowInstrumentationContext}. When each span is created,
+ * {@link OTelWorkflowExecutionListener} captures its trace identifiers into that per-instance
+ * store, so this provider is a pure read of those captured strings keyed by the lifecycle
+ * event - it does not touch live spans and does not depend on the order in which
+ * {@code WorkflowExecutionListener}s run.
+ */
+public class OTelTraceCorrelationProvider implements TraceCorrelationProvider {
+
+    @Override
+    public Optional<TraceContext> traceContextFor(WorkflowEvent ev) {
+        WorkflowInstrumentationContext workflowContext = getWorkflowInstrumentationContext(
+                ev.workflowContext().instanceData());
+        if (workflowContext == null) {
+            return Optional.empty();
+        }
+
+        if (ev instanceof TaskEvent taskEvent) {
+            TaskEventInfo info = TaskEventInfo.from(taskEvent);
+            TraceContext captured = workflowContext.getTaskTraceContext(
+                    info.taskId(), info.taskInstanceIteration(), info.taskInstanceRetryAttempt());
+            if (captured != null) {
+                return Optional.of(captured);
+            }
+            // No task span captured yet (e.g. task.started reached the logger before the OTel
+            // listener) or the entry was evicted: fall back to the workflow-instance span so the
+            // line still correlates to the right trace.
+        }
+        return Optional.ofNullable(workflowContext.getWorkflowTraceContext());
+    }
+}

--- a/opentelemetry/runtime/src/main/java/io/quarkiverse/flow/opentelemetry/runtime/OTelWorkflowExecutionListener.java
+++ b/opentelemetry/runtime/src/main/java/io/quarkiverse/flow/opentelemetry/runtime/OTelWorkflowExecutionListener.java
@@ -25,10 +25,14 @@ import org.slf4j.LoggerFactory;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.quarkiverse.flow.opentelemetry.runtime.config.FlowOTelConfig;
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider.TraceContext;
 import io.serverlessworkflow.api.types.TaskBase;
+import io.serverlessworkflow.impl.ServicePriority;
 import io.serverlessworkflow.impl.WorkflowPosition;
 import io.serverlessworkflow.impl.lifecycle.TaskCancelledEvent;
 import io.serverlessworkflow.impl.lifecycle.TaskCompletedEvent;
@@ -84,8 +88,9 @@ public class OTelWorkflowExecutionListener implements WorkflowExecutionListener 
                 .withStartTime(Instant.now())
                 .build();
 
-        setWorkflowInstrumentationContext(ev.workflowContext().instanceData(),
-                new WorkflowInstrumentationContext(workflowInstanceContext));
+        WorkflowInstrumentationContext instrumentationContext = new WorkflowInstrumentationContext(workflowInstanceContext);
+        instrumentationContext.setWorkflowTraceContext(toTraceContext(startSpan));
+        setWorkflowInstrumentationContext(ev.workflowContext().instanceData(), instrumentationContext);
     }
 
     @Override
@@ -192,6 +197,9 @@ public class OTelWorkflowExecutionListener implements WorkflowExecutionListener 
         workflowContext.putTaskInstanceInstanceContext(eventInfo.taskId(),
                 eventInfo.taskInstanceIteration(),
                 eventInfo.taskInstanceRetryAttempt(), taskInstanceContext);
+        workflowContext.putTaskTraceContext(eventInfo.taskId(),
+                eventInfo.taskInstanceIteration(),
+                eventInfo.taskInstanceRetryAttempt(), toTraceContext(startSpan));
     }
 
     @Override
@@ -321,5 +329,31 @@ public class OTelWorkflowExecutionListener implements WorkflowExecutionListener 
 
     private void enrichSpan(SpanBuilder span, TaskBase task) {
         SpanUtils.getTaskSpanEnricher(task).enrich(span, task);
+    }
+
+    static TraceContext toTraceContext(Span span) {
+        if (span == null) {
+            return null;
+        }
+        SpanContext spanContext = span.getSpanContext();
+        if (!spanContext.isValid()) {
+            return null;
+        }
+        String parentId = "";
+        if (span instanceof ReadableSpan readableSpan) {
+            SpanContext parent = readableSpan.getParentSpanContext();
+            if (parent.isValid()) {
+                parentId = parent.getSpanId();
+            }
+        }
+        return new TraceContext(spanContext.getTraceId(), spanContext.getSpanId(),
+                Boolean.toString(spanContext.isSampled()), parentId);
+    }
+
+    @Override
+    public int priority() {
+        // Soft ordering only: running before TraceLoggerExecutionListener lets workflow.started
+        // and task.started log lines carry their own (just-created) span id.
+        return ServicePriority.DEFAULT_PRIORITY - 100;
     }
 }

--- a/opentelemetry/runtime/src/main/java/io/quarkiverse/flow/opentelemetry/runtime/WorkflowInstrumentationContext.java
+++ b/opentelemetry/runtime/src/main/java/io/quarkiverse/flow/opentelemetry/runtime/WorkflowInstrumentationContext.java
@@ -1,16 +1,44 @@
 package io.quarkiverse.flow.opentelemetry.runtime;
 
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider.TraceContext;
 import io.serverlessworkflow.impl.WorkflowInstanceData;
 import io.serverlessworkflow.impl.WorkflowMutableInstance;
 
 public class WorkflowInstrumentationContext implements AutoCloseable {
     private static final String OTEL_CONTEXT = "OTEL_CONTEXT";
+
+    /**
+     * Upper bound on the correlation-only {@link #taskTraceContext} map. It keeps entries for
+     * tasks whose span has already ended (so a lifecycle log line for a terminal task event can
+     * still carry the task's own span id regardless of listener order), so a long {@code for}
+     * loop or a wide {@code fork} would otherwise grow it without limit. On eviction the trace
+     * correlation for that task falls back to the workflow-instance identifiers.
+     */
+    private static final int TRACE_CONTEXT_MAX = 256;
+
     private final InstrumentationContext workflowInstanceContext;
     private final Map<String, InstrumentationContext> workflowInstanceTaskContext = new ConcurrentHashMap<>();
+
+    /**
+     * Trace/span identifiers captured when each span is created, kept only so lifecycle logging
+     * can correlate a log line with the right span. This is deliberately independent of
+     * {@link #workflowInstanceTaskContext} (the span-parenting map): entries are never removed
+     * on a terminal task event, so it must not be used for parenting new spans.
+     */
+    private volatile TraceContext workflowTraceContext;
+    private final Map<String, TraceContext> taskTraceContext = Collections.synchronizedMap(
+            new LinkedHashMap<>(16, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, TraceContext> eldest) {
+                    return size() > TRACE_CONTEXT_MAX;
+                }
+            });
 
     public WorkflowInstrumentationContext(InstrumentationContext workflowInstanceContext) {
         this.workflowInstanceContext = workflowInstanceContext;
@@ -36,6 +64,32 @@ public class WorkflowInstrumentationContext implements AutoCloseable {
     public InstrumentationContext getTaskInstanceContext(String taskInstanceId, int iteration,
             int retryAttempt) {
         return workflowInstanceTaskContext.get(taskContextId(taskInstanceId, iteration, retryAttempt));
+    }
+
+    public TraceContext getWorkflowTraceContext() {
+        return workflowTraceContext;
+    }
+
+    public void setWorkflowTraceContext(TraceContext workflowTraceContext) {
+        this.workflowTraceContext = workflowTraceContext;
+    }
+
+    /**
+     * Records the trace identifiers of a task span for later log correlation. Safe to call with
+     * a {@code null} context (nothing is stored) so callers need not null-check the extraction.
+     */
+    public void putTaskTraceContext(String taskInstanceId, int iteration, int retryAttempt, TraceContext context) {
+        if (context != null) {
+            taskTraceContext.put(taskContextId(taskInstanceId, iteration, retryAttempt), context);
+        }
+    }
+
+    /**
+     * The trace identifiers captured for a task span, or {@code null} if none were captured or
+     * the entry has been evicted. Used only for log correlation, never for span parenting.
+     */
+    public TraceContext getTaskTraceContext(String taskInstanceId, int iteration, int retryAttempt) {
+        return taskTraceContext.get(taskContextId(taskInstanceId, iteration, retryAttempt));
     }
 
     private String findParentContextId(String jsonPosition) {
@@ -82,6 +136,7 @@ public class WorkflowInstrumentationContext implements AutoCloseable {
                     }
                 });
         workflowInstanceTaskContext.clear();
+        taskTraceContext.clear();
     }
 
     @Override

--- a/opentelemetry/runtime/src/test/java/io/quarkiverse/flow/opentelemetry/runtime/OTelSpanTraceContextTest.java
+++ b/opentelemetry/runtime/src/test/java/io/quarkiverse/flow/opentelemetry/runtime/OTelSpanTraceContextTest.java
@@ -1,0 +1,74 @@
+package io.quarkiverse.flow.opentelemetry.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider.TraceContext;
+
+@DisplayName("OTelWorkflowExecutionListener.toTraceContext span extraction")
+class OTelSpanTraceContextTest {
+
+    private static final String TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
+    private static final String SPAN_ID = "b7ad6b7169203331";
+
+    @Test
+    @DisplayName("null span yields no trace context")
+    void null_span() {
+        assertThat(OTelWorkflowExecutionListener.toTraceContext(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("an invalid span yields no trace context")
+    void invalid_span() {
+        assertThat(OTelWorkflowExecutionListener.toTraceContext(Span.getInvalid())).isNull();
+    }
+
+    @Test
+    @DisplayName("a propagation-only span exposes its ids and an empty parent id")
+    void wrapped_span() {
+        Span span = Span.wrap(SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
+
+        TraceContext tc = OTelWorkflowExecutionListener.toTraceContext(span);
+
+        assertThat(tc).isEqualTo(new TraceContext(TRACE_ID, SPAN_ID, "true", ""));
+    }
+
+    @Test
+    @DisplayName("an SDK child span exposes the sampled flag and the parent span id")
+    void sdk_child_span() {
+        Tracer tracer = SdkTracerProvider.builder().build().get("test");
+        Span parent = tracer.spanBuilder("parent").startSpan();
+        Span child = tracer.spanBuilder("child").setParent(Context.root().with(parent)).startSpan();
+        try {
+            TraceContext tc = OTelWorkflowExecutionListener.toTraceContext(child);
+
+            assertThat(tc).isNotNull();
+            assertThat(tc.traceId()).isEqualTo(child.getSpanContext().getTraceId());
+            assertThat(tc.spanId()).isEqualTo(child.getSpanContext().getSpanId());
+            assertThat(tc.sampled()).isEqualTo("true");
+            assertThat(tc.parentId()).isEqualTo(parent.getSpanContext().getSpanId());
+        } finally {
+            child.end();
+            parent.end();
+        }
+    }
+
+    @Test
+    @DisplayName("an unsampled span reports sampled=false")
+    void unsampled_span() {
+        Span span = Span.wrap(SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getDefault(), TraceState.getDefault()));
+
+        TraceContext tc = OTelWorkflowExecutionListener.toTraceContext(span);
+
+        assertThat(tc.sampled()).isEqualTo("false");
+    }
+}

--- a/opentelemetry/runtime/src/test/java/io/quarkiverse/flow/opentelemetry/runtime/OTelTraceCorrelationProviderTest.java
+++ b/opentelemetry/runtime/src/test/java/io/quarkiverse/flow/opentelemetry/runtime/OTelTraceCorrelationProviderTest.java
@@ -1,0 +1,128 @@
+package io.quarkiverse.flow.opentelemetry.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider.TraceContext;
+import io.serverlessworkflow.api.types.SetTask;
+import io.serverlessworkflow.impl.TaskContext;
+import io.serverlessworkflow.impl.WorkflowInstanceData;
+import io.serverlessworkflow.impl.WorkflowPosition;
+import io.serverlessworkflow.impl.lifecycle.TaskStartedEvent;
+import io.serverlessworkflow.impl.lifecycle.WorkflowStartedEvent;
+
+@DisplayName("OTelTraceCorrelationProvider reads the captured trace identifiers")
+class OTelTraceCorrelationProviderTest {
+
+    private static final String WF_TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
+    private static final String WF_SPAN_ID = "b7ad6b7169203331";
+    private static final String TASK_SPAN_ID = "00f067aa0ba902b7";
+    private static final String TASK_ID = "do/0/set-0";
+
+    private static final TraceContext WF_CONTEXT = new TraceContext(WF_TRACE_ID, WF_SPAN_ID, "true", "");
+    private static final TraceContext TASK_CONTEXT = new TraceContext(WF_TRACE_ID, TASK_SPAN_ID, "true", WF_SPAN_ID);
+
+    private final OTelTraceCorrelationProvider provider = new OTelTraceCorrelationProvider();
+
+    private static WorkflowInstrumentationContext newContext() {
+        return new WorkflowInstrumentationContext(
+                InstrumentationContext.newBuilder().withStartTime(Instant.now()).build());
+    }
+
+    private static WorkflowStartedEvent workflowEventWith(WorkflowInstrumentationContext ctx) {
+        WorkflowStartedEvent ev = mock(WorkflowStartedEvent.class, RETURNS_DEEP_STUBS);
+        WorkflowInstanceData instanceData = ev.workflowContext().instanceData();
+        when(instanceData.findMetadata(anyString(), eq(WorkflowInstrumentationContext.class)))
+                .thenReturn(Optional.ofNullable(ctx));
+        return ev;
+    }
+
+    private static TaskStartedEvent taskEventWith(WorkflowInstrumentationContext ctx) {
+        TaskStartedEvent ev = mock(TaskStartedEvent.class, RETURNS_DEEP_STUBS);
+        WorkflowInstanceData instanceData = ev.workflowContext().instanceData();
+        when(instanceData.findMetadata(anyString(), eq(WorkflowInstrumentationContext.class)))
+                .thenReturn(Optional.ofNullable(ctx));
+
+        TaskContext taskContext = mock(TaskContext.class);
+        WorkflowPosition position = mock(WorkflowPosition.class);
+        when(position.jsonPointer()).thenReturn(TASK_ID);
+        when(taskContext.position()).thenReturn(position);
+        when(taskContext.taskName()).thenReturn("set-0");
+        when(taskContext.task()).thenReturn(new SetTask());
+        when(taskContext.iteration()).thenReturn(0);
+        when(taskContext.isRetrying()).thenReturn(false);
+        when(taskContext.retryAttempt()).thenReturn(0);
+        when(taskContext.tryRetryCount()).thenReturn(Optional.empty());
+        when(ev.taskContext()).thenReturn(taskContext);
+        return ev;
+    }
+
+    @Test
+    @DisplayName("a workflow event returns the captured workflow-instance trace context")
+    void workflow_event_returns_workflow_context() {
+        WorkflowInstrumentationContext ctx = newContext();
+        ctx.setWorkflowTraceContext(WF_CONTEXT);
+
+        assertThat(provider.traceContextFor(workflowEventWith(ctx))).contains(WF_CONTEXT);
+    }
+
+    @Test
+    @DisplayName("returns empty when the instance has no instrumentation context")
+    void no_instrumentation_context_returns_empty() {
+        assertThat(provider.traceContextFor(workflowEventWith(null))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns empty when no span has been captured yet")
+    void nothing_captured_returns_empty() {
+        assertThat(provider.traceContextFor(workflowEventWith(newContext()))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("a task event returns the captured task trace context")
+    void task_event_returns_task_context() {
+        WorkflowInstrumentationContext ctx = newContext();
+        ctx.setWorkflowTraceContext(WF_CONTEXT);
+        ctx.putTaskTraceContext(TASK_ID, 0, 0, TASK_CONTEXT);
+
+        assertThat(provider.traceContextFor(taskEventWith(ctx))).contains(TASK_CONTEXT);
+    }
+
+    @Test
+    @DisplayName("a terminal task event still resolves the task's own span after the active context is removed")
+    void terminal_task_event_still_resolves_task_context() {
+        WorkflowInstrumentationContext ctx = newContext();
+        ctx.setWorkflowTraceContext(WF_CONTEXT);
+        ctx.putTaskTraceContext(TASK_ID, 0, 0, TASK_CONTEXT);
+        // the OTel listener ends the span and drops the active context on a terminal event;
+        // the captured trace identifiers are independent of that map
+        ctx.removeTaskInstanceInstanceContext(TASK_ID, 0, 0);
+
+        assertThat(provider.traceContextFor(taskEventWith(ctx))).contains(TASK_CONTEXT);
+    }
+
+    @Test
+    @DisplayName("a task event with no captured task span falls back to the workflow trace context")
+    void task_event_falls_back_to_workflow_context() {
+        WorkflowInstrumentationContext ctx = newContext();
+        ctx.setWorkflowTraceContext(WF_CONTEXT);
+
+        assertThat(provider.traceContextFor(taskEventWith(ctx))).contains(WF_CONTEXT);
+    }
+
+    @Test
+    @DisplayName("a task event with neither task nor workflow context returns empty")
+    void task_event_without_any_context_returns_empty() {
+        assertThat(provider.traceContextFor(taskEventWith(newContext()))).isEmpty();
+    }
+}

--- a/opentelemetry/runtime/src/test/java/io/quarkiverse/flow/opentelemetry/runtime/WorkflowInstrumentationContextTest.java
+++ b/opentelemetry/runtime/src/test/java/io/quarkiverse/flow/opentelemetry/runtime/WorkflowInstrumentationContextTest.java
@@ -1,0 +1,71 @@
+package io.quarkiverse.flow.opentelemetry.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.flow.spi.observability.TraceCorrelationProvider.TraceContext;
+
+@DisplayName("WorkflowInstrumentationContext trace-correlation store")
+class WorkflowInstrumentationContextTest {
+
+    private static final int TRACE_CONTEXT_MAX = 256;
+
+    private static WorkflowInstrumentationContext newContext() {
+        return new WorkflowInstrumentationContext(
+                InstrumentationContext.newBuilder().withStartTime(Instant.now()).build());
+    }
+
+    private static TraceContext trace(String spanId) {
+        return new TraceContext("0af7651916cd43dd8448eb211c80319c", spanId, "true", "");
+    }
+
+    @Test
+    @DisplayName("a captured task trace context survives removal of the active span context")
+    void task_trace_context_survives_active_context_removal() {
+        WorkflowInstrumentationContext ctx = newContext();
+        ctx.putTaskTraceContext("do/0/a", 0, 0, trace("aaaaaaaaaaaaaaaa"));
+
+        ctx.removeTaskInstanceInstanceContext("do/0/a", 0, 0);
+
+        assertThat(ctx.getTaskTraceContext("do/0/a", 0, 0)).isEqualTo(trace("aaaaaaaaaaaaaaaa"));
+    }
+
+    @Test
+    @DisplayName("a null task trace context is ignored")
+    void null_task_trace_context_is_ignored() {
+        WorkflowInstrumentationContext ctx = newContext();
+
+        ctx.putTaskTraceContext("do/0/a", 0, 0, null);
+
+        assertThat(ctx.getTaskTraceContext("do/0/a", 0, 0)).isNull();
+    }
+
+    @Test
+    @DisplayName("the task trace store is bounded and evicts the eldest entries")
+    void task_trace_store_is_bounded() {
+        WorkflowInstrumentationContext ctx = newContext();
+        for (int i = 0; i < TRACE_CONTEXT_MAX + 50; i++) {
+            ctx.putTaskTraceContext("do/0/task", i, 0, trace(String.format("%016x", i)));
+        }
+
+        // the very first entries have been evicted
+        assertThat(ctx.getTaskTraceContext("do/0/task", 0, 0)).isNull();
+        // the most recent ones are retained
+        assertThat(ctx.getTaskTraceContext("do/0/task", TRACE_CONTEXT_MAX + 49, 0)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("closing the context clears the captured task trace store")
+    void close_clears_task_trace_store() throws Exception {
+        WorkflowInstrumentationContext ctx = newContext();
+        ctx.putTaskTraceContext("do/0/a", 0, 0, trace("aaaaaaaaaaaaaaaa"));
+
+        ctx.close();
+
+        assertThat(ctx.getTaskTraceContext("do/0/a", 0, 0)).isNull();
+    }
+}


### PR DESCRIPTION
## Description

Flow lifecycle log lines had no link to the active distributed trace. This PR
correlates them: every flow log line (MDC and structured JSON) now carries
`traceId`, `spanId`, `sampled` and `parentId`, using the same key names Quarkus'
own OpenTelemetry logging instrumentation uses.

Relates to discussion #902.

## Changes

- New `quarkus-flow-spi` module with `TraceCorrelationProvider` — a neutral bridge
  that yields trace identifiers for a lifecycle event without `core` depending on any
  tracing library. Falls back to `NOOP` when no tracing extension is installed.
- OpenTelemetry integration contributes `OTelTraceCorrelationProvider`.
  `OTelWorkflowExecutionListener` captures each span's identifiers into the
  per-instance `WorkflowInstrumentationContext` at span-creation time; the provider is
  a pure read of those, keyed by the event (task span for task events, workflow span
  otherwise). Correlation is independent of `WorkflowExecutionListener` ordering.
- `TraceLoggerExecutionListener` writes the four keys into the MDC (inside its
  existing snapshot bracket); `EventFormatter` writes them into the structured JSON
  payload.
- Bounded LRU task-trace store (256 entries) with fallback to the workflow-instance
  identifiers on eviction.

## Testing

### Test Plan

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] Tested manually (describe below if applicable)

Unit tests cover the SPI wiring, span → `TraceContext` extraction, the OTel provider
and the bounded context store. `LogTraceCorrelationTest` (integration) asserts
terminal task/workflow events resolve the same trace id as the exported spans and the
matching span id.
