### PR TITLE
fix: run documentation locally

### DIFF
--- a/docs/src/main/resources/application.properties
+++ b/docs/src/main/resources/application.properties
@@ -9,3 +9,12 @@ quarkus.flow.messaging.defaults-enabled=true
 # Example messaging setup - tells the compiled bridge to route traffic to local memory for tests
 mp.messaging.incoming.flow-in.connector=smallrye-in-memory
 mp.messaging.outgoing.flow-out.connector=smallrye-in-memory
+
+
+# Dev-mode only: the example workflows under modules/ROOT/examples inject these via
+# @ConfigProperty, but they are normally supplied by the WireMock @QuarkusTestResource
+# classes, which do not run in dev mode. Without them `mvn quarkus:dev` fails config
+# validation before Antora can serve the site.
+%dev.wiremock.url=http://localhost:8089
+%dev.wiremock.secure.url=http://localhost:8090
+


### PR DESCRIPTION
## Description

`docs/README.md` tells contributors to preview the documentation with:
```
cd docs
mvn clean quarkus:dev
```

When you navigate to localhost:8080 you see an error instead of the docs page

Fixes https://github.com/quarkiverse/quarkus-flow/issues/968

## Changes

- Add wiremock urls to docs `application.properties` for dev mode

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] Tested manually (describe below if applicable)

### Manual Testing

Before
<img width="1738" height="1037" alt="Screenshot 2026-09-11 at 12 35 50" src="https://github.com/user-attachments/assets/b83c341f-17a7-4ddb-beaf-0cd84ca57f84" />

After
<img width="1334" height="1035" alt="Screenshot 2026-09-11 at 12 48 29" src="https://github.com/user-attachments/assets/d65c7226-86e9-457c-b92e-e53bb4e9a5e8" />


## Checklist

Before submitting this PR, please ensure:

- [ ] **I ran the full build with integration tests locally**: `./mvnw clean install -DskipITs=false`
- [ ] Code follows the project's code conventions
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation has been updated (if user-facing changes)
- [ ] Commit messages are clear and follow conventional commits style
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have read and comply with the [LLM Usage Policy](../CONTRIBUTING.md#llm-usage-policy) (if applicable)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
