### PR TITLE
fix: correct graphify update command in CI workflow

### DIFF
--- a/.github/workflows/update-graph.yml
+++ b/.github/workflows/update-graph.yml
@@ -56,7 +56,7 @@ jobs:
           " || true
 
           # Run the actual update
-          graphify --update
+          graphify update .
         env:
           # No API keys needed - AST extraction is free, semantic uses host agent
           PYTHONUNBUFFERED: '1'


### PR DESCRIPTION
## Summary

Fixes the failing graphify update pipeline in GitHub Actions.

## Problem

The CI workflow was using incorrect syntax:
```bash
graphify --update
```

This caused the pipeline to fail with:
```
error: unknown command '--update'
```

## Solution

Changed to the correct CLI syntax:
```bash
graphify update .
```

The graphify CLI uses subcommands, not flags for the update operation.

## Testing

- ✅ Tested locally: `graphify update .` runs successfully
- ✅ Re-extracts code files using AST
- ✅ Updates graph in `.graphify/` directory

## References

- Error log from failing CI: `error: unknown command '--update'`
- Verified with `graphify --help` output