### PR TITLE
docs: replace mermaid references with diagram editor

### DIFF
--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -88,7 +88,7 @@ One of the most powerful features of Quarkus Flow is its visualizer. Because you
 
 1. Press `d` in the terminal where Quarkus is running to open the **Quarkus Dev UI** in your browser.
 2. Find the **Quarkus Flow** card and click the **Workflows** link.
-3. Click on your `hello-workflow` to see the auto-generated Mermaid.js diagram showing exactly how your tasks execute!
+3. Click on your `hello-workflow` to visualize your workflow in the interactive Diagram Editor, showing all tasks and their execution flow!
 
 == What’s next?
 

--- a/docs/modules/ROOT/pages/langchain4j.adoc
+++ b/docs/modules/ROOT/pages/langchain4j.adoc
@@ -309,7 +309,7 @@ When you start your application in dev mode (`./mvnw quarkus:dev`):
 Open the **Quarkus Flow Dev UI** (`http://localhost:8080/q/dev`), and you will see your annotated agents listed as fully-fledged workflows. You can:
 
 * Execute them via auto-generated HTML forms
-* View their internal topology using Mermaid diagrams
+* View their internal topology using the Diagram Editor
 * Inspect execution traces and state transitions
 * Monitor performance and error rates
 

--- a/docs/modules/ROOT/pages/wk-lab-1-hello-flow-devui.adoc
+++ b/docs/modules/ROOT/pages/wk-lab-1-hello-flow-devui.adoc
@@ -9,7 +9,7 @@ You will:
 * Create a Quarkus app and add the Quarkus Flow extension.
 * Write a workflow using the Java DSL.
 * Invoke it via a reactive REST endpoint.
-* Inspect the auto-generated Mermaid diagram in the Quarkus Dev UI.
+* Inspect the auto-generated diagram in the Diagram Editor within the Quarkus Dev UI.
 
 == 1. Create the Quarkus project
 
@@ -107,7 +107,7 @@ With dev mode still running:
 
 Here you can:
 
-* See the auto-generated **Mermaid.js diagram** showing your exact execution sequence.
+* See the auto-generated diagram in the **Diagram Editor** showing your exact execution sequence.
 * Trigger new workflow instances directly from the UI using auto-generated input forms.
 * View execution traces and logs.
 

--- a/docs/modules/ROOT/pages/wk-lab-4b-agentic-langchain4j-annotations.adoc
+++ b/docs/modules/ROOT/pages/wk-lab-4b-agentic-langchain4j-annotations.adoc
@@ -64,7 +64,7 @@ Start (or restart) your application in dev mode:
 1. Open the **Quarkus Dev UI** (`http://localhost:8080/q/dev`).
 2. Navigate to **Quarkus Flow → Workflows**.
 3. You should see two brand-new workflows that you didn't manually define: `story-creator-with-configurable-style-editor` and `evening-planner-agent`.
-4. Click on **`evening-planner-agent`** to execute the workflow and then view the auto-generated **Mermaid diagram**.
+4. Click on **`evening-planner-agent`** to execute the workflow and then view the auto-generated diagram in the **Diagram Editor**.
 
 Notice how the topology compares to the manual DSL version. The engine has automatically mapped the sequential annotation to a series of CNCF "Function Tasks" and handled the data mapping between the internal AI services.
 

--- a/examples/langchain4j-agentic-workflow/README.md
+++ b/examples/langchain4j-agentic-workflow/README.md
@@ -10,7 +10,7 @@ It demonstrates:
 - How `quarkus-flow-langchain4j` automatically turns these into **Quarkus Flow workflows**.
 - How to **run and inspect** these workflows in the **Quarkus Flow Dev UI**:
   - Auto-generated input forms (from the agent method signatures).
-  - Mermaid diagrams of the workflow topology.
+  - Workflow topology diagrams in the Diagram Editor.
   - Execution traces and output.
 
 ## Prerequisites
@@ -43,7 +43,7 @@ Click the **play** icon to:
 
 - Fill in the generated form (for example `topic`, `style`, `audience`, `city`, `mood`).
 - Execute the workflow and see the output.
-- Explore the generated Mermaid diagram and task-level traces.
+- Explore the generated diagram in the Diagram Editor and task-level traces.
 
 ## Documentation
 


### PR DESCRIPTION
## Description

Fixes https://github.com/quarkiverse/quarkus-flow/issues/964

Replace references to "Mermaid diagram/Mermaid.js diagram" with "Diagram Editor" throughout the documentation.

## Changes

Updates to following docs:
- docs/modules/ROOT/pages/getting-started.adoc
- docs/modules/ROOT/pages/langchain4j.adoc
- docs/modules/ROOT/pages/wk-lab-1-hello-flow-devui.adoc
- docs/modules/ROOT/pages/wk-lab-4b-agentic-langchain4j-annotations.adoc
- examples/langchain4j-agentic-workflow/README.md

## Testing

- `make quick-verify`