### PR TITLE
Add core/deployment to CI extensions matrix legs

### DIFF
--- a/.github/workflows/build-it.yml
+++ b/.github/workflows/build-it.yml
@@ -173,19 +173,19 @@ jobs:
       matrix:
         include:
           - name: messaging
-            modules: messaging/runtime,messaging/deployment,messaging/integration-tests,messaging/integration-tests-amqp,grpc/runtime,grpc/deployment,grpc/integration-tests,oidc/runtime,oidc/deployment,oidc/integration-tests
+            modules: core/deployment,messaging/runtime,messaging/deployment,messaging/integration-tests,messaging/integration-tests-amqp,grpc/runtime,grpc/deployment,grpc/integration-tests,oidc/runtime,oidc/deployment,oidc/integration-tests
           - name: persistence
-            modules: messaging/deployment,persistence/common/runtime,persistence/common/deployment,persistence/test-common,persistence/redis/runtime,persistence/redis/deployment,persistence/redis/integration-tests,persistence/jpa/runtime,persistence/jpa/deployment,persistence/jpa/integration-tests,persistence/mvstore/runtime,persistence/mvstore/deployment,persistence/mvstore/integration-tests,persistence/infinispan/integration-tests
+            modules: core/deployment,messaging/deployment,persistence/common/runtime,persistence/common/deployment,persistence/test-common,persistence/redis/runtime,persistence/redis/deployment,persistence/redis/integration-tests,persistence/jpa/runtime,persistence/jpa/deployment,persistence/jpa/integration-tests,persistence/mvstore/runtime,persistence/mvstore/deployment,persistence/mvstore/integration-tests,persistence/infinispan/integration-tests
           - name: scheduling
-            modules: messaging/deployment,scheduler/memory/runtime,scheduler/memory/deployment,scheduler/memory/integration-tests,scheduler/quartz/runtime,scheduler/quartz/deployment,scheduler/quartz/integration-tests,durable-kubernetes/runtime,durable-kubernetes/deployment,durable-kubernetes/integration-tests
+            modules: core/deployment,messaging/deployment,scheduler/memory/runtime,scheduler/memory/deployment,scheduler/memory/integration-tests,scheduler/quartz/runtime,scheduler/quartz/deployment,scheduler/quartz/integration-tests,durable-kubernetes/runtime,durable-kubernetes/deployment,durable-kubernetes/integration-tests
           - name: runner
             # runner/app (image-minimal profile, active by default) needs persistence/mvstore
             # at build time; -am only follows plain <dependency> edges, not Quarkus's dynamic
             # runtime->deployment artifact resolution, so the *-deployment modules must be
             # listed explicitly or the augmentation step fails looking for them.
-            modules: runner/runtime,runner/deployment,runner/integration-tests,runner/app,messaging/deployment,persistence/common/runtime,persistence/common/deployment,persistence/test-common,persistence/mvstore/runtime,persistence/mvstore/deployment
+            modules: runner/runtime,runner/deployment,runner/integration-tests,runner/app,core/deployment,messaging/deployment,persistence/common/runtime,persistence/common/deployment,persistence/test-common,persistence/mvstore/runtime,persistence/mvstore/deployment
           - name: opentelemetry
-            modules: messaging/deployment,opentelemetry/runtime,opentelemetry/deployment,opentelemetry/integration-tests
+            modules: core/deployment,messaging/deployment,opentelemetry/runtime,opentelemetry/deployment,opentelemetry/integration-tests
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- The `extensions` CI matrix legs (`messaging`, `persistence`, `scheduling`, `runner`, `opentelemetry`) pull `quarkus-flow` (core/runtime) into the Maven reactor via `-am`, since their `integration-tests` modules declare a direct dependency on it.
- `core/runtime`'s `extension-descriptor` build step then needs to resolve `quarkus-flow-deployment` (core/deployment) for consistency checking, but nothing in these legs has a plain `<dependency>` edge on it, so `-am` never adds it to the reactor.
- On a fresh runner this leaves `core/deployment` unresolvable, failing with a Quarkus Extension Dependency Verification Error listing every expected deployment dependency as missing — same root cause as #946 (`messaging/deployment`), now hitting `core/deployment` itself. See the failing run: https://github.com/quarkiverse/quarkus-flow/actions/runs/34238457813/job/102102177373
- Fix: add `core/deployment` explicitly to each affected leg's `modules` list, same pattern as #946.

## Test plan
- [x] Reproduced locally by hiding `quarkus-flow`/`quarkus-flow-deployment` from the local `.m2` repo and running the opentelemetry leg's exact CI command — failed with the same error before the fix.
- [x] Re-ran the same command after the fix — build succeeds.
- [ ] CI green on this PR